### PR TITLE
Simplify dmtcp_restart (no need for wrapper fncs or _real_XXX())

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,7 +83,7 @@ __targetdir__bin_dmtcp_coordinator_SOURCES = dmtcp_coordinator.cpp lookup_servic
 
 __targetdir__bin_dmtcp_nocheckpoint_SOURCES = dmtcp_nocheckpoint.c
 
-__targetdir__bin_dmtcp_restart_SOURCES = dmtcp_restart.cpp util_exec.cpp ckptserializer.cpp
+__targetdir__bin_dmtcp_restart_SOURCES = dmtcp_restart.cpp util_exec.cpp
 
 __targetdir__bin_dmtcp_command_SOURCES = dmtcp_command.cpp
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -174,7 +174,7 @@ __targetdir__bin_dmtcp_nocheckpoint_OBJECTS =  \
 	$(am___targetdir__bin_dmtcp_nocheckpoint_OBJECTS)
 __targetdir__bin_dmtcp_nocheckpoint_LDADD = $(LDADD)
 am___targetdir__bin_dmtcp_restart_OBJECTS = dmtcp_restart.$(OBJEXT) \
-	util_exec.$(OBJEXT) ckptserializer.$(OBJEXT)
+	util_exec.$(OBJEXT)
 __targetdir__bin_dmtcp_restart_OBJECTS =  \
 	$(am___targetdir__bin_dmtcp_restart_OBJECTS)
 __targetdir__bin_dmtcp_restart_DEPENDENCIES = libdmtcpinternal.a \
@@ -563,7 +563,7 @@ libsyscallsreal_a_SOURCES = syscallsreal.c trampolines.cpp
 libnohijack_a_SOURCES = nosyscallsreal.c dmtcpnohijackstubs.cpp
 __targetdir__bin_dmtcp_coordinator_SOURCES = dmtcp_coordinator.cpp lookup_service.cpp
 __targetdir__bin_dmtcp_nocheckpoint_SOURCES = dmtcp_nocheckpoint.c
-__targetdir__bin_dmtcp_restart_SOURCES = dmtcp_restart.cpp util_exec.cpp ckptserializer.cpp
+__targetdir__bin_dmtcp_restart_SOURCES = dmtcp_restart.cpp util_exec.cpp
 __targetdir__bin_dmtcp_command_SOURCES = dmtcp_command.cpp
 __targetdir__lib_dmtcp_libdmtcp_so_SOURCES = dmtcpworker.cpp threadsync.cpp \
 		      coordinatorapi.cpp execwrappers.cpp \

--- a/src/ckptserializer.cpp
+++ b/src/ckptserializer.cpp
@@ -102,7 +102,7 @@ static void restore_sigchld_handler_and_wait_for_zombie(pid_t pid)
     sigset_t suspend_sigset;
     sigfillset(&suspend_sigset);
     sigdelset(&suspend_sigset, SIGCHLD);
-    sigsuspend(&suspend_sigset);
+    _real_sigsuspend(&suspend_sigset);
     JWARNING(_real_waitpid(pid, NULL, 0) != -1) (pid) (JASSERT_ERRNO);
     pid = -1;
     sigaction(SIGCHLD, &saved_sigchld_action, NULL);

--- a/src/ckptserializer.cpp
+++ b/src/ckptserializer.cpp
@@ -53,13 +53,6 @@
 
 using namespace dmtcp;
 
-// Copied from mtcp/mtcp_restart.c.
-#define DMTCP_MAGIC_FIRST 'D'
-#define GZIP_FIRST 037
-#ifdef HBICT_DELTACOMP
-#define HBICT_FIRST 'H'
-#endif
-
 #define FORKED_CKPT_FAILED 0
 #define FORKED_CKPT_PARENT 1
 #define FORKED_CKPT_CHILD 2
@@ -69,21 +62,6 @@ static pid_t ckpt_extcomp_child_pid = -1;
 static struct sigaction saved_sigchld_action;
 static int open_ckpt_to_write(int fd, int pipe_fds[2], char **extcomp_args);
 void mtcp_writememoryareas(int fd) __attribute__((weak));
-
-static char first_char(const char *filename)
-{
-  int fd, rc;
-  char c;
-
-  fd = open(filename, O_RDONLY);
-  JASSERT(fd >= 0) (filename) .Text("ERROR: Cannot open filename");
-
-  rc = _real_read(fd, &c, 1);
-  JASSERT(rc == 1) (filename) .Text("ERROR: Error reading from filename");
-
-  close(fd);
-  return c;
-}
 
 /* We handle SIGCHLD while checkpointing. */
 static void default_sigchld_handler(int sig) {
@@ -396,135 +374,6 @@ open_ckpt_to_write(int fd, int pipe_fds[2], char **extcomp_args)
 }
 
 
-// Copied from mtcp/mtcp_restart.c.
-// Let's keep this code close to MTCP code to avoid maintenance problems.
-// MTCP code in:  mtcp/mtcp_restart.c:open_ckpt_to_read()
-// A previous version tried to replace this with popen, causing a regression:
-//   (no call to pclose, and possibility of using a wrong fd).
-// Returns fd;
-static int open_ckpt_to_read(const char *filename)
-{
-  int fd;
-  int fds[2];
-  char fc;
-  const char *decomp_path;
-  const char **decomp_args;
-  const char *gzip_path = "gzip";
-  static const char * gzip_args[] = {
-    const_cast<char*> ("gzip"),
-    const_cast<char*> ("-d"),
-    const_cast<char*> ("-"),
-    NULL
-  };
-#ifdef HBICT_DELTACOMP
-  const char *hbict_path = const_cast<char*> ("hbict");
-  static const char *hbict_args[] = {
-    const_cast<char*> ("hbict"),
-    const_cast<char*> ("-r"),
-    NULL
-  };
-#endif
-  pid_t cpid;
-
-  fc = first_char(filename);
-  fd = open(filename, O_RDONLY);
-  JASSERT(fd>=0)(filename).Text("Failed to open file.");
-
-  if (fc == DMTCP_MAGIC_FIRST) { /* no compression */
-    return fd;
-  }
-  else if (fc == GZIP_FIRST
-#ifdef HBICT_DELTACOMP
-           || fc == HBICT_FIRST
-#endif
-          ) {
-    if (fc == GZIP_FIRST) {
-      decomp_path = gzip_path;
-      decomp_args = gzip_args;
-    }
-#ifdef HBICT_DELTACOMP
-    else {
-      decomp_path = hbict_path;
-      decomp_args = hbict_args;
-    }
-#endif
-
-    JASSERT(pipe(fds) != -1) (filename)
-      .Text("Cannot create pipe to execute gunzip to decompress ckpt file!");
-
-    cpid = _real_fork();
-
-    JASSERT(cpid != -1)
-      .Text("ERROR: Cannot fork to execute gunzip to decompress ckpt file!");
-    if (cpid > 0) { /* parent process */
-      JTRACE("created child process to uncompress checkpoint file") (cpid);
-      close(fd);
-      close(fds[1]);
-      // Wait for child process
-      JASSERT(waitpid(cpid, NULL, 0) == cpid);
-      return fds[0];
-    } else { /* child process */
-      /* Fork a grandchild process and kill the parent. This way the grandchild
-       * process never becomes a zombie.
-       *
-       * Sometimes dmtcp_restart is called with multiple ckpt images. In that
-       * situation, the dmtcp_restart process creates gzip processes and only
-       * later forks mtcp_restart processes. The gzip processes can not be
-       * wait()'d upon by the corresponding mtcp_restart processes because
-       * their parent is the original dmtcp_restart process and thus they
-       * become zombie.
-       */
-      cpid = _real_fork();
-      JASSERT(cpid != -1);
-      if (cpid > 0) {
-        // Use _exit() instead of exit() to avoid popping atexit() handlers
-        // registered by the parent process.
-        _exit(0);
-      }
-
-      // Grandchild process
-      JTRACE ( "child process, will exec into external de-compressor");
-      fd = _real_dup(_real_dup(_real_dup(fd)));
-      fds[1] = _real_dup(fds[1]);
-      close(fds[0]);
-      JASSERT(fd != -1);
-      JASSERT(_real_dup2(fd, STDIN_FILENO) == STDIN_FILENO);
-      close(fd);
-      JASSERT(_real_dup2(fds[1], STDOUT_FILENO) == STDOUT_FILENO);
-      close(fds[1]);
-      _real_execvp(decomp_path, (char **)decomp_args);
-      JASSERT(decomp_path!=NULL) (decomp_path)
-        .Text("Failed to launch gzip.");
-      /* should not get here */
-      JASSERT(false)
-        .Text("Decompression failed!  No restoration will be performed!");
-    }
-  } else { /* invalid magic number */
-    JASSERT(false)
-      .Text("ERROR: Invalid magic number in this checkpoint file!");
-  }
-  return -1;
-}
-
-// See comments above for open_ckpt_to_read()
-int CkptSerializer::openCkptFileToRead(const string& path)
-{
-  char buf[1024];
-  int fd = open_ckpt_to_read(path.c_str());
-  // The rest of this function is for compatibility with original definition.
-  JASSERT(fd >= 0) (path) .Text("Failed to open file.");
-  const int len = strlen(DMTCP_FILE_HEADER);
-  JASSERT(_real_read(fd, buf, len) == len)(path) .Text("_real_read() failed");
-  if (strncmp(buf, DMTCP_FILE_HEADER, len) == 0) {
-    JTRACE("opened checkpoint file [uncompressed]")(path);
-  } else {
-    _real_close(fd);
-    fd = open_ckpt_to_read(path.c_str()); /* Re-open from beginning */
-    JASSERT(fd >= 0) (path) .Text("Failed to open file.");
-  }
-  return fd;
-}
-
 void CkptSerializer::createCkptDir()
 {
   string ckptDir = ProcessInfo::instance().getCkptDir();
@@ -615,21 +464,4 @@ void CkptSerializer::writeDmtcpHeader(int fd)
   ssize_t remaining = pagesize - (written % pagesize);
   char buf[remaining];
   JASSERT(Util::writeAll(fd, buf, remaining) == remaining);
-}
-
-int CkptSerializer::readCkptHeader(const string& path, ProcessInfo *pInfo)
-{
-  int fd = openCkptFileToRead(path);
-  const size_t len = strlen(DMTCP_FILE_HEADER);
-
-  jalib::JBinarySerializeReaderRaw rdr("", fd);
-  pInfo->serialize(rdr);
-  size_t numRead = len + rdr.bytes();
-
-  // We must read in multiple of PAGE_SIZE
-  const ssize_t pagesize = Util::pageSize();
-  ssize_t remaining = pagesize - (numRead % pagesize);
-  char buf[remaining];
-  JASSERT(Util::readAll(fd, buf, remaining) == remaining);
-  return fd;
 }

--- a/src/ckptserializer.h
+++ b/src/ckptserializer.h
@@ -30,12 +30,10 @@ namespace dmtcp
 {
   namespace CkptSerializer
   {
-    int openCkptFileToRead(const string& path);
     int openCkptFileToWrite(const string& path);
     void createCkptDir();
     void writeCkptImage(void *mtcpHdr, size_t mtcpHdrLen);
     void writeDmtcpHeader(int fd);
-    int readCkptHeader(const string& path, ProcessInfo *pInfo);
   };
 }
 


### PR DESCRIPTION
This pull request includes two commits.  The first and larger one moves four functions from ckptserializer.cpp to dmtcp_restart.cpp:
    first_char(), open_ckpt_to_read(), CkptSerializer::openCkptFileToRead((), CkptSerializer::readCkptHeader()
They all become static functions in dmtcp_restart.cpp, since no other file refers to them.  (And of course, they are no longer methods of the CkptSerializer class.  This also makes logical sense, since the name ckpserializer.cpp refers to serializing files.  The files that were moved are used to inspec the already created checkpoint image file on restart, and so they are conceptually different.
&nbsp;&nbsp;&nbsp;&nbsp;And finally, the biggest win is that the four functions included about 12 occurrences of `_real_XXX()`.  The dmtcp_restart executable has no need for wrapper functions, and can now just call `XXX()` instead of `_real_XXX()`.

As for the second commit, this is a one-line change in ckptserializer.cpp:
```
-    sigsuspend(&suspend_sigset);
+    _real_sigsuspend(&suspend_sigset);
```
Our `sigsuspend()` wrapper ensured that SIGUSR2 was never blocked.  But in this usage, we are waiting for the gzip child process to finish during a checkpoint.  So, we really did want to block SIGUSR2 until the gzip from the previous checkpoint is done.  Using `_real_siguspend()` allows that to happen now.
&nbsp;&nbsp;&nbsp;&nbsp;The reason that this commit is bundled with the earlier one is that this commit becomes possible only once we moved the ckptserializer functions into dmtcp_restart.  Otherwise, there was a linker error in linking dmtcp_restart.o with ckptserializer.o, since neither of those defined _real_sigsuspend().