### PR TITLE
valloc: replace memalign with valloc

### DIFF
--- a/src/plugin/alloc/alloc.h
+++ b/src/plugin/alloc/alloc.h
@@ -30,6 +30,7 @@ extern "C" void *__libc_memalign(size_t boundary, size_t size);
 
 #define _real_malloc  NEXT_FNC(malloc)
 #define _real_calloc  NEXT_FNC(calloc)
+#define _real_valloc  NEXT_FNC(valloc)
 #define _real_realloc NEXT_FNC(realloc)
 #define _real_free    NEXT_FNC(free)
 #define _real_memalign NEXT_FNC(memalign)

--- a/src/plugin/alloc/mallocwrappers.cpp
+++ b/src/plugin/alloc/mallocwrappers.cpp
@@ -58,11 +58,10 @@ extern "C" int posix_memalign(void **memptr, size_t alignment, size_t size)
   return retval;
 }
 
-// man valloc: it is equivalent to memalign(sysconf(_SC_PAGESIZE),size).
 extern "C" void *valloc(size_t size)
 {
   DMTCP_PLUGIN_DISABLE_CKPT();
-  void *retval = _real_memalign(sysconf(_SC_PAGESIZE), size);
+  void *retval = _real_valloc(size);
   DMTCP_PLUGIN_ENABLE_CKPT();
   return retval;
 }


### PR DESCRIPTION
This patch replaces the call to _real_memalign() in the
valloc wrapper (in the alloc plugin) with a call to
_real_valloc(). The call to memalign() imposes a runtime
overhead of up to 600 percent.