### PR TITLE
Fix capitalizations for some ipc method names

### DIFF
--- a/src/plugin/ipc/connection.cpp
+++ b/src/plugin/ipc/connection.cpp
@@ -27,7 +27,7 @@
 using namespace dmtcp;
 
 Connection::Connection(uint32_t t)
-  : _id(ConnectionIdentifier::Create())
+  : _id(ConnectionIdentifier::create())
   , _type((ConnectionType) t)
   , _fcntlFlags(-1)
   , _fcntlOwner(-1)

--- a/src/plugin/ipc/connectionidentifier.cpp
+++ b/src/plugin/ipc/connectionidentifier.cpp
@@ -45,16 +45,17 @@ void ConnectionIdentifier::serialize (jalib::JBinarySerializer& o)
   JASSERT(_nextConId >= CONNECTION_ID_START);
 }
 
-ConnectionIdentifier ConnectionIdentifier::Create()
+ConnectionIdentifier ConnectionIdentifier::create()
 {
   return ConnectionIdentifier (_nextConnectionId());
 }
-ConnectionIdentifier ConnectionIdentifier::Null()
+ConnectionIdentifier ConnectionIdentifier::null()
 {
   static ConnectionIdentifier n;
   return n;
 }
-ConnectionIdentifier ConnectionIdentifier::Self()
+// FIXME:  This is never used.
+ConnectionIdentifier ConnectionIdentifier::self()
 {
   return ConnectionIdentifier(-1);
 }

--- a/src/plugin/ipc/connectionidentifier.h
+++ b/src/plugin/ipc/connectionidentifier.h
@@ -40,9 +40,9 @@ namespace dmtcp
       static void* operator new(size_t nbytes) { JALLOC_HELPER_NEW(nbytes); }
       static void  operator delete(void* p) { JALLOC_HELPER_DELETE(p); }
 #endif
-      static ConnectionIdentifier Create();
-      static ConnectionIdentifier Null();
-      static ConnectionIdentifier Self();
+      static ConnectionIdentifier create();
+      static ConnectionIdentifier null();
+      static ConnectionIdentifier self();
 
       static void serialize ( jalib::JBinarySerializer& o );
 

--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -48,7 +48,7 @@ using namespace dmtcp;
 static bool ptmxTestPacketMode(int masterFd);
 static ssize_t ptmxReadAll(int fd, const void *origBuf, size_t maxCount);
 static ssize_t ptmxWriteAll(int fd, const void *buf, bool isPacketMode);
-static void CreateDirectoryStructure(const string& path);
+static void createDirectoryStructure(const string& path);
 static void writeFileFromFd(int fd, int destFd);
 static bool areFilesEqual(int fd, int destFd, size_t size);
 
@@ -639,7 +639,7 @@ void FileConnection::preCkpt()
     JASSERT(SharedData::getCkptLeaderForFile(_st_dev, _st_ino, &id));
     if (id == _id) {
       string savedFilePath = getSavedFilePath(_path);
-      CreateDirectoryStructure(savedFilePath);
+      createDirectoryStructure(savedFilePath);
 
       int destFd = _real_open(savedFilePath.c_str(), O_CREAT | O_WRONLY | O_TRUNC,
                               S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
@@ -824,7 +824,7 @@ void FileConnection::postRestart()
     JTRACE("Restore Resource Manager File") (_path);
   } else {
     refreshPath();
-    CreateDirectoryStructure(_path);
+    createDirectoryStructure(_path);
     /* Now try to create the file with O_EXCL. If we fail with EEXIST, there
      * are two possible scenarios:
      * - The file was created by a different restarting process with data from
@@ -872,7 +872,7 @@ bool FileConnection::checkDup(int fd)
   return retVal;
 }
 
-static void CreateDirectoryStructure(const string& path)
+static void createDirectoryStructure(const string& path)
 {
   size_t index = path.rfind('/');
 

--- a/src/plugin/ipc/socket/socketconnection.cpp
+++ b/src/plugin/ipc/socket/socketconnection.cpp
@@ -179,7 +179,7 @@ void SocketConnection::serialize(jalib::JBinarySerializer& o)
   , SocketConnection(domain, type, protocol)
   , _listenBacklog(-1)
   , _bindAddrlen(0)
-  , _remotePeerId(ConnectionIdentifier::Null())
+  , _remotePeerId(ConnectionIdentifier::null())
 {
   if (domain != -1) {
     // Sometimes _sockType contains SOCK_CLOEXEC/SOCK_NONBLOCK flags.

--- a/src/plugin/ipc/socket/socketwrappers.cpp
+++ b/src/plugin/ipc/socket/socketwrappers.cpp
@@ -169,7 +169,7 @@ static void process_accept(int ret, int sockfd, struct sockaddr *addr,
   JASSERT(ret != -1);
   TcpConnection *parent =
     (TcpConnection*) SocketConnList::instance().getConnection(sockfd);
-  TcpConnection* con = new TcpConnection(*parent, ConnectionIdentifier::Null());
+  TcpConnection* con = new TcpConnection(*parent, ConnectionIdentifier::null());
   if (con == NULL) {
     JTRACE("accept operation on unsupported socket type.");
     return;


### PR DESCRIPTION
CreateDirectoryStructure(), Create(), Null(), and Self() are all methods (not constructors) that start with capital letters.  It's been that way probably since 2012.  This seems to violate standard C++ conventions.  So, I'm changing them to start with lower case.

Also, Self() seems never to be used.  I added a FIXME comment in front of it.  Should we just remove the Self() method?