### PR TITLE
Fix 3b06a815 : buggy condition in 'test' command

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -118,7 +118,7 @@ tests: build
 LIMIT=ulimit -v 33554432
 
 check: tests
-	@ if [ "`id -u`" == "0" ]; then \
+	@ if which id > /dev/null && test "`id -u`" = "0" ; then \
 	  echo "'make check' will fail if run as root."; \
 	  exit 1; \
 	fi


### PR DESCRIPTION
The '==' operator is not legal for the 'test' command.  Also, I added a test if the 'id' command exists, as extra insurance against this blowing up.