### PR TITLE
Coordinator is CPU hog during checkpointing when using interval timer

### DIFF
--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -1659,7 +1659,7 @@ int DmtcpCoordinator::getRemainingTimeoutMS()
     timeout = startTime.tv_sec + theCheckpointInterval - curTime.tv_sec;
     timeout *= 1000;
     if (timeout < 0) {
-      timeout = 0;
+      timeout = -1;
     }
   }
   return timeout;


### PR DESCRIPTION
`dmtcp_launch -i5 test/dmtcp1` causes the coordinator to do busy waiting during the checkpointing sequence.  This slows down a client on the same host, which is trying to use the CPU to do the checkpoint.  See issue #165 for a detailed analysis of the cause, and why this one-line patch fixes it.