### PR TITLE
Temporary fix for deleted shm file at Stampede.

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -1259,8 +1259,10 @@ static void read_shared_memory_area_from_file(int fd, Area* area, int flags)
    * the second checkpoint, the FILE plugin will treat them as undeleted files.
    * This would cause a problem on the second restart.
    */
+#ifndef STAMPEDE_FIX
   if (deletedFile)
     mtcp_sys_unlink (area->name);
+#endif
 }
 
 /*****************************************************************************


### PR DESCRIPTION
At Stampede, when more than one process on one node share the same deleted shared-memory file, the unlink in mtcp_restart() would cause a race condition. This is just a temporary fix to make it work.