### PR TITLE
Fix for f01c300996fcde04d1a4f6c2ac6d3f39e8a32bc4

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -560,7 +560,7 @@ static void restorememoryareas(RestoreInfo *rinfo_ptr)
   DPRINTF("close cpfd %d\n", restore_info.fd);
   mtcp_sys_close (restore_info.fd);
 
-  //IMB; // flush instruction cache, since mtcp_restart.c code is now gone.
+  IMB; // flush instruction cache, since mtcp_restart.c code is now gone.
   DPRINTF("restore complete, resuming by jumping to %p...\n",
           restore_info.post_restart);
 


### PR DESCRIPTION
* Brings back IMB (instr. memory barrier) after moving mtcp_restart code.

(The commit message says it all.  This was lost in a large reorganization of MTCP on Jan. 21, 2014.)