### PR TITLE
Better vDSO handling

### DIFF
--- a/src/mtcp/mtcp_header.h
+++ b/src/mtcp/mtcp_header.h
@@ -44,6 +44,10 @@ typedef union _MtcpHeader {
     void *saved_brk;
     void *restore_addr;
     size_t restore_size;
+    void *vdsoStart;
+    void *vdsoEnd;
+    void *vvarStart;
+    void *vvarEnd;
     void (*post_restart) ();
     ThreadTLSInfo motherofall_tls_info;
     int tls_pid_offset;

--- a/src/mtcp/mtcp_sys.h
+++ b/src/mtcp/mtcp_sys.h
@@ -278,7 +278,7 @@ struct linux_dirent {
 #else
 # error "getrlimit kernel call not implemented in this architecture"
 #endif
-#define mtcp_sys_mremap(args...)  (void *)mtcp_inline_syscall(mremap,4,args)
+#define mtcp_sys_mremap(args...)  (void *)mtcp_inline_syscall(mremap,5,args)
 #define mtcp_sys_munmap(args...)  mtcp_inline_syscall(munmap,2,args)
 #define mtcp_sys_mprotect(args...)  mtcp_inline_syscall(mprotect,3,args)
 #define mtcp_sys_nanosleep(args...)  mtcp_inline_syscall(nanosleep,2,args)

--- a/src/mtcp/mtcp_util.ic
+++ b/src/mtcp/mtcp_util.ic
@@ -452,6 +452,7 @@ int mtcp_readmapsline (int mapsfd, Area *area)
   if (c != '\n') goto skipeol;
 
   area -> addr = startaddr;
+  area -> endAddr = endaddr;
   area -> size = endaddr - startaddr;
   area -> prot = 0;
   if (rflag == 'r') area -> prot |= PROT_READ;

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -154,7 +154,7 @@ void ProcessInfo::growStack()
     stackSize = rlim.rlim_cur;
   }
 
-  // Find the current stack area and heap
+  // Find the current stack area, heap, stack, vDSO and vvar areas.
   ProcMapsArea area;
   ProcMapsArea stackArea = {0};
   size_t allocSize;
@@ -165,6 +165,12 @@ void ProcessInfo::growStack()
     if (strcmp(area.name, "[heap]") == 0) {
       // Record start of heap which will later be used to restore heap
       _savedHeapStart = (unsigned long) area.addr;
+    } else if (strcmp(area.name, "[vdso]") == 0) {
+      _vdsoStart = (unsigned long) area.addr;
+      _vdsoEnd = (unsigned long) area.endAddr;
+    } else if (strcmp(area.name, "[vvar]") == 0) {
+      _vvarStart = (unsigned long) area.addr;
+      _vvarEnd = (unsigned long) area.endAddr;
     } else if ((VA) &area >= area.addr && (VA) &area < area.endAddr) {
       JTRACE("Original stack area") ((void*)area.addr) (area.size);
       stackArea = area;
@@ -504,6 +510,7 @@ void ProcessInfo::serialize(jalib::JBinarySerializer& o)
   o & _procname & _hostname & _launchCWD & _ckptCWD & _upid & _uppid;
   o & _compGroup & _numPeers & _noCoordinator & _argvSize & _envSize;
   o & _restoreBufAddr & _savedHeapStart & _savedBrk;
+  o & _vdsoStart & _vdsoEnd & _vvarStart & _vvarEnd;
   o & _ckptDir & _ckptFileName & _ckptFilesSubDir;
 
   JTRACE("Serialized process information")

--- a/src/processinfo.h
+++ b/src/processinfo.h
@@ -100,7 +100,7 @@ namespace dmtcp
       int elfType() const { return _elfType; }
       uint64_t savedBrk(void) const { return _savedBrk;}
       uint64_t restoreBufAddr(void) const { return _restoreBufAddr;}
-      uint32_t restoreBufLen(void) const { return RESTORE_TOTAL_SIZE;}
+      uint64_t restoreBufLen(void) const { return RESTORE_TOTAL_SIZE;}
 
       string getCkptFilename() const { return _ckptFileName; }
       string getCkptFilesSubDir() const { return _ckptFilesSubDir; }
@@ -143,7 +143,8 @@ namespace dmtcp
       UniquePid     _compGroup;
 
       uint64_t      _restoreBufAddr;
-      uint32_t      _restoreBufLen;
+      uint64_t      _restoreBufLen;
+
       uint64_t      _savedHeapStart;
       uint64_t      _savedBrk;
   };

--- a/src/processinfo.h
+++ b/src/processinfo.h
@@ -102,6 +102,11 @@ namespace dmtcp
       uint64_t restoreBufAddr(void) const { return _restoreBufAddr;}
       uint64_t restoreBufLen(void) const { return RESTORE_TOTAL_SIZE;}
 
+      uint64_t vdsoStart(void) const { return _vdsoStart;}
+      uint64_t vdsoEnd(void) const { return _vdsoEnd;}
+      uint64_t vvarStart(void) const { return _vvarStart;}
+      uint64_t vvarEnd(void) const { return _vvarEnd;}
+
       string getCkptFilename() const { return _ckptFileName; }
       string getCkptFilesSubDir() const { return _ckptFilesSubDir; }
       string getCkptDir() const { return _ckptDir; }
@@ -147,6 +152,11 @@ namespace dmtcp
 
       uint64_t      _savedHeapStart;
       uint64_t      _savedBrk;
+
+      uint64_t      _vdsoStart;
+      uint64_t      _vdsoEnd;
+      uint64_t      _vvarStart;
+      uint64_t      _vvarEnd;
   };
 
 }

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -255,6 +255,12 @@ static void prepareMtcpHeader(MtcpHeader *mtcpHdr)
   // restoreBuf should go in there.
   mtcpHdr->restore_addr = (void*) ProcessInfo::instance().restoreBufAddr();
   mtcpHdr->restore_size = ProcessInfo::instance().restoreBufLen();
+
+  mtcpHdr->vdsoStart = (void*) ProcessInfo::instance().vdsoStart();
+  mtcpHdr->vdsoEnd = (void*) ProcessInfo::instance().vdsoEnd();
+  mtcpHdr->vvarStart = (void*) ProcessInfo::instance().vvarStart();
+  mtcpHdr->vvarEnd = (void*) ProcessInfo::instance().vvarEnd();
+
   mtcpHdr->post_restart = &ThreadList::postRestart;
   memcpy(&mtcpHdr->motherofall_tls_info,
          &motherofall->tlsInfo,


### PR DESCRIPTION
Assumption: the layout and contents of the vDSO (and vvar) sections has not changed between checkpoint and restart.

- The addresses of vDSO (and vvar) sections are stored in ProcessInfo during initialization.
- During checkpoint, the contents of vDSO, vvar, and vsyscall sections are not written to the checkpoint image.
- The vDSO (and vvar) sections are checked for layout compatibility at restart.
- If the layout is correct, the new vDSO (and vvar) section(s) are mremap()'d to the older addresses. (mremap just updates the page tables to establish a new virtual page to physical page mapping, thus the vDSO (and vvar) pages still point to the backing kernel pages).

TODO: If the vDSO (and vvar) section(s) have a different layout (e.g., restarting on a different kernel), one potential fix is to keep the older vDSO section, but modify the _vdso_gettimeofday, etc., to point into the new vDSO. This can be done by a simple `jmp` instruction on x86.