### PR TITLE
Fixes dmtcp_launch for native 32-bit Linux

### DIFF
--- a/src/util_exec.cpp
+++ b/src/util_exec.cpp
@@ -584,7 +584,8 @@ string Util::getPath(string cmd, bool is32bit)
   };
 
   string suffixFor32Bits;
-  if (is32bit) {
+#if defined(__x86_64__) || defined(__aarch64__)
+  if (is32bit) {  // if this is a multi-architecture build
     string basename = jalib::Filesystem::BaseName(cmd);
     if (cmd == "mtcp_restart-32") {
       suffixFor32Bits = "32/bin/";
@@ -592,6 +593,7 @@ string Util::getPath(string cmd, bool is32bit)
       suffixFor32Bits = "32/lib/dmtcp/";
     }
   }
+#endif
 
   // Search relative to dir of this command (bin/dmtcp_launch), (using p1).
   string udir = SharedData::getInstallDir();


### PR DESCRIPTION
This fixes dmtcp_launch when building on native 32-bit Linux (e.g., login-old):
  ./configure && make clean && make -j && make -j check-dmtcp
   bin/dmtcp_launch test/dmtcp1

NOTE:  However, dmtcp_restart was not working for me when I tried it in combination with pull request #71 using the updated pull requrest of April 28 (based on the comments of @karya0 about vdso).  It correctly execs into mtcp_restart, and mtcp_restart succeeds in restoring all memory areas, but it then fails when jumping back into the src directory with the message: `restore complete, resuming by jumping to ...`  But that is a separate issue, involving pull request #71.