### PR TITLE
Enhance test/plugin/*/Makefile; kill old coordinator

### DIFF
--- a/test/plugin/applic-delayed-ckpt/Makefile
+++ b/test/plugin/applic-delayed-ckpt/Makefile
@@ -34,11 +34,16 @@ check: ${LIBNAME}.so applic
 	@ echo ""
 	@ sleep 3
 	@ echo "============ TESTING ./applic WITH DMTCP ================="
+	# Kill any old coordinator on this port, just in case.
+	@ ${DMTCP_ROOT}/bin/dmtcp_command --quit --quiet \
+	  --coord-port ${DEMO_PORT} || true
 	# --interval 2 flag will write checkpoint every two seconds.
 	${DMTCP_ROOT}/bin/dmtcp_launch --quiet --coord-port ${DEMO_PORT} \
 	  --interval 2 --with-plugin $$PWD/${LIBNAME}.so ./applic &
 	@ sleep 7
 	@ echo ""
+	@ echo "DEBUGGING"
+	@ ${DMTCP_ROOT}/bin/dmtcp_command --coord-port ${DEMO_PORT} -s || echo "NO COORDINATOR"
 	@ echo "===== RESTARTING USING ./dmtcp_restart_script.sh ============="
 	./dmtcp_restart_script.sh
 	@ echo ""

--- a/test/plugin/applic-initiated-ckpt/Makefile
+++ b/test/plugin/applic-initiated-ckpt/Makefile
@@ -34,6 +34,9 @@ check: ${LIBNAME}.so applic
 	@ echo ""
 	@ sleep 3
 	@ echo "============ TESTING ./applic WITH DMTCP ================="
+	# Kill any old coordinator on this port, just in case.
+	@ ${DMTCP_ROOT}/bin/dmtcp_command --quit --quiet \
+	  --coord-port ${DEMO_PORT} || true
 	${DMTCP_ROOT}/bin/dmtcp_launch --quiet --coord-port ${DEMO_PORT} \
 	  --with-plugin $$PWD/${LIBNAME}.so ./applic
 	@ echo ""

--- a/test/plugin/example-db/Makefile
+++ b/test/plugin/example-db/Makefile
@@ -27,6 +27,10 @@ default: ${LIBNAME}.so
 ${DMTCP_ROOT}/test/dmtcp1: ${DMTCP_ROOT}/test
 	cd ${DMTCP_ROOT}/test; make dmtcp1
 check: ${LIBNAME}.so ${DMTCP_ROOT}/test/dmtcp1
+	# Kill any old coordinator on this port, just in case.
+	@ ${DMTCP_ROOT}/bin/dmtcp_command --quit --quiet \
+	  --coord-port ${DEMO_PORT} || true
+	# Begin test
 	${DMTCP_ROOT}/bin/dmtcp_coordinator --coord-port ${DEMO_PORT} \
 	  --daemon --exit-on-last -i 5
 	EXAMPLE_DB_KEY=1 EXAMPLE_DB_KEY_OTHER=2 \

--- a/test/plugin/example/Makefile
+++ b/test/plugin/example/Makefile
@@ -26,6 +26,9 @@ default: ${LIBNAME}.so
 ${DMTCP_ROOT}/test/dmtcp1: ${DMTCP_ROOT}/test
 	cd ${DMTCP_ROOT}/test; make dmtcp1
 check: ${LIBNAME}.so ${DMTCP_ROOT}/test/dmtcp1
+	# Kill any old coordinator on this port, just in case.
+	@ ${DMTCP_ROOT}/bin/dmtcp_command --quit --quiet \
+	  --coord-port ${DEMO_PORT} || true
 	# Note that full path of plugin (using $$PWD in this case) is required.
 	${DMTCP_ROOT}/bin/dmtcp_launch --coord-port ${DEMO_PORT} --interval 5 \
 	  --with-plugin $$PWD/${LIBNAME}.so ${DMTCP_ROOT}/test/dmtcp1

--- a/test/plugin/sleep1/Makefile
+++ b/test/plugin/sleep1/Makefile
@@ -26,6 +26,9 @@ default: ${LIBNAME}.so
 ${DMTCP_ROOT}/test/dmtcp1: ${DMTCP_ROOT}/test
 	cd ${DMTCP_ROOT}/test; make dmtcp1
 check: ${LIBNAME}.so ${DMTCP_ROOT}/test/dmtcp1
+	# Kill any old coordinator on this port, just in case.
+	@ ${DMTCP_ROOT}/bin/dmtcp_command --quit --quiet \
+	  --coord-port ${DEMO_PORT} || true
 	${DMTCP_ROOT}/bin/dmtcp_launch --coord-port ${DEMO_PORT} --interval 5 \
 	  --with-plugin $$PWD/${LIBNAME}.so ${DMTCP_ROOT}/test/dmtcp1
 

--- a/test/plugin/sleep2/Makefile
+++ b/test/plugin/sleep2/Makefile
@@ -29,6 +29,9 @@ ${DMTCP_ROOT}/test/dmtcp1: ${DMTCP_ROOT}/test
 ../sleep1/libdmtcp_sleep1.so: ../sleep1
 	cd ../sleep1; make libdmtcp_sleep1.so
 check: ${LIBNAME}.so ../sleep1/libdmtcp_sleep1.so ${DMTCP_ROOT}/test/dmtcp1
+	# Kill any old coordinator on this port, just in case.
+	@ ${DMTCP_ROOT}/bin/dmtcp_command --quit --quiet \
+	  --coord-port ${DEMO_PORT} || true
 	${DMTCP_ROOT}/bin/dmtcp_launch --coord-port ${DEMO_PORT} --interval 5 \
 	  --with-plugin \
 		$$PWD/../sleep1/libdmtcp_sleep1.so:$$PWD/${LIBNAME}.so \


### PR DESCRIPTION
In the test/plugin examples, kill any old coordinator using `${DEMO_PORT}` as first step of `make check`.