### PR TITLE
Polish comments (esp. dmtcp.h)

### DIFF
--- a/src/ckptserializer.cpp
+++ b/src/ckptserializer.cpp
@@ -539,7 +539,6 @@ void CkptSerializer::createCkptDir()
 
 // See comments above for open_ckpt_to_read()
 void CkptSerializer::writeCkptImage(void *mtcpHdr, size_t mtcpHdrLen)
-
 {
   string ckptFilename = ProcessInfo::instance().getCkptFilename();
   string tempCkptFilename = ckptFilename;

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -68,7 +68,7 @@ static const char* theUsage =
   "              If no port is specified, start coordinator at a random port\n"
   "              (same as specifying port '0').\n"
   "  --no-coordinator\n"
-  "              Execute the process in stand-alone coordinator-less mode.\n"
+  "              Execute the process in standalone coordinator-less mode.\n"
   "              Use dmtcp_command or --interval to request checkpoints.\n"
   "  -i, --interval SECONDS (environment variable DMTCP_CHECKPOINT_INTERVAL)\n"
   "              Time in seconds between automatic checkpoints.\n"

--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -149,6 +149,10 @@ EXTERNC int dmtcp_get_local_status(int *nCheckpoints, int *nRestarts)
   return 1;
 }
 
+// DEPRECATED:  This function is deprecated.  It and the userHook functions
+//   and variables of this file are all part of the older dmtcpaware API.
+//   They will be deleted, along with the declaration in include/dmtcp.h,
+//   in some future release.
 EXTERNC int dmtcp_install_hooks(dmtcp_fnptr_t preCheckpoint,
                                 dmtcp_fnptr_t postCheckpoint,
                                 dmtcp_fnptr_t postRestart)

--- a/test/forkexec.c
+++ b/test/forkexec.c
@@ -34,7 +34,6 @@ int main ( int argc, char** argv )
 
     if ( fork() == 0 )  // if child
     {
-printf("child created\n");
       //oops... the user forgot to close an unused socket!!!
       //close(fd[1]);
       dup2 ( fd[0], WELL_KNOWN_FD );

--- a/test/misc/README
+++ b/test/misc/README
@@ -8,6 +8,7 @@ Examples of special cases are:
                                           RedHat/Fedora/CoreOS, OpenSUSE/SUSE
 * 32-bit Linux:  native, --enable-m32, and multi-arch  (see multi-arch.sh)
 * 'make install' for native 64-bit and each of the 32-bit Linux combinations
+* for file in test/plugin/*; do (cd $file && make check); done
 * forked checkpointing
 * fast restart
 * --no-gzip

--- a/test/plugin/applic-delayed-ckpt/README
+++ b/test/plugin/applic-delayed-ckpt/README
@@ -1,11 +1,12 @@
 In this example, 'dmtcp_launch -i 2' was invoked to checkpoint
 every 2 seconds.  This plugin causes the application applic.c to delay
 the checkpoint that is requested by the coordinator In this example,
-the plugin could be omitted.
 
-Note the need to compile with -fPIC the target file that
-uses dmtcpDelayCheckpointsLock().
-This is needed so that the same binary can used both with and without DMTCP.
+The plugin is not needed here.  It's used only to generate printing of events.
+
+Note the need to compile the target application with -fPIC , due to the use
+of dmtcpDelayCheckpointsLock().  The '-fPIC' is needed so that the same binary
+can used both with and without DMTCP.
 
 This example is sufficient for most application, but more advanced
 hooks to DMTCP are also listed in applic.c .

--- a/test/plugin/applic-initiated-ckpt/README
+++ b/test/plugin/applic-initiated-ckpt/README
@@ -1,8 +1,12 @@
 This plugin causes the application applic.c to invoke DMTCP
-to checkpoint itself.  In this example, the plugin could be omitted.
+to checkpoint itself.
 
-Note the need to compile with -fPIC the target file that uses dmtcpCheckpoint().
-This is needed so that the same binary can used both with and without DMTCP.
+The plugin is not needed here.  It's used only to generate printing of events.
+
+Note the need to compile the target application with -fPIC, due to the use
+of dmtcpCheckpoint().  The '-fPIC' is needed so that the same binary
+can used both with and without DMTCP.
+
 
 This example is sufficient for most application, but more advanced
 hooks to DMTCP are also listed in applic.c .

--- a/util/git-bisect.sh
+++ b/util/git-bisect.sh
@@ -2,8 +2,8 @@
 
 # Copy this script to the DMTCP root director.
 # Then modify this script first for your purposes.
-# In particular, look for the two grep strings (test if good, test if bad), and
-#   modify them for your test.
+# In particular, search below for the two strings
+#   ("Test if good", "Test if bad"), and modify them for your test.
 # Then execute something like:
 # git bisect start
 # git bisect bad
@@ -47,7 +47,7 @@ good_match="$good_match_1$good_match_2"
   exit 0
 
 # Test if bad
-# We consider a run "bad" only if it compiled and started autotext.py.
+# Consider a run "bad" only if it compiled and started autotest.py and failed.
 #   Anything else should be skipped as a problem for that single revision.
 grep 'ckpt:' git-bisect.out > /dev/null && exit 1
 


### PR DESCRIPTION
There are two commits.  The first commit should be standard, and not need any significant review.

The second commit changes include/dmtcp.h.  It adds comments, and re-orders some declarations.  But it does not make changes to the code.  The goal is to better document the use of plugins for end users.  Comments and improvements to the dmtcp.h comments are welcome.