### PR TITLE
PID: Removed definitions of gettid() and friends.

### DIFF
--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -30,12 +30,6 @@
 # undef __USE_GNU
 #endif
 
-// for NEXT_FNC_DEFAULT();  Needed to handle GNU symbol versioning.
-#include "dlsym_default.h"
-
-// Defines DLSYM_DEFAULT and NEXT_FNC_DEFAULT
-#include "dlsym_default.h"
-
 #ifndef EXTERNC
 # ifdef __cplusplus
 #  define EXTERNC extern "C"
@@ -44,7 +38,6 @@
 # endif
 #endif
 
-#define DELETED_FILE_SUFFIX " (deleted)"
 #define LIB_PRIVATE __attribute__ ((visibility ("hidden")))
 
 typedef enum eDmtcpEvent {

--- a/src/ckptserializer.cpp
+++ b/src/ckptserializer.cpp
@@ -545,7 +545,7 @@ void CkptSerializer::writeCkptImage(void *mtcpHdr, size_t mtcpHdrLen)
   string tempCkptFilename = ckptFilename;
   tempCkptFilename += ".temp";
 
-  JTRACE("Thread performing checkpoint.") (gettid());
+  JTRACE("Thread performing checkpoint.") (dmtcp_gettid());
   createCkptDir();
   forked_ckpt_status = test_and_prepare_for_forked_ckpt();
   if (forked_ckpt_status == FORKED_CKPT_PARENT) {

--- a/src/nosyscallsreal.c
+++ b/src/nosyscallsreal.c
@@ -375,24 +375,14 @@ long _real_syscall(long sys_num, ...) {
                                                arg[5], arg[6]);
 }
 
-LIB_PRIVATE pid_t gettid() {
+LIB_PRIVATE pid_t dmtcp_gettid() {
   return syscall(SYS_gettid);
 }
-LIB_PRIVATE int tkill(int tid, int sig) {
+LIB_PRIVATE int dmtcp_tkill(int tid, int sig) {
   return syscall(SYS_tkill, tid, sig);
 }
-LIB_PRIVATE int tgkill(int tgid, int tid, int sig) {
+LIB_PRIVATE int dmtcp_tgkill(int tgid, int tid, int sig) {
   return syscall(SYS_tgkill, tgid, tid, sig);
-}
-
-// gettid / tkill / tgkill are not defined in libc.
-pid_t _real_gettid(void) {
-  REAL_FUNC_PASSTHROUGH_PID_T (syscall(SYS_gettid));
-}
-
-LIB_PRIVATE
-int   _real_tgkill(int tgid, int tid, int sig) {
-  return (int) _real_syscall(SYS_tgkill, tgid, tid, sig);
 }
 
 int _real_open (const char *pathname, int flags, ...) {

--- a/src/plugin/pid/pid.cpp
+++ b/src/plugin/pid/pid.cpp
@@ -172,7 +172,7 @@ static void pidVirt_ThreadExit(DmtcpEventData_t *data)
    *  FIXME: What if the process gets checkpointed after erase() but before the
    *  thread actually exits?
    */
-  pid_t tid = gettid();
+  pid_t tid = dmtcp_gettid();
   VirtualPidTable::instance().erase(tid);
 }
 

--- a/src/plugin/pid/pid.h
+++ b/src/plugin/pid/pid.h
@@ -1,1 +1,5 @@
 #include "dmtcp.h"
+
+// Defines DLSYM_DEFAULT and NEXT_FNC_DEFAULT
+// Needed to handle GNU symbol versioning.
+#include "dlsym_default.h"

--- a/src/plugin/pid/pid_miscwrappers.cpp
+++ b/src/plugin/pid/pid_miscwrappers.cpp
@@ -327,19 +327,19 @@ extern "C" long syscall(long sys_num, ...)
   switch (sys_num) {
     case SYS_gettid:
     {
-      ret = gettid();
+      ret = dmtcp_gettid();
       break;
     }
     case SYS_tkill:
     {
       SYSCALL_GET_ARGS_2(int, tid, int, sig);
-      ret = tkill(tid, sig);
+      ret = dmtcp_tkill(tid, sig);
       break;
     }
     case SYS_tgkill:
     {
       SYSCALL_GET_ARGS_3(int, tgid, int, tid, int, sig);
-      ret = tgkill(tgid, tid, sig);
+      ret = dmtcp_tgkill(tgid, tid, sig);
       break;
     }
 

--- a/src/plugin/pid/pidwrappers.cpp
+++ b/src/plugin/pid/pidwrappers.cpp
@@ -101,7 +101,7 @@ void dmtcp_update_ppid()
   }
 }
 
-extern "C" pid_t gettid()
+LIB_PRIVATE pid_t dmtcp_gettid()
 {
   /* dmtcp::ThreadList::updateTid calls gettid() before calling
    *  ThreadSync::decrementUninitializedThreadCount() and so the value is
@@ -326,7 +326,7 @@ extern "C" int   kill(pid_t pid, int sig)
 }
 
 LIB_PRIVATE
-int tkill(int tid, int sig)
+int dmtcp_tkill(int tid, int sig)
 {
   // FIXME: Check the comments in kill()
 //  DMTCP_PLUGIN_DISABLE_CKPT();
@@ -341,7 +341,7 @@ int tkill(int tid, int sig)
 }
 
 LIB_PRIVATE
-int tgkill(int tgid, int tid, int sig)
+int dmtcp_tgkill(int tgid, int tid, int sig)
 {
   // FIXME: Check the comments in kill()
 //  DMTCP_PLUGIN_DISABLE_CKPT();

--- a/src/plugin/pid/pidwrappers.h
+++ b/src/plugin/pid/pidwrappers.h
@@ -84,9 +84,9 @@ extern "C"
   LIB_PRIVATE void *_real_dlsym(void *handle, const char *symbol);
 
 /* The following function are defined in pidwrappers.cpp */
-  pid_t gettid();
-  int tkill(int tid, int sig);
-  int tgkill(int tgid, int tid, int sig);
+  LIB_PRIVATE pid_t dmtcp_gettid();
+  LIB_PRIVATE int dmtcp_tkill(int tid, int sig);
+  LIB_PRIVATE int dmtcp_tgkill(int tgid, int tid, int sig);
 
 #define FOREACH_PIDVIRT_WRAPPER(MACRO)\
   MACRO(fork)               \

--- a/src/plugin/pid/virtualpidtable.cpp
+++ b/src/plugin/pid/virtualpidtable.cpp
@@ -125,7 +125,7 @@ pid_t VirtualPidTable::realToVirtual(pid_t realPid)
 
   _do_lock_tbl();
   if (dmtcp_is_ptracing != 0 && dmtcp_is_ptracing() && realPid > 0) {
-    pid_t virtualPid = readVirtualTidFromFileForPtrace(gettid());
+    pid_t virtualPid = readVirtualTidFromFileForPtrace(dmtcp_gettid());
     if (virtualPid != -1) {
       _do_unlock_tbl();
       updateMapping(virtualPid, realPid);

--- a/src/procname.cpp
+++ b/src/procname.cpp
@@ -69,7 +69,7 @@ void prctlGetProcessName()
   int ret = prctl(PR_GET_NAME, name);
   if (ret != -1) {
     lockPrgNameMapLock();
-    prgNameMap[gettid()] = name;
+    prgNameMap[dmtcp_gettid()] = name;
     unlockPrgNameMapLock();
     JTRACE("prctl(PR_GET_NAME, ...) succeeded") (name);
   } else {
@@ -88,7 +88,7 @@ void prctlRestoreProcessName()
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,11)
   // NOTE: We don't need to protect the access to prgNameMap with a lock
   // because all accesses during restart are guaranteed to be read-only.
-  string prgName = prgNameMap[gettid()];
+  string prgName = prgNameMap[dmtcp_gettid()];
   if (!Util::strStartsWith(prgName, DMTCP_PRGNAME_PREFIX)) {
     // Add the "DMTCP:" prefix.
     prgName = DMTCP_PRGNAME_PREFIX + prgName;

--- a/src/syscallsreal.c
+++ b/src/syscallsreal.c
@@ -52,14 +52,15 @@ typedef funcptr_t (*signal_funcptr_t) ();
 
 static pthread_mutex_t theMutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
-LIB_PRIVATE pid_t gettid() {
-  return syscall(SYS_gettid);
+// gettid / tkill / tgkill are not defined in libc.
+LIB_PRIVATE pid_t dmtcp_gettid() {
+  return _real_syscall(SYS_gettid);
 }
-LIB_PRIVATE int tkill(int tid, int sig) {
-  return syscall(SYS_tkill, tid, sig);
+LIB_PRIVATE int dmtcp_tkill(int tid, int sig) {
+  return _real_syscall(SYS_tkill, tid, sig);
 }
-LIB_PRIVATE int tgkill(int tgid, int tid, int sig) {
-  return syscall(SYS_tgkill, tgid, tid, sig);
+LIB_PRIVATE int dmtcp_tgkill(int tgid, int tid, int sig) {
+  return _real_syscall(SYS_tgkill, tgid, tid, sig);
 }
 
 // FIXME: Are these primitives (_dmtcp_lock, _dmtcp_unlock) required anymore?
@@ -796,28 +797,6 @@ LIB_PRIVATE
 int _real_sigtimedwait(const sigset_t *set, siginfo_t *info,
                        const struct timespec *timeout) {
   REAL_FUNC_PASSTHROUGH (sigtimedwait) (set, info, timeout);
-}
-
-// gettid / tkill / tgkill are not defined in libc.
-LIB_PRIVATE
-pid_t _real_gettid(void) {
-  // No glibc wrapper for gettid, although even if it had one, we would have
-  // the issues similar to getpid/getppid().
-  return (pid_t) _real_syscall(SYS_gettid);
-}
-
-LIB_PRIVATE
-int   _real_tkill(int tid, int sig) {
-  // No glibc wrapper for tkill, although even if it had one, we would have
-  // the issues similar to getpid/getppid().
-  return (int) _real_syscall(SYS_tkill, tid, sig);
-}
-
-LIB_PRIVATE
-int   _real_tgkill(int tgid, int tid, int sig) {
-  // No glibc wrapper for tgkill, although even if it had one, we would have
-  // the issues similar to getpid/getppid().
-  return (int) _real_syscall(SYS_tgkill, tgid, tid, sig);
 }
 
 LIB_PRIVATE

--- a/src/syscallwrappers.h
+++ b/src/syscallwrappers.h
@@ -86,10 +86,9 @@ extern "C"
 # define DISABLE_PTHREAD_GETSPECIFIC_TRICK
 #endif
 
-LIB_PRIVATE pid_t gettid();
-LIB_PRIVATE int tkill(int tid, int sig);
-LIB_PRIVATE int tgkill(int tgid, int tid, int sig);
-
+LIB_PRIVATE pid_t dmtcp_gettid();
+LIB_PRIVATE int dmtcp_tkill(int tid, int sig);
+LIB_PRIVATE int dmtcp_tgkill(int tgid, int tid, int sig);
 
 extern int dmtcp_wrappers_initializing;
 
@@ -379,10 +378,6 @@ LIB_PRIVATE extern __thread int thread_performing_dlopen_dlsym;
   int _real_sigwaitinfo(const sigset_t *set, siginfo_t *info);
   int _real_sigtimedwait(const sigset_t *set, siginfo_t *info,
                          const struct timespec *timeout);
-
-  pid_t _real_gettid(void);
-  int   _real_tkill(int tid, int sig);
-  int   _real_tgkill(int tgid, int tid, int sig);
 
   long _real_syscall(long sys_num, ...);
 

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -223,7 +223,7 @@ void ThreadList::updateTid(Thread *th)
   if (curThread == NULL)
     curThread = th;
   th->tid = THREAD_REAL_TID();
-  th->virtual_tid = _real_gettid();
+  th->virtual_tid = dmtcp_gettid();
   JTRACE("starting thread") (th->tid) (th->virtual_tid);
   // Check and remove any thread descriptor which has the same tid as ours.
   // Also, remove any dead threads from the list.

--- a/src/threadsync.cpp
+++ b/src/threadsync.cpp
@@ -251,7 +251,7 @@ void ThreadSync::sendCkptSignalOnFinalUnlock()
   if (_sendCkptSignalOnFinalUnlock && isThisThreadHoldingAnyLocks() == false) {
     _sendCkptSignalOnFinalUnlock = false;
     JASSERT(raise(DmtcpWorker::determineCkptSignal()) == 0)
-      (getpid()) (gettid()) (JASSERT_ERRNO);
+      (getpid()) (dmtcp_gettid()) (JASSERT_ERRNO);
   }
 }
 
@@ -341,9 +341,9 @@ bool ThreadSync::libdlLockLock()
   int saved_errno = errno;
   bool lockAcquired = false;
   if (WorkerState::currentState() == WorkerState::RUNNING &&
-      libdlLockOwner !=  gettid()) {
+      libdlLockOwner !=  dmtcp_gettid()) {
     JASSERT(_real_pthread_mutex_lock(&libdlLock) == 0);
-    libdlLockOwner = gettid();
+    libdlLockOwner = dmtcp_gettid();
     lockAcquired = true;
   }
   errno = saved_errno;
@@ -353,8 +353,8 @@ bool ThreadSync::libdlLockLock()
 void ThreadSync::libdlLockUnlock()
 {
   int saved_errno = errno;
-  JASSERT(libdlLockOwner == 0 || libdlLockOwner == gettid())
-    (libdlLockOwner) (gettid());
+  JASSERT(libdlLockOwner == 0 || libdlLockOwner == dmtcp_gettid())
+    (libdlLockOwner) (dmtcp_gettid());
   JASSERT (WorkerState::currentState() == WorkerState::RUNNING);
   libdlLockOwner = 0;
   JASSERT(_real_pthread_mutex_unlock(&libdlLock) == 0);
@@ -640,7 +640,7 @@ void ThreadSync::processPreResumeCB()
   if (_real_pthread_mutex_lock(&preResumeThreadCountLock) != 0) {
     JASSERT(false) .Text("Failed to acquire preResumeThreadCountLock");
   }
-  JASSERT(preResumeThreadCount > 0) (gettid()) (preResumeThreadCount);
+  JASSERT(preResumeThreadCount > 0) (dmtcp_gettid()) (preResumeThreadCount);
   preResumeThreadCount--;
   if (_real_pthread_mutex_unlock(&preResumeThreadCountLock) != 0) {
     JASSERT(false) .Text("Failed to release preResumeThreadCountLock");

--- a/src/threadwrappers.cpp
+++ b/src/threadwrappers.cpp
@@ -64,7 +64,7 @@ int clone_start(void *arg)
    */
   ThreadSync::decrementUninitializedThreadCount();
 
-  JTRACE("Calling user function") (gettid());
+  JTRACE("Calling user function") (dmtcp_gettid());
   int ret = thread->fn(thread->arg);
 
   ThreadList::threadExit();

--- a/src/util_misc.cpp
+++ b/src/util_misc.cpp
@@ -441,7 +441,7 @@ pid_t Util::getTracerPid(pid_t tid)
   int fd;
 
   if (tid == -1) {
-    tid = gettid();
+    tid = dmtcp_gettid();
   }
   sprintf(buf, "/proc/%d/status", tid);
   fd = _real_open(buf, O_RDONLY, 0);

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -100,6 +100,9 @@ else
 	#$@: required libraries missing, skipping test
 endif
 
+syscall-tester: syscall-tester.c
+	$(CC) -o $@ $< $(CFLAGS) -rdynamic
+
 timer%: timer%.c
 	$(CC) -o $@ $< $(CFLAGS) -lrt
 


### PR DESCRIPTION
These symbols are not exported by libc and so we don't need to export
them either. This also caused segfault if the application binary that
was compiled with '-rdynamic' provided a definition of 'gettid()' (as
reported in #129).

Also added gettid/getpid test to syscall-tester and added -rdynamic
compilation flag along with creating a definition for gettid().

Fixes #129.