### PR TITLE
is32bitElf should not be used with a 32-bit Linux

### DIFF
--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -347,9 +347,11 @@ static void runMtcpRestart(int is32bitElf, int fd, ProcessInfo *pInfo)
 
   static string mtcprestart = Util::getPath ("mtcp_restart");
 
+#if defined(__x86_64__) || defined(__aarch64__)
   if (is32bitElf) {
     mtcprestart = Util::getPath("mtcp_restart-32", is32bitElf);
   }
+#endif
 
   char* const newArgs[] = {
     (char*) mtcprestart.c_str(),

--- a/src/util_exec.cpp
+++ b/src/util_exec.cpp
@@ -179,7 +179,7 @@ int Util::elfType(const char *pathname, bool *isElf, bool *is32bitElf)
 static string ld_linux_so_path(int version, bool is32bitElf = false)
 {
   char buf[80];
-#if defined(__x86_64__) && !defined(CONFIG_M32)
+#if (defined(__x86_64__) || defined(__aarch64__)) && !defined(CONFIG_M32)
   if (is32bitElf) {
     sprintf(buf, "/lib/ld-linux.so.%d", version);
   } else {
@@ -333,7 +333,7 @@ void Util::patchArgvIfSetuid(const char* filename, char *const origArgv[],
   // Use /lib64 if 64-bit O/S and not 32-bit app:
 
   char *ldStrPtr = NULL;
-# if defined(__x86_64__) && !defined(CONFIG_M32)
+#if (defined(__x86_64__) || defined(__aarch64__)) && !defined(CONFIG_M32)
   bool isElf, is32bitElf;
   elfType(cmdBuf, &isElf, &is32bitElf);
   if (is32bitElf)


### PR DESCRIPTION
An alternative design would be to set is32bitElf to false in a 32-bit OS.  All of this is also related to issue #79 (choosing a better name than is32bitElf).

Let's push in this fix, and do the polishing later.  As of now, rc4 does not work on 32-bit Linux without this commit.