### PR TITLE
In mtcp, fix restoring of deleted directory tree (and add new tests)

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -716,6 +716,10 @@ CKPT_CMD = old_ckpt_cmd
 # Test for files opened with WRONLY mode and later unlinked.
 runTest("file1",         1, ["./test/file1"])
 
+# FIXME:  Currently, we re-create deleted subdirectories when file
+#         is mmap'ed, but not yet when file is referenced by open fd.
+# runTest("file2",         1, ["./test/file2"])
+
 runTest("dmtcpaware1",   1, ["./test/dmtcpaware1"])
 
 PWD=os.getcwd()
@@ -779,7 +783,8 @@ runTest("frisbee",       3, ["./test/frisbee "+p1+" localhost "+p2,
                              "./test/frisbee "+p3+" localhost "+p1+" starter"])
 os.environ['DMTCP_GZIP'] = "0"
 
-runTest("shared-memory", 2, ["./test/shared-memory"])
+runTest("shared-memory1", 2, ["./test/shared-memory1"])
+runTest("shared-memory2", 2, ["./test/shared-memory2"])
 
 runTest("sysv-shm1",     2, ["./test/sysv-shm1"])
 runTest("sysv-shm2",     2, ["./test/sysv-shm2"])

--- a/test/file1.c
+++ b/test/file1.c
@@ -43,10 +43,10 @@ int main()
 
     while (1) {
       if (count % (int)1e6 == 0) {
-        printf("%d ", count);
+        printf("%ld ", count);
         fflush(stdout);
       }
-      fprintf(fp, "%d", count++);
+      fprintf(fp, "%ld", count++);
     }
 
     fprintf(stdout, "I have returned\n");

--- a/test/file2.c
+++ b/test/file2.c
@@ -1,0 +1,67 @@
+#include <stdio.h>
+#define __USE_GNU
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+
+int main()
+{
+    long int count = 0;
+    int fd;
+    int rc;
+    FILE *fp;
+    char filename[100];
+    char dir1[100];
+    char dir2[100];
+
+    char *dir = getenv("DMTCP_TMPDIR");
+    if (!dir) dir = getenv("TMPDIR");
+    if (!dir) dir = "/tmp";
+    if (sizeof(filename) < strlen(dir) + 3*sizeof("/dmtcp_file_XXXXXX")) {
+      printf("Directory string too large.\n");
+      return 1;
+    }
+    strcpy(filename, dir);
+    strcat(filename, "/dmtcp_dir1_XXXXXX");
+    strcpy(dir1, filename);
+    strcat(filename, "/dmtcp_dir2_XXXXXX");
+    strcpy(dir2, filename);
+    strcat(filename, "/dmtcp_file_XXXXXX");
+
+    // Create dir1, dir2, and filename
+    if (mkdtemp(dir1) == NULL) abort();
+    strncpy(dir2, dir1, strlen(dir1));  // Update new prefix
+    if (mkdtemp(dir2) == NULL) abort();
+    strncpy(filename, dir2, strlen(dir2));  // Update new prefix
+    fd = mkostemp(filename, O_WRONLY|O_CREAT);
+    if (fd == -1)
+      abort();
+
+    // Problematic only when in "w" mode or "a". All + modes and "r" are fine.
+    fp = fdopen(fd, "w");
+
+    fprintf(stdout, "Opened %s\n", filename);
+    fprintf(stdout, "Deleting %s\n", filename);
+    rc = unlink(filename);
+    if (rc == -1) abort();
+    fprintf(stdout, "Deleting %s\n", dir2);
+    rc = rmdir(dir2);
+    if (rc == -1) abort();
+    fprintf(stdout, "Deleting %s\n", dir1);
+    rc = rmdir(dir1);
+    if (rc == -1) abort();
+
+    while (1) {
+      if (count % (int)1e6 == 0) {
+        printf("%ld ", count);
+        fflush(stdout);
+      }
+      fprintf(fp, "%ld", count++);
+    }
+
+    return 0;
+}

--- a/test/shared-memory1.c
+++ b/test/shared-memory1.c
@@ -1,8 +1,4 @@
-/* Compile:
- * gcc -o shared-memory -Wl,--export-dynamic THIS_FILE
- */
-
-// _DEFAULT_SOURCE for mkstemp
+// _DEFAULT_SOURCE for mkstemp  (WHY?)
 #define _DEFAULT_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
@@ -21,10 +17,11 @@ void writer(int fd);
 
 int main() {
   char filename[] = "dmtcp-shared-memory.XXXXXX";
-  int initValue = -1;
   int fd;
 
   fd = mkstemp(filename);
+  printf("creating temporary file in local directory: %s\n", filename);
+  //printf("creating file: %s\n", "/tmp/dmtcp-shared-memory.dat");
   unlink(filename);
   //if (-1 == unlink(filename)) {
   //  perror("unlink");
@@ -33,10 +30,9 @@ int main() {
   //fd = open("/tmp/dmtcp-shared-memory.dat", O_RDWR | O_CREAT, S_IREAD|S_IWRITE);
   // if (fd == -1) perror("open");
   /* Extend file to needed size */
-  while ( write(fd, &initValue, sizeof(int)) != sizeof(int) )
+  int initValue = -1;
+  while ( write(fd, &initValue, sizeof(initValue)) != sizeof(initValue) )
     continue;
-  printf("creating temporary file in local directory: %s\n", filename);
-  //printf("creating file: %s\n", "/tmp/dmtcp-shared-memory.dat");
 
   if (fork())
     writer(fd);

--- a/test/shared-memory2.c
+++ b/test/shared-memory2.c
@@ -1,0 +1,104 @@
+#include <stdio.h>
+#define __USE_GNU
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <errno.h>
+
+
+void reader(int fd);
+void writer(int fd);
+
+int main()
+{
+  // Most of main() copied from file2.c
+  long int count = 0;
+  int fd;
+  int rc;
+  FILE *fp;
+  char filename[100];
+  char dir1[100];
+  char dir2[100];
+
+  char *dir = getenv("DMTCP_TMPDIR");
+  if (!dir) dir = getenv("TMPDIR");
+  if (!dir) dir = "/tmp";
+  if (sizeof(filename) < strlen(dir) + 3*sizeof("/dmtcp_file_XXXXXX")) {
+    printf("Directory string too large.\n");
+    return 1;
+  }
+  strcpy(filename, dir);
+  strcat(filename, "/dmtcp_dir1_XXXXXX");
+  strcpy(dir1, filename);
+  strcat(filename, "/dmtcp_dir2_XXXXXX");
+  strcpy(dir2, filename);
+  strcat(filename, "/dmtcp_file_XXXXXX");
+
+  // Create dir1, dir2, and filename
+  if (mkdtemp(dir1) == NULL) abort();
+  strncpy(dir2, dir1, strlen(dir1));  // Update new prefix
+  if (mkdtemp(dir2) == NULL) abort();
+  strncpy(filename, dir2, strlen(dir2));  // Update new prefix
+  fd = mkstemp(filename);
+  if (fd == -1)
+    abort();
+
+  fprintf(stdout, "Opened %s\n", filename);
+  fprintf(stdout, "Deleting %s\n", filename);
+  rc = unlink(filename);
+  if (rc == -1) abort();
+  fprintf(stdout, "Deleting %s\n", dir2);
+  rc = rmdir(dir2);
+  if (rc == -1) abort();
+  fprintf(stdout, "Deleting %s\n", dir1);
+  rc = rmdir(dir1);
+  if (rc == -1) abort();
+
+  /* Extend file to needed size */
+  int initValue = -1;
+  while ( write(fd, &initValue, sizeof(initValue)) != sizeof(initValue) )
+    continue;
+
+  if (fork())
+    writer(fd);
+  else
+    reader(fd);
+  return 0;
+}
+
+void reader(int fd) {
+  int *sharedMemory;
+  int i;
+  sharedMemory = mmap(0, sizeof(int), PROT_READ, MAP_SHARED, fd, 0);
+  if (sharedMemory == MAP_FAILED) {
+    perror("mmap");
+    exit(1);
+  }
+  for (i = -1; ; ) {
+    if (*sharedMemory > i) {
+      i = *sharedMemory;
+      printf("%d ", i);
+      fflush(stdout);
+    }
+    sleep(1);
+  }
+}
+
+void writer(int fd) {
+  int *sharedMemory;
+  int i;
+  sharedMemory = mmap(0, sizeof(int), PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0)
+;
+  if (sharedMemory == MAP_FAILED) {
+    perror("mmap");
+    exit(1);
+  }
+  for (i = 0; ; i++) {
+    *sharedMemory = i;
+    sleep(2);
+  }
+}


### PR DESCRIPTION
If an application like Open MPI created a directory tree in a temp directory, and then unlinked its files and directories, DMTCP fails to restore.  (DMTCP does work correctly, if there is only a deleted file and no deleted directories.)  This addition will call fix_parent_directories() both for MAP_SHARED and for the standard files mapped private.
This addition also creates shared-memory2.c and file2.c to test the code.  Unfortunately, the file2.c test exposes a corresponding bug in fileconnection.cpp.  So, file2 has not yet been added to autotest.py. 