### PR TITLE
Standalone m32 now builds easily:  configure --enable-m32 && make clean && make

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -59,7 +59,12 @@ MANPAGES=dmtcp.1.gz dmtcp_coordinator.1.gz dmtcp_command.1.gz dmtcp_launch.1.gz 
 
 default: display-build-env build
 
+# If M32, 'rm -rf lib bin'.  Can't do a 32-bit build on top of a 64-bit build,
+#   neither './configure --enable-m32' nor 'make clean' will remove these dirs.
 mkdirs:
+ifeq ($(M32),1)
+	rm -rf lib bin
+endif
 	$(MKDIR_P) $(targetdir)/bin
 	$(MKDIR_P) $(targetdir)/lib/dmtcp
 
@@ -100,6 +105,10 @@ display-config:
 
 dmtcp:
 	cd src && $(MAKE)
+ifeq ($(M32),1)
+	cd lib/dmtcp && ln -s 32/lib/dmtcp/* ./
+	mkdir -p bin && cd bin && ln -s ../lib/dmtcp/32/bin/* ./
+endif
 
 plugin: dmtcp
 	cd plugin && $(MAKE)

--- a/doc/multi-arch.txt
+++ b/doc/multi-arch.txt
@@ -27,11 +27,13 @@ A. Compiling DMTCP for multi-arch support:
    ./configure --enable-m32
    make clean
    make -j
-   make install
 2. Do the usual 64-bit compilation
    ./configure
+   make clean-64
    make -j
-   make install
+
+Optionally, add 'make install' at the end of each of the above stages,
+if you want to install a mulit-arch implementation.
 
 Use "./configure --prefix=$PWD/build" if you wish to build a local copy,
 instead of installing globally.


### PR DESCRIPTION
@karya0:  We had wanted to talk together about a clean design to support both standalone --enable-m32 and multi-arch.  There hasn't been time to do it yet.  So, I created his commit as one possible design.  This can serve as a _baseline_ for further discussions.

My goal here is to push into the development branch one clean way to do this.  Then we can talk together about changing _this_ baseline to find the cleanest possible design.  That will be easier than comparing several new designs against a baseline in the development branch that is only partially working.

I've tested this commit in four modes:
* Native 32-bit Ubuntu distro
* 64-bit distro, standalone m32:

    `configure --enable-m32 && make clean && make`
* multi-arch:

    `./configure --enable-m32 && make clean && make -j`
    `./configure && make clean-64 && make -j`
    `gcc -m32 test/dmtcp1.c`
    [ And test DMTCP on the `a.out` generated above. ]`
* multi-arch with `--prefix=.../dmtcp-build`, while adding `&& make install`` to above recipe

All four of the above cases are now working when I use this commit.