### PR TITLE
Minor fix for autotest script

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -65,6 +65,8 @@ RETRIES=2
 DEFAULT_S=0.3
 if uname_p[0:3] == 'arm':
   DEFAULT_S *= 2
+
+uname_m = uname_m.strip() # strip off any whitespace characters
 #Allow extra time for slower CPUs
 if uname_m in ["i386", "i486", "i586", "i686", "armv7", "armv71", "aarch64"]:
   DEFAULT_S *= 4


### PR DESCRIPTION
This patch adds a fix for a bug in the autotest.py script
that would preclude slower CPUs from having extra time
for process start up. The problem was because of the
extra whitespace characters in the output of `uname -m`
used by the script to detect the architecture.