### PR TITLE
Cleaning up <DMTCP_ROOT>/test/plugin

### DIFF
--- a/test/plugin/README
+++ b/test/plugin/README
@@ -35,7 +35,7 @@ impressed by how few lines of code can express so much flexibility
 for checkpointing:
 
     cd sleep1
-    make clean tidy
+    make clean
     ls
     make -n
     make 
@@ -44,7 +44,7 @@ for checkpointing:
     make check
 
     cd ../sleep2
-    make clean tidy
+    make clean
     make -n check
     make check
 

--- a/test/plugin/applic-delayed-ckpt/Makefile
+++ b/test/plugin/applic-delayed-ckpt/Makefile
@@ -17,6 +17,7 @@ DMTCP_INCLUDE=${DMTCP_ROOT}/include
 
 CFLAGS += -I${DMTCP_INCLUDE} -DDMTCP -fPIC -c -g
 CXXFLAGS += -I${DMTCP_INCLUDE} -DDMTCP -fPIC -c -g
+LINK = ${CC}
 
 DEMO_PORT=7781
 
@@ -45,7 +46,7 @@ check: ${LIBNAME}.so applic
 
 # We link the library using C++ for compatibility with the main libdmtcp.so
 ${LIBNAME}.so: ${LIBOBJS}
-	${CXX} -shared -fPIC -o $@ $^
+	${LINK} -shared -fPIC -o $@ $^
 
 .c.o:
 	${CC} ${CFLAGS} -o $@ $<

--- a/test/plugin/applic-delayed-ckpt/Makefile
+++ b/test/plugin/applic-delayed-ckpt/Makefile
@@ -3,10 +3,10 @@
 # The name will be the same as the current directory name.
 NAME=${shell basename $$PWD}
 
-# By default, your resulting library will have this name.
-LIBNAME=dmtcp_plugin-to-announce-events
+# By default, your resulting plugin library will have this name.
+LIBNAME=libdmtcp_plugin-to-announce-events
 
-# As you add new files to your hijack library, add the object file names here.
+# As you add new files to your plugin library, add the object file names here.
 LIBOBJS = plugin-to-announce-events.o
 
 # Modify if your DMTCP_ROOT is located elsewhere.

--- a/test/plugin/applic-initiated-ckpt/Makefile
+++ b/test/plugin/applic-initiated-ckpt/Makefile
@@ -17,6 +17,7 @@ DMTCP_INCLUDE=${DMTCP_ROOT}/include
 
 CFLAGS += -I${DMTCP_INCLUDE} -DDMTCP -fPIC -c -g
 CXXFLAGS += -I${DMTCP_INCLUDE} -DDMTCP -fPIC -c -g
+LINK = ${CC}
 
 DEMO_PORT=7781
 
@@ -44,7 +45,7 @@ check: ${LIBNAME}.so applic
 
 # We link the library using C++ for compatibility with the main libdmtcp.so
 ${LIBNAME}.so: ${LIBOBJS}
-	${CXX} -shared -fPIC -o $@ $^
+	${LINK} -shared -fPIC -o $@ $^
 
 .c.o:
 	${CC} ${CFLAGS} -o $@ $<

--- a/test/plugin/applic-initiated-ckpt/Makefile
+++ b/test/plugin/applic-initiated-ckpt/Makefile
@@ -3,10 +3,10 @@
 # The name will be the same as the current directory name.
 NAME=${shell basename $$PWD}
 
-# By default, your resulting library will have this name.
-LIBNAME=dmtcp_plugin-to-announce-events
+# By default, your resulting plugin library will have this name.
+LIBNAME=libdmtcp_plugin-to-announce-events
 
-# As you add new files to your hijack library, add the object file names here.
+# As you add new files to your plugin library, add the object file names here.
 LIBOBJS = plugin-to-announce-events.o
 
 # Modify if your DMTCP_ROOT is located elsewhere.

--- a/test/plugin/example-db/Makefile
+++ b/test/plugin/example-db/Makefile
@@ -3,10 +3,10 @@
 # The name will be the same as the current directory name.
 NAME=${shell basename $$PWD}
 
-# By default, your resulting library will have this name.
-LIBNAME=dmtcp_${NAME}hijack
+# By default, your resulting plugin library will have this name.
+LIBNAME=libdmtcp_${NAME}
 
-# As you add new files to your hijack library, add the object file names here.
+# As you add new files to your plugin library, add the object file names here.
 LIBOBJS = ${NAME}.o
 
 # Modify if your DMTCP_ROOT is located elsewhere.

--- a/test/plugin/example-db/Makefile
+++ b/test/plugin/example-db/Makefile
@@ -17,6 +17,7 @@ DMTCP_INCLUDE=${DMTCP_ROOT}/include
 
 CFLAGS += -I${DMTCP_INCLUDE} -DDMTCP -fPIC -c -g
 CXXFLAGS += -I${DMTCP_INCLUDE} -DDMTCP -fPIC -c -g
+LINK = ${CC}
 
 DEMO_PORT=7781
 
@@ -38,7 +39,7 @@ check: ${LIBNAME}.so ${DMTCP_ROOT}/test/dmtcp1
 
 # We link the library using C++ for compatibility with the main libdmtcp.so
 ${LIBNAME}.so: ${LIBOBJS}
-	${CXX} -shared -fPIC -o $@ $^
+	${LINK} -shared -fPIC -o $@ $^
 
 .c.o:
 	${CC} ${CFLAGS} -o $@ $<

--- a/test/plugin/example/Makefile
+++ b/test/plugin/example/Makefile
@@ -3,10 +3,10 @@
 # The name will be the same as the current directory name.
 NAME=${shell basename $$PWD}
 
-# By default, your resulting library will have this name.
-LIBNAME=dmtcp_${NAME}hijack
+# By default, your resulting plugin library will have this name.
+LIBNAME=libdmtcp_${NAME}
 
-# As you add new files to your hijack library, add the object file names here.
+# As you add new files to your plugin library, add the object file names here.
 LIBOBJS = ${NAME}.o
 
 # Modify if your DMTCP_ROOT is located elsewhere.

--- a/test/plugin/example/Makefile
+++ b/test/plugin/example/Makefile
@@ -17,6 +17,7 @@ DMTCP_INCLUDE=${DMTCP_ROOT}/include
 
 CFLAGS += -I${DMTCP_INCLUDE} -DDMTCP -fPIC -c -g
 CXXFLAGS += -I${DMTCP_INCLUDE} -DDMTCP -fPIC -c -g
+LINK = ${CC}
 
 DEMO_PORT=7781
 
@@ -31,7 +32,7 @@ check: ${LIBNAME}.so ${DMTCP_ROOT}/test/dmtcp1
 
 # We link the library using C++ for compatibility with the main libdmtcp.so
 ${LIBNAME}.so: ${LIBOBJS}
-	${CXX} -shared -fPIC -o $@ $^
+	${LINK} -shared -fPIC -o $@ $^
 
 .c.o:
 	${CC} ${CFLAGS} -o $@ $<

--- a/test/plugin/sleep1/Makefile
+++ b/test/plugin/sleep1/Makefile
@@ -3,10 +3,10 @@
 # The name will be the same as the current directory name.
 NAME=${shell basename $$PWD}
 
-# By default, your resulting library will have this name.
-LIBNAME=dmtcp_${NAME}hijack
+# By default, your resulting plugin library will have this name.
+LIBNAME=libdmtcp_${NAME}
 
-# As you add new files to your hijack library, add the object file names here.
+# As you add new files to your plugin library, add the object file names here.
 LIBOBJS = ${NAME}.o
 
 # Modify if your DMTCP_ROOT is located elsewhere.

--- a/test/plugin/sleep1/Makefile
+++ b/test/plugin/sleep1/Makefile
@@ -17,6 +17,7 @@ DMTCP_INCLUDE=${DMTCP_ROOT}/include
 
 CFLAGS += -I${DMTCP_INCLUDE} -DDMTCP -fPIC -c -g
 CXXFLAGS += -I${DMTCP_INCLUDE} -DDMTCP -fPIC -c -g
+LINK = ${CC}
 
 DEMO_PORT=7781
 
@@ -30,7 +31,7 @@ check: ${LIBNAME}.so ${DMTCP_ROOT}/test/dmtcp1
 
 # We link the library using C++ for compatibility with the main libdmtcp.so
 ${LIBNAME}.so: ${LIBOBJS}
-	${CXX} -shared -fPIC -o $@ $^
+	${LINK} -shared -fPIC -o $@ $^
 
 .c.o:
 	${CC} ${CFLAGS} -o $@ $<

--- a/test/plugin/sleep2/Makefile
+++ b/test/plugin/sleep2/Makefile
@@ -18,6 +18,7 @@ DMTCP_INCLUDE=${DMTCP_ROOT}/include
 
 CFLAGS += -I${DMTCP_INCLUDE} -DDMTCP -fPIC -c -g
 CXXFLAGS += -I${DMTCP_INCLUDE} -DDMTCP -fPIC -c -g
+LINK = ${CC}
 
 DEMO_PORT=7781
 
@@ -35,7 +36,7 @@ check: ${LIBNAME}.so ../sleep1/dmtcp_sleep1hijack.so ${DMTCP_ROOT}/test/dmtcp1
 
 # We link the library using C++ for compatibility with the main libdmtcp.so
 ${LIBNAME}.so: ${LIBOBJS}
-	${CXX} -shared -fPIC -o $@ $^
+	${LINK} -shared -fPIC -o $@ $^
 
 .c.o:
 	${CC} ${CFLAGS} -o $@ $<

--- a/test/plugin/sleep2/Makefile
+++ b/test/plugin/sleep2/Makefile
@@ -4,10 +4,10 @@
 # The name will be the same as the current directory name.
 NAME=${shell basename $$PWD}
 
-# By default, your resulting library will have this name.
-LIBNAME=dmtcp_${NAME}hijack
+# By default, your resulting plugin library will have this name.
+LIBNAME=libdmtcp_${NAME}
 
-# As you add new files to your hijack library, add the object file names here.
+# As you add new files to your plugin library, add the object file names here.
 LIBOBJS = ${NAME}.o
 
 # Modify if your DMTCP_ROOT is located elsewhere.


### PR DESCRIPTION
Look at README, and one Makefile to see the pattern.
Three commits:
* README:  make clean tidy -> make clean
* Makefile:  dmtcp_NAMEhijack.so -> libdmtcp_NAME.so (and use word 'plugin library' in comments; not 'hijack library')
* Makefile:  LINKER = ${CC}    [ and the .so target uses ${LINKER} ... ]

QUESTION:  Is there a convention for the macro name LINKER (used to create a .so file from .o files)?