### PR TITLE
mtcp_restart exits if no match, MTCP_SIGNATURE

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -235,6 +235,7 @@ MTCP_PRINTF("Attach for debugging.");
   if (rinfo.fd != -1) {
     mtcp_readfile(rinfo.fd, &mtcpHdr, sizeof mtcpHdr);
   } else {
+    int rc = -1;
     rinfo.fd = mtcp_sys_open2(ckptImage, O_RDONLY);
     if (rinfo.fd == -1) {
       MTCP_PRINTF("***ERROR opening ckpt image (%s): %d\n",
@@ -243,8 +244,12 @@ MTCP_PRINTF("Attach for debugging.");
     }
     // This assumes that the MTCP header signature is unique.
     do {
-      mtcp_readfile(rinfo.fd, &mtcpHdr, sizeof mtcpHdr);
-    } while (mtcp_strcmp(mtcpHdr.signature, MTCP_SIGNATURE) != 0);
+      rc = mtcp_readfile(rinfo.fd, &mtcpHdr, sizeof mtcpHdr);
+    } while (rc > 0 && mtcp_strcmp(mtcpHdr.signature, MTCP_SIGNATURE) != 0);
+    if (rc == 0) { /* if end of file */
+      MTCP_PRINTF("***ERROR: ckpt image doesn't match MTCP_SIGNATURE\n");
+      return 1;  /* exit with error code 1 */
+    }
   }
 
   DPRINTF("For debugging:\n"
@@ -849,7 +854,7 @@ static int read_one_memory_area(int fd)
     }
 
     if (area.prot & MAP_SHARED) {
-      imagefd = mtcp_sys_open (area.name, flags, 0);  // Can we open file.?
+      imagefd = mtcp_sys_open (area.name, flags, 0);  // Can we open file?
       if (imagefd < 0 && mtcp_sys_errno == ENOENT) {
         // File doesn't exist.  Do we have perm to create it and write data?
         imagefd = mtcp_sys_open (area.name, O_CREAT|O_RDWR, 0);
@@ -858,6 +863,8 @@ static int read_one_memory_area(int fd)
         } else {
           // We don't have permission to re-create shared file.
           // Open it as anonymous private, and hope for the best.
+          // FIXME: Or maybe we do have permission to re-create shared file,
+          // but it requires us to also re-create the parent directory.
           area.flags ^= MAP_SHARED;
           area.flags |= MAP_PRIVATE;
           area.flags |= MAP_ANONYMOUS;

--- a/src/mtcp/mtcp_util.h
+++ b/src/mtcp/mtcp_util.h
@@ -164,7 +164,7 @@ mtcp_sys_memcmp (s1, s2, len)
 
 void mtcp_printf (char const *format, ...);
 ssize_t mtcp_read_all(int fd, void *buf, size_t count);
-void mtcp_readfile(int fd, void *buf, size_t size);
+int mtcp_readfile(int fd, void *buf, size_t size);
 void mtcp_skipfile(int fd, size_t size);
 unsigned long mtcp_strtol (char *str);
 char mtcp_readchar (int fd);

--- a/src/mtcp/mtcp_util.ic
+++ b/src/mtcp/mtcp_util.ic
@@ -243,7 +243,7 @@ void mtcp_mkdir(const char *dir)
   mtcp_sys_mkdir(tmp, S_IRWXU);
 }
 
-void mtcp_readfile(int fd, void *buf, size_t size)
+int mtcp_readfile(int fd, void *buf, size_t size)
 {
   int mtcp_sys_errno;
   ssize_t rc;
@@ -263,16 +263,22 @@ void mtcp_readfile(int fd, void *buf, size_t size)
   while(ar != size) {
     rc = mtcp_sys_read(fd, buf + ar, size - ar);
     if (rc < 0 && rc > -4096) { /* kernel could return large unsigned int */
-      MTCP_PRINTF("error %d reading checkpoint\n", mtcp_sys_errno);
-      mtcp_abort();
-    }
-    else if (rc == 0) {
-      MTCP_PRINTF("only read %u bytes instead of %u from checkpoint file\n",
-                  (unsigned)ar, (unsigned)size);
-      if (tries++ >= 10) {
-        MTCP_PRINTF(" failed to read after 10 tries in a row.\n");
+      if (rc == -1 && (mtcp_sys_errno == EAGAIN || mtcp_sys_errno == EINTR)) {
+        tries++;
+        if (tries++ >= 10) {
+          MTCP_PRINTF(" failed to read after 10 tries in a row.\n");
+          mtcp_abort();
+        }
+        continue;
+      } else {  /* else error:  rc < 0 and not EAGAIN and not EINTR */
+        MTCP_PRINTF("error %d reading checkpoint\n", mtcp_sys_errno);
+        MTCP_PRINTF("only read %u bytes instead of %u from checkpoint file\n",
+                    (unsigned)ar, (unsigned)size);
         mtcp_abort();
       }
+    }
+    else if (rc == 0) {  /* if end of file */
+      return 0;  /* success:  end of file */
     }
     ar += rc;
   }
@@ -286,6 +292,7 @@ void mtcp_readfile(int fd, void *buf, size_t size)
   WMB;
   IMB;
 #endif
+  return ar;  /* read ar characters */
 }
 
 // FIXME:  Equiv. to mtcp_sys_lseek(fd, size, SEEK_CUR), but doesn't work


### PR DESCRIPTION
* It used to verbosely make 20 tries at end of file, and then abort.
  Now, it prints a simple error statement, and exits with 'return 1'.

I've tested this on:  bin/mtcp_restart --simulate IMG
for the cases when IMG is a gzipped ckpt image, an unzipped ckpt image, and a random file still ending in .dmtcp.  It seems to do the right thing in all cases, and without the previous bug of repeatedly printing:
  " failed to read after 10 tries in a row.\n"