### PR TITLE
Jalib cleanup

### DIFF
--- a/jalib/jalib.cpp
+++ b/jalib/jalib.cpp
@@ -34,28 +34,55 @@
 #include "jalib.h"
 #include "jassert.h"
 
-jalib::JalibFuncPtrs jalib::jalibFuncPtrs;
-int jalib::jalib_funcptrs_initialized = 0;
-const char *jalib::elfInterpreter = NULL;
-int jalib::stderrFd = -1;
-int jalib::logFd = -1;
-int jalib::dmtcp_fail_rc = -1;
+static jalib::JalibFuncPtrs jalibFuncPtrs;
+static int jalib_funcptrs_initialized = 0;
+
+static struct {
+  const char *elfInterpreter;
+  int stderrFd;
+  int logFd;
+  int dmtcp_fail_rc;
+} dmtcpInfo = {NULL, -1, -1, -1};
+
 extern "C" void initializeJalib();
 
-extern "C" void jalib_init(jalib::JalibFuncPtrs jalibFuncPtrs,
-                      const char *elfInterpreter,
-                      int stderrFd,
-                      int jassertLogFd,
-                      int dmtcp_fail_rc)
+extern "C" void jalib_init(jalib::JalibFuncPtrs _jalibFuncPtrs,
+                           const char *elfInterpreter,
+                           int stderrFd,
+                           int jassertLogFd,
+                           int dmtcp_fail_rc)
 {
-  jalib::jalibFuncPtrs = jalibFuncPtrs;
-  jalib::elfInterpreter = elfInterpreter;
-  jalib::stderrFd = stderrFd;
-  jalib::logFd = jassertLogFd;
-  jalib::jalib_funcptrs_initialized = 1;
-  jalib::dmtcp_fail_rc = dmtcp_fail_rc;
+  dmtcpInfo.elfInterpreter = elfInterpreter;
+  dmtcpInfo.stderrFd = stderrFd;
+  dmtcpInfo.logFd = jassertLogFd;
+  dmtcpInfo.dmtcp_fail_rc = dmtcp_fail_rc;
+
+  jalibFuncPtrs = _jalibFuncPtrs;
+  jalib_funcptrs_initialized = 1;
+
   JASSERT_INIT();
 }
+
+const char *jalib::elfInterpreter()
+{
+  return dmtcpInfo.elfInterpreter;
+}
+
+int jalib::stderrFd()
+{
+  return dmtcpInfo.stderrFd;
+}
+
+int jalib::logFd()
+{
+  return dmtcpInfo.logFd;
+}
+
+int jalib::dmtcp_fail_rc()
+{
+  return dmtcpInfo.dmtcp_fail_rc;
+}
+
 
 #define REAL_FUNC_PASSTHROUGH(type,name) \
   if (!jalib_funcptrs_initialized) { \

--- a/jalib/jalib.h
+++ b/jalib/jalib.h
@@ -65,12 +65,10 @@ namespace jalib {
     ssize_t (*readAll)(int fd, void *buf, size_t count);
   } JalibFuncPtrs;
 
-  extern JalibFuncPtrs jalibFuncPtrs;
-  extern int jalib_funcptrs_initialized;
-  extern const char *elfInterpreter;
-  extern int stderrFd;
-  extern int logFd;
-  extern int dmtcp_fail_rc;
+  const char *elfInterpreter();
+  int stderrFd();
+  int logFd();
+  int dmtcp_fail_rc();
 
   int open(const char *pathname, int flags, ...);
   FILE* fopen(const char *path, const char *mode);

--- a/jalib/jassert.cpp
+++ b/jalib/jassert.cpp
@@ -259,15 +259,11 @@ void jassert_internal::jassert_safe_print(const char* str, bool noConsoleOutput)
   if (theLogFileFd != -1) {
     int rv = jwrite(theLogFileFd, str);
 
-    if (rv < 0) {
+    if (rv < 0 && theLogFileFd == EBADF) {
       if (errConsoleFd != -1) {
-        jwrite(errConsoleFd, "JASSERT: write failed, reopening log file.\n");
+        jwrite(errConsoleFd, "JASSERT: failed to write to log file.\n");
       }
-      set_log_file(theLogFilePath());
-      if (theLogFileFd != -1) {
-        jwrite(theLogFileFd, "JASSERT: write failed, reopened log file:\n");
-        jwrite(theLogFileFd, str);
-      }
+      theLogFileFd = -1;
     }
   }
 }

--- a/jalib/jassert.cpp
+++ b/jalib/jassert.cpp
@@ -86,7 +86,7 @@ jassert_internal::JAssert::~JAssert()
     jassert_safe_print ( ss.str().c_str() );
 
   if ( _exitWhenDone ) {
-    _exit ( jalib::dmtcp_fail_rc );
+    _exit ( jalib::dmtcp_fail_rc() );
   }
 }
 
@@ -105,7 +105,7 @@ static int _open_log_safe ( const char* filename, int protectedFd )
   int tfd = jalib::open(filename, O_WRONLY | O_APPEND | O_CREAT /*| O_SYNC*/,
                         S_IRUSR | S_IWUSR );
   if (tfd == -1) return -1;
-  //change fd to 827 (jalib::logFd -- PFD(6))
+  //change fd to 827 (jalib::logFd() -- PFD(6))
   int nfd = jalib::dup2 ( tfd, protectedFd );
   if (tfd != nfd) {
     jalib::close ( tfd );
@@ -124,11 +124,11 @@ static jalib::string& theLogFilePath() {static jalib::string s;return s;};
 void jassert_internal::jassert_init()
 {
   // Check if we already have a valid stderrFd
-  if (jalib::dup2(jalib::stderrFd, jalib::stderrFd) != jalib::stderrFd) {
+  if (jalib::dup2(jalib::stderrFd(), jalib::stderrFd()) != jalib::stderrFd()) {
     const char* errpath = getenv("JALIB_STDERR_PATH");
 
     if (errpath != NULL) {
-      errConsoleFd = _open_log_safe(errpath, jalib::stderrFd);
+      errConsoleFd = _open_log_safe(errpath, jalib::stderrFd());
     } else {
       /* TODO:
        * If stderr is a pseudo terminal for IPC between parent/child processes,
@@ -142,9 +142,9 @@ void jassert_internal::jassert_init()
 
       if (stderrDevice.length() > 0
           && jalib::Filesystem::FileExists(stderrDevice)) {
-        errConsoleFd = jalib::dup2(fileno(stderr), jalib::stderrFd);
+        errConsoleFd = jalib::dup2(fileno(stderr), jalib::stderrFd());
       } else {
-        errConsoleFd = _open_log_safe("/dev/null", jalib::stderrFd);
+        errConsoleFd = _open_log_safe("/dev/null", jalib::stderrFd());
       }
     }
 
@@ -153,7 +153,7 @@ void jassert_internal::jassert_init()
              "dmtcp: cannot open output channel for error logging\n");
     }
   } else {
-    errConsoleFd = jalib::stderrFd;
+    errConsoleFd = jalib::stderrFd();
   }
 }
 
@@ -227,7 +227,7 @@ jassert_internal::JAssert& jassert_internal::JAssert::jbacktrace ()
 {
   writeBacktrace();
   writeProcMaps();
-  // This prints to stdout and to jalib::logFd
+  // This prints to stdout and to jalib::logFd()
   Print( writeJbacktraceMsg() );
   return *this;  // Needed as part of JASSERT macro
 }
@@ -239,15 +239,15 @@ void jassert_internal::set_log_file ( const jalib::string& path )
   theLogFileFd = -1;
   if ( path.length() > 0 )
   {
-    theLogFileFd = _open_log_safe ( path, jalib::logFd );
+    theLogFileFd = _open_log_safe ( path, jalib::logFd() );
     if ( theLogFileFd == -1 )
-      theLogFileFd = _open_log_safe ( path + "_2", jalib::logFd );
+      theLogFileFd = _open_log_safe ( path + "_2", jalib::logFd() );
     if ( theLogFileFd == -1 )
-      theLogFileFd = _open_log_safe ( path + "_3", jalib::logFd );
+      theLogFileFd = _open_log_safe ( path + "_3", jalib::logFd() );
     if ( theLogFileFd == -1 )
-      theLogFileFd = _open_log_safe ( path + "_4", jalib::logFd );
+      theLogFileFd = _open_log_safe ( path + "_4", jalib::logFd() );
     if ( theLogFileFd == -1 )
-      theLogFileFd = _open_log_safe ( path + "_5", jalib::logFd );
+      theLogFileFd = _open_log_safe ( path + "_5", jalib::logFd() );
   }
 }
 

--- a/jalib/jassert.h
+++ b/jalib/jassert.h
@@ -162,11 +162,15 @@ namespace jassert_internal
     return *this;
   }
 
-  void set_log_file ( const jalib::string& path );
+  void set_log_file(const jalib::string& path,
+                    const jalib::string tmpDir,
+                    const jalib::string& uniquePidStr);
 }//jassert_internal
 
 #define JASSERT_INIT(p) (jassert_internal::jassert_init());
-#define JASSERT_SET_LOG(p) (jassert_internal::set_log_file(p));
+
+#define JASSERT_SET_LOG(log, tmpdir, uniquePidStr) \
+  (jassert_internal::set_log_file(log, tmpdir, uniquePidStr));
 
 #define JASSERT_CLOSE_STDERR() (jassert_internal::close_stderr());
 

--- a/jalib/jfilesystem.cpp
+++ b/jalib/jfilesystem.cpp
@@ -171,8 +171,8 @@ jalib::string jalib::Filesystem::GetProgramName()
     value = BaseName ( GetProgramPath() ); // uses /proc/self/exe
     // We may rewrite "a.out" to "/lib/ld-linux.so.2 a.out".  If so, find cmd.
     if (!value.empty()
-        && elfInterpreter != NULL
-        && value == ResolveSymlink(elfInterpreter) // e.g. /lib/ld-linux.so.2
+        && jalib::elfInterpreter() != NULL
+        && value == ResolveSymlink(jalib::elfInterpreter()) // e.g. /lib/ld-linux.so.2
 	&& (len = _GetProgramCmdline(cmdline, sizeof(cmdline))) > 0
 	&& len > strlen(cmdline) + 1 // more than one word in cmdline
 	&& *(cmdline + strlen(cmdline) + 1) != '-') // second word not a flag

--- a/src/util_init.cpp
+++ b/src/util_init.cpp
@@ -120,7 +120,7 @@ void Util::initializeLogFile(string tmpDir, string procname, string prevLogPath)
     o << procname;
   }
 
-  JASSERT_SET_LOG(o.str());
+  JASSERT_SET_LOG(o.str(), tmpDir, UniquePid::ThisProcess().toString());
 
   ostringstream a;
   a << "\n========================================";
@@ -147,6 +147,8 @@ void Util::initializeLogFile(string tmpDir, string procname, string prevLogPath)
   a << "\n========================================\n";
 
   JLOG(a.str().c_str());
+#else
+  JASSERT_SET_LOG("", tmpDir, UniquePid::ThisProcess().toString());
 #endif
   if (getenv(ENV_VAR_QUIET)) {
     jassert_quiet = *getenv(ENV_VAR_QUIET) - '0';


### PR DESCRIPTION
This is an attempt to remove Jalib's dependency on dmtcp.h to get closer to the ideal world where jalib is oblivious to DMTCP.

Addresses #63.