### PR TITLE
__xstat() survives bad mem addr

### DIFF
--- a/src/plugin/pid/pid_filewrappers.cpp
+++ b/src/plugin/pid/pid_filewrappers.cpp
@@ -156,8 +156,16 @@ extern "C" int __xstat(int vers, const char *path, struct stat *buf)
 {
   char tmpbuf[PATH_MAX];
   char *newpath = tmpbuf;
-  updateProcPathVirtualToReal(path, &newpath);
-  int retval = _real_xstat( vers, newpath, buf );
+  // See filewrapper.cpp:__xstat() for comments on this code.
+  int retval = _real_xstat(vers, path, buf);
+  if (retval == -1 && errno == EFAULT) {
+    // We're done.  Return.
+  } else {
+    updateProcPathVirtualToReal(path, &newpath);
+    if (newpath != path) {
+      retval = _real_xstat(vers, newpath, buf); 
+    } 
+  }
   return retval;
 }
 
@@ -165,8 +173,16 @@ extern "C" int __xstat64(int vers, const char *path, struct stat64 *buf)
 {
   char tmpbuf[PATH_MAX];
   char *newpath = tmpbuf;
-  updateProcPathVirtualToReal(path, &newpath);
-  int retval = _real_xstat64( vers, newpath, buf );
+  // See filewrapper.cpp:__xstat() for comments on this code.
+  int retval = _real_xstat64(vers, path, buf);
+  if (retval == -1 && errno == EFAULT) {
+    // We're done.  Return.
+  } else {
+    updateProcPathVirtualToReal(path, &newpath);
+    if (newpath != path) {
+      retval = _real_xstat64(vers, newpath, buf); 
+    } 
+  }
   return retval;
 }
 
@@ -188,8 +204,16 @@ extern "C" int __lxstat(int vers, const char *path, struct stat *buf)
 {
   char tmpbuf[PATH_MAX];
   char *newpath = tmpbuf;
-  updateProcPathVirtualToReal(path, &newpath);
-  int retval = _real_lxstat( vers, newpath, buf );
+  // See filewrapper.cpp:__xstat() for comments on this code.
+  int retval = _real_lxstat(vers, path, buf);
+  if (retval == -1 && errno == EFAULT) {
+    // We're done.  Return.
+  } else {
+    updateProcPathVirtualToReal(path, &newpath);
+    if (newpath != path) {
+      retval = _real_lxstat(vers, newpath, buf); 
+    } 
+  }
   return retval;
 }
 
@@ -197,8 +221,16 @@ extern "C" int __lxstat64(int vers, const char *path, struct stat64 *buf)
 {
   char tmpbuf[PATH_MAX];
   char *newpath = tmpbuf;
-  updateProcPathVirtualToReal(path, &newpath);
-  int retval = _real_lxstat64( vers, newpath, buf );
+  // See filewrapper.cpp:__xstat() for comments on this code.
+  int retval = _real_lxstat64(vers, path, buf);
+  if (retval == -1 && errno == EFAULT) {
+    // We're done.  Return.
+  } else {
+    updateProcPathVirtualToReal(path, &newpath);
+    if (newpath != path) {
+      retval = _real_lxstat64(vers, newpath, buf); 
+    } 
+  }
   return retval;
 }
 

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -750,6 +750,9 @@ runTest("file1",         1, ["./test/file1"])
 #         is mmap'ed, but not yet when file is referenced by open fd.
 # runTest("file2",         1, ["./test/file2"])
 
+# Test for normal file, /dev/tty, proc file, and illegal pathname
+runTest("stat",         1, ["./test/stat"])
+
 PWD=os.getcwd()
 runTest("plugin-sleep2", 1, ["--with-plugin "+
                              PWD+"/test/plugin/sleep1/dmtcp_sleep1hijack.so:"+

--- a/test/stat.c
+++ b/test/stat.c
@@ -1,0 +1,47 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+
+#if defined(__x86_64__) || defined(__aarch64__)
+static const char * badAddress = (char *)0xffffffffff000000;
+#else
+static const char * badAddress = (char *)0xff000000;
+#endif
+
+int main() {
+  struct stat buf;
+  int rc;
+  while (1) {
+    char procFd[100];
+    snprintf(procFd, sizeof(procFd), "/proc/%d/fd", getpid());
+    procFd[sizeof(procFd)-1] = '\0';
+
+    rc = stat("/dev/tty", &buf);
+    if (rc == -1) return 1;
+    rc = stat("/etc/passwd", &buf);
+    if (rc == -1) return 2;
+    rc = stat(procFd, &buf);
+    if (rc == -1) return 3;
+    rc = stat("/etc/there_is_no_such_file_and_so_rc_is_error", &buf);
+    if (rc != -1 || errno != ENOENT) return 4;
+    rc = stat(badAddress, &buf);
+    if (rc != -1 || errno != EFAULT) return 5;
+
+    rc = lstat("/dev/tty", &buf);
+    if (rc == -1) return 1;
+    rc = lstat("/etc/passwd", &buf);
+    if (rc == -1) return 2;
+    rc = lstat(procFd, &buf);
+    if (rc == -1) return 3;
+    rc = lstat("/etc/there_is_no_such_file_and_so_rc_is_error", &buf);
+    if (rc != -1 || errno != ENOENT) return 4;
+    rc = lstat(badAddress, &buf);
+    if (rc != -1 || errno != EFAULT) return 5;
+
+    printf(". "); fflush(stdout);
+    sleep(1);
+  }
+  return 1;  /* NOTREACHED */
+}


### PR DESCRIPTION
In a user's program, stat() was being called with a bad memory address for pathname.  The combination of libc and the kernel then returned -1 with `errno == EFAULT`.
&nbsp;&nbsp;&nbsp;&nbsp;Under DMTCP, stat() went through a wrapper, which tried to read the memory at the address of the pathname.  Because of this it segfaulted.  Now, our utilities updateStatPath() and updateProcPathVirtualToReal() check if the memory address is readable before reading it.
&nbsp;&nbsp;&nbsp;&nbsp;A test program, stat.c, has been added that used to fail under DMTCP.  It now works.

(This pull request address issue #102.)