### PR TITLE
PID: Fixed a race when parent exits right after fork.

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -134,7 +134,7 @@ namespace dmtcp
 
     bool isStaticallyLinked(const char *filename);
 
-    void setVirtualPidEnvVar(pid_t pid, pid_t ppid);
+    void setVirtualPidEnvVar(pid_t pid, pid_t virtPpid, pid_t realPpid);
     bool isScreen(const char *filename);
     void setScreenDir();
     string getScreenDir();

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -165,7 +165,8 @@ void CoordinatorAPI::setupVirtualCoordinator(CoordinatorInfo *coordInfo,
   _coordinatorSocket.changeFd(PROTECTED_COORD_FD);
   Util::setCoordPort(_coordinatorSocket.port());
 
-  Util::setVirtualPidEnvVar(INITIAL_VIRTUAL_PID, getppid());
+  pid_t ppid = getppid();
+  Util::setVirtualPidEnvVar(INITIAL_VIRTUAL_PID, ppid, ppid);
 
   UniquePid coordId = UniquePid(INITIAL_VIRTUAL_PID,
                                 UniquePid::ThisProcess().hostid(),
@@ -538,7 +539,9 @@ void CoordinatorAPI::connectToCoordOnStartup(CoordinatorMode mode,
 
   JASSERT(hello_remote.virtualPid != -1);
   JTRACE("Got virtual pid from coordinator") (hello_remote.virtualPid);
-  Util::setVirtualPidEnvVar(hello_remote.virtualPid, getppid());
+
+  pid_t ppid = getppid();
+  Util::setVirtualPidEnvVar(hello_remote.virtualPid, ppid, ppid);
 
   JASSERT(compId != NULL && localIP != NULL && coordInfo != NULL);
   *compId = hello_remote.compGroup.upid();
@@ -568,7 +571,9 @@ void CoordinatorAPI::createNewConnectionBeforeFork(string& progname)
 
   if (dmtcp_virtual_to_real_pid) {
     JTRACE("Got virtual pid from coordinator") (hello_remote.virtualPid);
-    Util::setVirtualPidEnvVar(hello_remote.virtualPid, getpid());
+    pid_t pid = getpid();
+    pid_t realPid = dmtcp_virtual_to_real_pid(pid);
+    Util::setVirtualPidEnvVar(hello_remote.virtualPid, pid, realPid);
   }
 }
 

--- a/src/plugin/pid/pid.cpp
+++ b/src/plugin/pid/pid.cpp
@@ -67,7 +67,9 @@ int dmtcp_real_tgkill(pid_t tgid, pid_t tid, int sig)
 
 static void pidVirt_AtForkParent(DmtcpEventData_t *data)
 {
-  Util::setVirtualPidEnvVar(getpid(), getppid());
+  pid_t virtPpid = getppid();
+  pid_t realPpid = VIRTUAL_TO_REAL_PID(virtPpid);
+  Util::setVirtualPidEnvVar(getpid(), virtPpid, realPpid);
 }
 
 static void pidVirt_ResetOnFork(DmtcpEventData_t *data)
@@ -77,7 +79,10 @@ static void pidVirt_ResetOnFork(DmtcpEventData_t *data)
 
 static void pidVirt_PrepareForExec(DmtcpEventData_t *data)
 {
-  Util::setVirtualPidEnvVar(getpid(), getppid());
+  pid_t virtPpid = getppid();
+  pid_t realPpid = VIRTUAL_TO_REAL_PID(virtPpid);
+  Util::setVirtualPidEnvVar(getpid(), virtPpid, realPpid);
+
   JASSERT(data != NULL);
   jalib::JBinarySerializeWriterRaw wr ("", data->serializerInfo.fd);
   VirtualPidTable::instance().serialize(wr);

--- a/src/util_exec.cpp
+++ b/src/util_exec.cpp
@@ -37,7 +37,7 @@ using namespace dmtcp;
 static int32_t getDlsymOffset();
 static int32_t getDlsymOffset_m32();
 
-void Util::setVirtualPidEnvVar(pid_t pid, pid_t ppid)
+void Util::setVirtualPidEnvVar(pid_t pid, pid_t virtPpid, pid_t realPpid)
 {
   // We want to use setenv() only once. For all later changes, we manipulate
   // the buffer in place. This was done to avoid a bug when using Perl. Perl
@@ -49,7 +49,7 @@ void Util::setVirtualPidEnvVar(pid_t pid, pid_t ppid)
   memset(buf2, '#', sizeof(buf2));
   buf2[sizeof(buf2) - 1] = '\0';
 
-  sprintf(buf1, "%d:%d:", pid, ppid);
+  sprintf(buf1, "%d:%d:%d:", pid, virtPpid, realPpid);
 
   if (getenv(ENV_VAR_VIRTUAL_PID) == NULL) {
     memcpy(buf2, buf1, strlen(buf1));


### PR DESCRIPTION
The parent will set the virtual-pid environment variable with
"<virtual-PID>:<virtual-PPID>". The child then records a mapping between
_real_getpid() and virtual-PID as well as _real_getppid() and
virtual-PPID. However, if the parent dies before _real_getppid() is
called, the latter would return the real-pid of the new parent (init
process). The child process then records a mapping between virtual-PPID
of the original parent and real-pid of "init" process. Later on, the
getppid() wrapper fails to detect the exited parent and keeps returning
the virtual-pid of the original parent. This further prevents
ProcessInfo from marking the process as the root of process tree and
thus we see errors on restart.

The bug has been present for a while but didn't show up on faster
machines. We observed it on travis-ci's containerized setup where the
bug showed up quite frequently after a series of recent commits.