### PR TITLE
Fix dmtcp_get_generation()

### DIFF
--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -208,6 +208,7 @@ EXTERNC const char* dmtcp_get_computation_id_str(void);
 EXTERNC uint64_t dmtcp_get_coordinator_timestamp(void);
 // Generation is 0 before first checkpoint, and then successively incremented.
 EXTERNC uint32_t dmtcp_get_generation(void) __attribute__((weak));
+EXTERNC int checkpoint_is_pending(void) __attribute__((weak));
 
 /**
  * Gets the coordinator-specific status of DMTCP.

--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -207,7 +207,7 @@ EXTERNC const char* dmtcp_get_uniquepid_str(void) __attribute__((weak));
 EXTERNC const char* dmtcp_get_computation_id_str(void);
 EXTERNC uint64_t dmtcp_get_coordinator_timestamp(void);
 // Generation is 0 before first checkpoint, and then successively incremented.
-EXTERNC uint32_t dmtcp_get_generation(void) __attribute((weak));
+EXTERNC uint32_t dmtcp_get_generation(void) __attribute__((weak));
 
 /**
  * Gets the coordinator-specific status of DMTCP.

--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -99,7 +99,7 @@ typedef struct DmtcpUniqueProcessId {
   uint64_t  _hostid; //gethostid()
   uint64_t _time; //time()
   pid_t _pid; //getpid()
-  uint32_t _generation; //generation()
+  uint32_t _computation_generation; //computationGeneration()
 } DmtcpUniqueProcessId;
 
 EXTERNC int dmtcp_unique_pids_equal(DmtcpUniqueProcessId a,

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -1243,7 +1243,7 @@ bool DmtcpCoordinator::validateNewWorkerProcess(
       // Connection of new computation.
       compId = UniquePid(hello_remote.from.hostid(), client->virtualPid(),
                          hello_remote.from.time(),
-                         hello_remote.from.generation());
+                         hello_remote.from.computationGeneration());
 
       JASSERT(gettimeofday(&tv, NULL) == 0);
       // Get the resolution down to 100 mili seconds.
@@ -1279,7 +1279,7 @@ bool DmtcpCoordinator::startCheckpoint()
     _restartFilenames.clear();
     JNOTE ( "starting checkpoint, suspending all nodes" )( s.numPeers );
     compId.incrementGeneration();
-    JNOTE("Incremented Generation") (compId.generation());
+    JNOTE("Incremented computationGeneration") (compId.computationGeneration());
     // Pass number of connected peers to all clients
     broadcastMessage(DMT_DO_SUSPEND);
 
@@ -1361,7 +1361,7 @@ void DmtcpCoordinator::writeRestartScript()
   o << string(ckptDir) << "/"
     << RESTART_SCRIPT_BASENAME << "_" << compId;
   if (uniqueCkptFilenames) {
-    o << "_" << std::setw(5) << std::setfill('0') << compId.generation();
+    o << "_" << std::setw(5) << std::setfill('0') << compId.computationGeneration();
   }
   o << "." << RESTART_SCRIPT_EXT;
   uniqueFilename = o.str();

--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -322,7 +322,7 @@ EXTERNC uint64_t dmtcp_get_coordinator_timestamp(void)
 
 EXTERNC uint32_t dmtcp_get_generation(void)
 {
-  return SharedData::getCompId()._computation_generation;
+  return ProcessInfo::instance().get_generation();
 }
 
 EXTERNC int dmtcp_is_running_state(void)

--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -312,7 +312,7 @@ EXTERNC int dmtcp_unique_pids_equal(DmtcpUniqueProcessId a,
   return a._hostid == b._hostid &&
          a._pid == b._pid &&
          a._time == b._time &&
-         a._generation == b._generation;
+         a._computation_generation == b._computation_generation;
 }
 
 EXTERNC uint64_t dmtcp_get_coordinator_timestamp(void)
@@ -322,7 +322,7 @@ EXTERNC uint64_t dmtcp_get_coordinator_timestamp(void)
 
 EXTERNC uint32_t dmtcp_get_generation(void)
 {
-  return SharedData::getCompId()._generation;
+  return SharedData::getCompId()._computation_generation;
 }
 
 EXTERNC int dmtcp_is_running_state(void)

--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -325,6 +325,12 @@ EXTERNC uint32_t dmtcp_get_generation(void)
   return ProcessInfo::instance().get_generation();
 }
 
+EXTERNC int checkpoint_is_pending(void)
+{
+  return SharedData::getCompId()._computation_generation >
+           ProcessInfo::instance().get_generation();
+}
+
 EXTERNC int dmtcp_is_running_state(void)
 {
   return WorkerState::currentState() == WorkerState::RUNNING;

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -482,7 +482,7 @@ void DmtcpWorker::waitForCoordinatorMsg(string msgStr,
   // Coordinator sends some computation information along with the SUSPEND
   // message. Extracting that.
   if (type == DMT_DO_SUSPEND) {
-    SharedData::updateGeneration(msg.compGroup.generation());
+    SharedData::updateGeneration(msg.compGroup.computationGeneration());
     JASSERT(SharedData::getCompId() == msg.compGroup.upid())
       (SharedData::getCompId()) (msg.compGroup);
   } else if (type == DMT_DO_FD_LEADER_ELECTION) {

--- a/src/plugin/ipc/connectionidentifier.cpp
+++ b/src/plugin/ipc/connectionidentifier.cpp
@@ -78,7 +78,7 @@ bool ConnectionIdentifier::operator==(const ConnectionIdentifier& that)
   return  _upid._hostid == that._upid._hostid &&
           _upid._pid == that._upid._pid &&
           _upid._time == that._upid._time &&
-          _upid._generation == that._upid._generation &&
+          _upid._computation_generation == that._upid._computation_generation &&
           _id   == that._id;
 }
 

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -112,6 +112,11 @@ ProcessInfo::ProcessInfo()
   _sid = -1;
   _isRootOfProcessTree = false;
   _noCoordinator = false;
+  _generation = 0;
+    // _generation, above, is per-process.
+    // This constrasts with DmtcpUniqueProcessId:_computation_generation, which is
+    //   shared among all process on a node; used in variable sharedDataHeader.
+    // _generation is updated when _this_ process begins its checkpoint.
   _childTable.clear();
   _pthreadJoinId.clear();
   _procSelfExe = jalib::Filesystem::ResolveSymlink("/proc/self/exe");
@@ -542,7 +547,7 @@ void ProcessInfo::serialize(jalib::JBinarySerializer& o)
   _savedBrk = (uint64_t) sbrk(0);
 
   o & _elfType;
-  o & _isRootOfProcessTree & _pid & _sid & _ppid & _gid & _fgid;
+  o & _isRootOfProcessTree & _pid & _sid & _ppid & _gid & _fgid & _generation;
   o & _procname & _hostname & _launchCWD & _ckptCWD & _upid & _uppid;
   o & _compGroup & _numPeers & _noCoordinator & _argvSize & _envSize;
   o & _restoreBufAddr & _savedHeapStart & _savedBrk;

--- a/src/processinfo.h
+++ b/src/processinfo.h
@@ -79,6 +79,8 @@ namespace dmtcp
       void noCoordinator(bool nc) { _noCoordinator = nc; }
       pid_t pid() const { return _pid; }
       pid_t sid() const { return _sid; }
+      uint32_t get_generation() { return _generation; }
+      void set_generation(uint32_t generation) { _generation = generation; }
 
       size_t argvSize() { return _argvSize; }
       void argvSize(int size) { _argvSize = size; }
@@ -129,6 +131,12 @@ namespace dmtcp
 
       uint32_t  _numPeers;
       uint32_t  _noCoordinator;
+      uint32_t  _generation;
+        // _generation, above, is per-process.  This constrasts with
+        //   _computation_generation, which is shared among all processes on a host.
+        // _computation_generation is updated in shareddata.cpp by:
+        //      sharedDataHeader->compId._computation_generation = generation;
+        // _generation is updated later when this process begins its checkpoint.
       uint32_t  _argvSize;
       uint32_t  _envSize;
       uint32_t  _elfType;

--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -267,7 +267,7 @@ uint32_t SharedData::getCkptInterval()
 void SharedData::updateGeneration(uint32_t generation)
 {
   if (sharedDataHeader == NULL) initialize();
-  sharedDataHeader->compId._generation = generation;
+  sharedDataHeader->compId._computation_generation = generation;
 }
 DmtcpUniqueProcessId SharedData::getCompId()
 {

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -364,6 +364,12 @@ static void *checkpointhread (void *dummy)
     /* All other threads halted in 'stopthisthread' routine (they are all
      * in state ST_SUSPENDED).  It's safe to write checkpoint file now.
      */
+
+    // Update generation, in case user callback calls dmtcp_get_generation().
+    uint32_t computation_generation =
+               SharedData::getCompId()._computation_generation;
+    ProcessInfo::instance().set_generation(computation_generation);
+
     JTRACE("before callbackSleepBetweenCheckpoint(0)");
     callbackPreCheckpoint();
 

--- a/src/uniquepid.cpp
+++ b/src/uniquepid.cpp
@@ -81,7 +81,7 @@ static UniquePid& parentProcess()
   return *t;
 }
 
-// _generation field of return value may later have to be modified.
+// _computation_generation field of return value may later have to be modified.
 // So, it can't return a const UniquePid
 UniquePid& UniquePid::ThisProcess(bool disableJTrace /*=false*/)
 {
@@ -113,9 +113,10 @@ UniquePid::UniquePid()
   memset(&_time, 0, sizeof(_time));
 }
 
+// This is called only by the DMTCP coordinator.
 void  UniquePid::incrementGeneration()
 {
-  _generation++;
+  _computation_generation++;
 }
 
 /*!
@@ -155,7 +156,7 @@ bool dmtcp::operator==(const DmtcpUniqueProcessId& a,
   return a._hostid == b._hostid &&
          a._pid == b._pid &&
          a._time == b._time &&
-         a._generation == b._generation;
+         a._computation_generation == b._computation_generation;
 }
 
 bool dmtcp::operator!=(const DmtcpUniqueProcessId& a,

--- a/src/uniquepid.h
+++ b/src/uniquepid.h
@@ -42,26 +42,26 @@ namespace dmtcp
       _hostid = host;
       _pid = pd;
       _time = tm;
-      _generation = gen;
+      _computation_generation = gen;
     }
 
     UniquePid(DmtcpUniqueProcessId id) {
       _hostid = id._hostid;
       _pid = id._pid;
       _time = id._time;
-      _generation = id._generation;
+      _computation_generation = id._computation_generation;
     }
 
     uint64_t hostid() const { return _hostid; }
     pid_t pid() const { return _pid; }
-    int generation() const { return _generation; }
+    int computationGeneration() const { return _computation_generation; }
     uint64_t time() const { return _time; }
     DmtcpUniqueProcessId upid() const {
       DmtcpUniqueProcessId up;
       up._hostid = _hostid;
       up._pid = _pid;
       up._time = _time;
-      up._generation = _generation;
+      up._computation_generation = _computation_generation;
       return up;
     }
 

--- a/test/plugin/applic-delayed-ckpt/applic.c
+++ b/test/plugin/applic-delayed-ckpt/applic.c
@@ -34,8 +34,12 @@ int main() {
     if (retval == DMTCP_NOT_PRESENT) {
       printf("\n *** dmtcp_disable_ckpt: DMTCP_NOT_PRESENT."
              "  Will exit.\n");
-      exit(1);
+      exit(0);
     }
+
+    // This assumes that DMTCP is present.
+    int original_generation = dmtcp_get_generation();
+
     printf("*** dmtcp_disable_ckpt: Checkpoints are blocked.\n");
     printf("      But a checkpoint was requested every two seconds: '-i 2'\n");
     printf("*** sleep: sleeping 3 seconds.\n\n");
@@ -44,7 +48,11 @@ int main() {
            "      and write ./dmtcp_restart_script.sh.\n");
     printf("*** Execute ./dmtcp_restart_script.sh to restart from here.\n");
     dmtcp_enable_ckpt();
-    sleep(2); // Wait long enough for checkpoint to be written.
+
+    // Wait long enough for checkpoint to be written.
+    while (dmtcp_get_generation() == original_generation) {
+      sleep(1);
+    }
 
     printf("\n*** Process done executing.  Successfully exiting.\n");
     return 0;

--- a/test/plugin/applic-initiated-ckpt/applic.c
+++ b/test/plugin/applic-initiated-ckpt/applic.c
@@ -24,13 +24,25 @@
 #include "dmtcp.h"
 
 int main() {
-    if ( ! dmtcp_is_enabled() ) {
+    int dmtcp_enabled = dmtcp_is_enabled();
+    if ( ! dmtcp_enabled ) {
       printf("\n *** dmtcp_is_enabled: executable seems to not be running"
              " under dmtcp_launch.\n\n");
     }
 
+    int original_generation;
+    if ( dmtcp_enabled ) {
+      original_generation = dmtcp_get_generation();
+    }
+
+
     int retval = dmtcp_checkpoint();
     if (retval == DMTCP_AFTER_CHECKPOINT) {
+      // Wait long enough for checkpoint request to be written out.
+      while (dmtcp_get_generation() == original_generation) {
+        sleep(1);
+    }
+
       printf("*** dmtcp_checkpoint: This program has now invoked a checkpoint.\n"
              "      It will resume its execution next.\n");
     } else if (retval == DMTCP_AFTER_RESTART) {


### PR DESCRIPTION
The function `dmtcp_get_generation()` in `include/dmtcp.h`.  Sometimes gives the wrong answer.  This fixes the bug.  In addition, a function `checkpoint_is_pending()` was added in the last of the commits.

I can optionally remove the function `checkpoint_is_pending()`, but the implementation is tiny, and it seems like it might be useful in the future.

The reason for the original bug is that the DMTCP generation (number of checkpoints so far) is maintained by the coordinator for the whole computation.  This is as it should be.  But on each host, the sharedDataHeader keeps one copy of the generation in shared memory for all processes on the same host.  This means that when a checkpoint request from the coordinator arrives at one process, it will update the generation even before the other processes have seen the checkpoint request.  Hence, other processes on that host will report a generation that is one too high (at least until they receive their own checkpoint request from the coordinator).

The bug also exists even for a single user process.  The checkpoint thread receives a checkpoint request and updates the shared memory variable for the generation.  The user thread then sees this and uses it, even before the checkpoint thread has had time to quiesce the process.

The motivation for this was that dmtcp_get_generation() was needed in test/plugin/applic-delayed-ckpt (and applic-initiated-ckpt), to fix a different plugin.  In those examples, the suer process would request a checkpoint, and it would then exit before the checkpoint had actually been invoked.  By using dmtcp_get_generation(), these examples can now test the generation count, and refuse to exit until the generation count has been updated (which happens now, just before the preCkpt event).  The improved code in applic-delayed-ckpt (provided as one of these commits) would still fail on slow computers with the old `dmtcp_get_generation()`.  (In fact, it seems to fail for still a different reason.  `dmtcp_get_generation()` continues to report the generation as 0.  It doesn't see the latest value in shared memory.)  The new version allows the improved code in applic-delayed-ckpt to succeed.

The solution was to rename the DmtcpUniquePid field, `_generation`, to now be `_coord_generation` (which is part of sharedDataHeader in shared memory); and then create a new field, `_generation`, as part of `ProcessInfo`, and that field is now a per-process value for the generation.  It is updated at the time of preCkpt, by coping the value of `_coord_generation` during preCkpt.

I observed the bug on a 32-bit dual-core Pentium 4 machine with 1 GB RAM, running at 3.2 GHz, and running Ubuntu 12.04.  To make the bug reproducible, I did:

    cd test/plugin/applic-delayed-ckpt
    make clean
    make
    make check
The original code of that example (with no call to  `dmtcp_get_generation()`) would exit before the ckpt, and so restart would fail.