### PR TITLE
Env var DMTCP_GDB_ATTACH_ON_RESTART allows attach

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,7 +4,7 @@ Please send DMTCP bug reports via <dmtcp-forum@lists.sourceforge.net>
 
 Version 2.4 release notes
 =========================
-Several important changes and enancements were added:
+Several important changes and enhancements were added:
 * dmtcp_launch/restart/command/coordinator now take the flags
     -h, -p, --coord-host/port and environment variables
     DMTCP_COORD_HOST/PORT.  The older --host, --port, DMTCP_HOST/PORT
@@ -26,6 +26,11 @@ Several important changes and enancements were added:
      cat /proc/self/maps | grep '\[vvar]'
 * Support for glibc version 2.21 added.  To see if this affects you, do:
      ls -l /lib*/libc.so.6 /lib/*/libc.so.6
+* The environment variable DMTCP_GDB_ATTACH_ON_RESTART was added.  Setting
+     this permanently is a security risk. But on a temporary basis,
+     it can enable easier debugging of restarted processes:
+       DMTCP_GDB_ATTACH_ON_RESTART=1 dmtcp_restart ckpt_a.out_*.dmtcp &
+       gdb a.out `pgrep -n a.out`
 * Enhancements added for newer 32-bit ARM (armv7) CPUs
 * Experimental support is now provided for 64-bit ARM (armv8)
 * Bug fixes
@@ -338,7 +343,7 @@ Version 1.2.4 release notes
   checkpoint-restart service of Open MPI.  The usage will be documented soon
   through the Open MPI web site.  As before, an alternative is to simply start
   Open MPI inside DMTCP, and let DMTCP treat all of Open MPI as a "black box"
-  that happens to be a ditributed computation
+  that happens to be a distributed computation
 - A new --prefix command line flag has been added to dmtcp_checkpoint.  It
   operates similarly to the flag of the same name in Open MPI.  For distributed
   computations, remote processes will use the prefix as part of the path to
@@ -430,7 +435,7 @@ Version 1.2.1 release notes
   the setuid/setgid bits of the binaries are set.
 * Several bug fixes related to GNU screen.
 * Experimental support for ptrace to allow checkpointing of gdb sessions,
-  strace, and other ptrace-based aplications.
+  strace, and other ptrace-based applications.
 * On restart, restore original process name for 'ps' and /proc/self/cmdline.
 * Additional bug fixes and enhancements.
 
@@ -532,7 +537,7 @@ Version 1.1.0 release notes
 * IPv6 fixes for supporting OpenMPI 1.3.x. (OpenMPI now works with DMTCP.)
 * changed fork to vfork for gzip spawning for handling programs with huge
   memory.
-* Process Group / foregroud process restored at restart.
+* Process Group / foreground process restored at restart.
 * Support for system() updated.
 * Some new configuration options
 * Several other bug fixes / enhancements.
@@ -556,7 +561,7 @@ Version 1.04 release notes
 
 * Fixed Ubuntu 9.01 bug. glic-2.9 was more stringent about stack overflow
   errors.
-* Ububtu 9.01 uses gcc-4.3.4 -Wformat=2 which produced false positives
+* Ubuntu 9.01 uses gcc-4.3.4 -Wformat=2 which produced false positives
   warnings. We added %s format specifier to format string and empty string
   argument to eliminate warnings.
 

--- a/doc/debugging-dmtcp.txt
+++ b/doc/debugging-dmtcp.txt
@@ -2,35 +2,128 @@ This is intended as one of a series of informal documents to describe
 and partially document some of the more subtle DMTCP data structures
 and algorithms.  These documents are snapshots in time, and they
 may become somewhat out-of-date over time (and hopefully also refreshed
-to re-sync them with the code again).  (Updated Feb., 2014)
+to re-sync them with the code again).  (Updated May, 2015)
+
+The topics on debugging include:
+A. PRINT DEBUGGING
+B. STOPPING GDB BEFORE JASSERT CAUSES PROCESS EXIT
+C. LAUNCHING A PROCESS UNDER DMTCP CONTROL USING GDB
+D. DEBUGGING ON RESTART USING GDB ATTACH
+E. TRICKS FOR DEBUGGING WHILE INSIDE GDB
 
 ===
+A. PRINT DEBUGGING
 
-There are several ways to debug.  One simple way, is:
+There are several ways to debug.  If you want "print debugging", with
+a trace of the major operations, do:
   ./configure --enable-debug
   make -j clean
   make -j check-dmtcp1
+and look in /tmp/dmtcp-USER@HOST for files of the form jassertlog.*,
+which contain copies of calls to JTRACE/JWARN/JNOTE inside DMTCP,
+with one file per process, and per exec into a new program.
 
 If there are multiple processes, then a log from each process will
 be in its own file in /tmp/dmtcp-USER@HOST/jassertlog*
 
 ===
+B. STOPPING GDB BEFORE JASSERT CAUSES PROCESS EXIT
 
-If debugging under gdb, and the process exits before you can examine
+If debugging under GDB, and the process exits before you can examine
 the cause, try:
  (gdb) break FNC
- [ for FNC among:  exit, _exit, _Exit, mtcp_abort ]
+ [ for FNC among:  exit, _exit, _Exit, mtcp_abort ;
+   The function _exit is used when Jassert() exits. ]
 
 ===
+C. LAUNCHING A PROCESS UNDER DMTCP CONTROL USING GDB
 
 If the bug occurs during launch or possibly in checkpoint-resume, try:
   gdb --args dmtcp_launch -i5 test/dmtcp1
 
-If you want to stop GDB when DMTCP first takes control, do:
-  (gdb) break 'dmtcp::DmtcpWorker::DmtcpWorker(bool)'
-  [ and yes, to making a "breakpoint pending on future shared library load" ]
+Note that GDB will first give you control under 'dmtcp_launch'.  
+(1) If you want to stop GDB when dmtcp1 enters its main() routine:
+  (gdb) break execvp
+  (gdb) run
+  (gdb) break main
+  (gdb) continue
+(2) If you want to stop GDB when the DMTCP constructor takes control
+      in dmtcp1 (even before entering the main() routine of dmtcp1), do:
+  (gdb) break 'dmtcp::DmtcpWorker::DmtcpWorker()'
+    [ and say yes to:  "breakpoint pending on future shared library load" ]
+  (gdb) run
 
 ===
+D. DEBUGGING ON RESTART USING GDB ATTACH
+
+Ideally, we would like to just use:  gdb --args dmtcp_restart ckpt_*.dmtcp
+This does not work (unless you just want to debug the command dmtcp_restart
+itself).  But the command dmtcp_restart overlays the old memory from
+ckpt_*.dmtcp into the current running 'dmtcp_restart' process.  As you would
+expect, GDB has difficulty following this memory overlay.  Therefore,
+the best way to debug a restarted process is to use the 'attach' feature
+of GDB.
+
+If you want to debug DMTCP functions also, be sure to compile DMTCP with
+debugging support.  A convenient recipe from the root directory of DMTcP is:
+  ./configure CXXFLAGS="-g3 -O0" CFLAGS="-g3 -O0" 
+  make -j clean
+  make -j
+
+There are four methods available.  Most users will prefer the first,
+or possibly the second method.  The methods are in order of increasing
+interest for developers of DMTCP.  Make sure that you compiled DMTCP
+with debugging support if you want to also see symbols for DMTCP functions.
+
+1. DMTCP_GDB_ATTACH_ON_RESTART:
+2. DMTCP_RESTART_PAUSE2:
+3. DMTCP_RESTART_PAUSE:
+4. USING GDB WITH MTCP (primarily for developers):
+
+The four methods follow:
+
+1. DMTCP_GDB_ATTACH_ON_RESTART:
+In the past, using 'gdb attach' was as easy as:
+       dmtcp_restart ckpt_a.out_*.dmtcp &
+       gdb a.out `pgrep -n a.out`
+
+Unfortunately, recent Linux distros have forbidden this type of
+'gdb attach' because it can expose security holes.  To get around
+this on a per-process basis, DMTCP provides the special
+environment variable DMTCP_GDB_ATTACH_ON_RESTART:
+       DMTCP_GDB_ATTACH_ON_RESTART=1 dmtcp_restart ckpt_a.out_*.dmtcp &
+       gdb a.out `pgrep -n a.out`
+
+2. DMTCP_RESTART_PAUSE2:
+If it's important to attach with GDB early in the restart process, then
+DMTCP provides this and the following alternatives:
+       DMTCP_RESTART_PAUSE2=1 bin/dmtcp_launch a.out
+       bin/dmtcp_command --checkpoint
+       dmtcp_restart ckpt_a.out_*.dmtcp &
+       # DMTCP will then pause for 15 seconds, and wait for a GDB attach.
+
+3. DMTCP_RESTART_PAUSE:
+If you need to attach with GDB _very_ early in the restart process (usually
+needed only by DMTCP developers), do:
+       DMTCP_RESTART_PAUSE=1 bin/dmtcp_launch a.out
+       # Continue as above.
+In this case, you will attach at a time when only the primary thread
+exists, and the DMTCP checkpoint thread is not yet distinguished from
+the original user thread executing main().
+
+Note that to attach early, you must set the environment variable during
+dmtcp_launch.  This is needed in order to embed the environment variable
+in the memory that is then saved in ckpt_a.out_*.dmtcp.  If you set the
+environment variable only during restart, then the memory overlay
+of dmtcp_restart will overwrite the environment variable that you set.
+
+*** NOTE:  The above restriction for DMTCP_RESTART_PAUSE / DMTCP_RESTART_PAUSE2
+***        may be relaxed in the future, to allow setting before dmtcp_restart.
+
+4. USING GDB WITH MTCP (primarily for developers):
+For developers only, 'gdb attach' can be useful _very_, _very_ early ---
+during the initial control of MTCP, the lowest layer of DMTCP. 
+Here are some instructions for this case.
 
 For low-level debugging on restart, try:
   cd src/mtcp
@@ -50,26 +143,33 @@ For low-level debugging on restart, try:
   // GDB should be more robust after this.
 
 ===
+E. TRICKS FOR DEBUGGING WHILE INSIDE GDB
 
-  If the target process exits under GDB, then you can catch it before
-  it exits by:
-  (gdb) break main
-  (gdb) run
-  (gdb) break exit
-  (gdb) break _exit
-  (gdb) break _Exit
+    Sometimes, you will want GDB to stop exactly at a certain line of code.
+If that line occurs early, execution may have already passed that line
+before you can attach.  One trick to stop GDB there is to add a line of code
+(even into DMTCP itself):
+  { int x = 1; while (x) {}; }
+After that, use one of the above techniques for attaching with GDB, and:
+  (gdb) where
+  (gdb) print x = 0
+  (gdb) next
 
-===
+    Most of DMTCP is written in C++.  If you want to list or set a breakpoint
+in a DMTCP function, it helps to search for full function signatures of
+non-static functions by giving a substring:
+  (gdb) info functions initialize
+  (gdb) break 'dmtcp::Util::initializ<TAB>
 
-      If debugging after restart, it is best to use 'gdb test/dmtcp1 PID'
-  (e.g., if debugging dmtcp1), in order to ensure that GDB understands
-  the full context.  If you want to capture DMTCP, add a 'sleep' or 'while'
-  loop at the beginning of threadinfo.c:void Thread_RestoreAllThreads()
-  to capture DMTCP early; or just before 'restarthread(motherofall)' at
-  the end of Thread_RestoreAllThreads() to capture DMTCP with all threads
-  restored.
-
-      Separately, if looking at DMTCP in GDB, one thread will be the
-  checkpoint thread.  You'll recognize it, because of the function
-  checkpointhread() on the stack.  It is the second thread on launch,
-  but it can be any thread on restart.
+    Note that during dmtcp_launch, the first thread will be the
+primary thread (the thread that executes the user's function main()).
+The second thread created is the checkpoint thread.  You'll recognize the
+difference because the user's primary thread will have main() on the stack;
+and the checkpoint thread will have the function checkpointhread() on the stack.
+    After dmtcp_restart, the primary thread will not necessarily
+be the first of the threads displayed by GDB's 'info threads' command.
+However, the threads can still be distinguished by examining the stack 
+for each thread:
+  primary thread: main()
+  checkpoint thread:  checkpointhread()
+  other user thread:  anything


### PR DESCRIPTION
Linux distros of the last few years don't allow 'gdb PROGNAME PID' when the PID is not a child process of the current process.  This allows:

    DMTCP_GDB_ATTACH_ON_RESTART=1 dmtcp_restart ckpt_a.out_*.dmtcp &
    gdb a.out `pgrep -n a.out`
(I plan to include the recipe above in the DMTCP FAQ.)