### PR TITLE
Better handling of deleted files.

### DIFF
--- a/src/plugin/ipc/file/fileconnection.h
+++ b/src/plugin/ipc/file/fileconnection.h
@@ -156,7 +156,6 @@ namespace dmtcp
     private:
       int  openFile();
       void refreshPath();
-      void handleUnlinkedFile();
       void calculateRelativePath();
       string getSavedFilePath(const string& path);
 

--- a/src/util_misc.cpp
+++ b/src/util_misc.cpp
@@ -386,7 +386,10 @@ int Util::readProcMapsLine(int mapsfd, ProcMapsArea *area)
   c = readDec (mapsfd, (VA *)&inodenum);
   area -> name[0] = '\0';
   while (c == ' ') c = readChar (mapsfd);
-  if (c == '/' || c == '[') { /* absolute pathname, or [stack], [vdso], etc. */
+  if (c == '/' || c == '[' || c == '(') {
+    // absolute pathname, or [stack], [vdso], etc.
+    // On some machines, deleted files have a " (deleted)" prefix to the
+    // filename.
     i = 0;
     do {
       area -> name[i++] = c;


### PR DESCRIPTION
Some systems _prepend_ " (deleted)" instead of doing an _append_. This was observed on travis ci builds (https://travis-ci.org/dmtcp/dmtcp/builds/70006651).