### PR TITLE
Delete orphan code in coord (newState not used)

### DIFF
--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -771,17 +771,6 @@ void DmtcpCoordinator::onData(CoordClient *client)
       client->setState ( msg.state );
       ComputationStatus s = getStatus();
       WorkerState newState = s.minimumState;
-      /* It is possible for minimumState to be RUNNING while one or more
-       * processes are still in REFILLED state.
-       */
-      if (s.minimumState == WorkerState::RUNNING && !s.minimumStateUnanimous &&
-          s.maximumState == WorkerState::REFILLED) {
-        /* If minimumState is RUNNING, and not every processes is in RUNNING
-         * state, the maximumState must be REFILLED. This is the case when we
-         * are performing ckpt-resume or rst-resume).
-         */
-        newState = s.maximumState;
-      }
 
       JTRACE ("got DMT_OK message")
         ( msg.from )( msg.state )( oldState )( newState );


### PR DESCRIPTION
This code sets a local variable, `newState`, and it never uses it.  The code seems to have been added to DMTCP in October, 2013 as commit 6aeee7005fad4f4c92c9586ac47bff58bd16f9d5.  But even in that commit, the code does not seem to use the local variable `newState`.

@karya0, you had added this code in 2013.  The log message says something about the intention of the commit, but it doesn't seem to have any effect.  Shall we delete this code as orphan code?