### PR TITLE
make clean-64: keeps lib/dmtcp/32; for multi-arch

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -189,6 +189,12 @@ clean: tidy
 	 rm -rf $$DMTCP_TMPDIR
 	rm -rf $(targetdir)/lib $(targetdir)/bin
 
+# clean-64 preserves files in lib/dmtcp/32.  This is useful for a local multi-arch.
+clean-64: tidy
+	mv ./lib/dmtcp/32 ./32
+	${MAKE} clean
+	mkdir -p ./lib/dmtcp && mv ./32 ./lib/dmtcp/32
+
 distclean: clean
 	- cd src && $(MAKE) distclean
 	- cd plugin && $(MAKE) distclean


### PR DESCRIPTION
Added clean-64 target.  With this target, the following recipe for a local multi-arch works:
  ./configure --enable-m32 && make clean && make -j
  ./configure && make clean-64 && make -j
Things like the following then work:
  gcc -m32 -o dmtcp-tmp test/dmtcp1.c
  bin/dmtcp_launch -i6 ./dmtcp-tmp
  bin/dmtcp_restart ckpt_dmtcp-tmp_*.dmtcp