### PR TITLE
Add repeated exec test to autotest

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -791,6 +791,8 @@ runTest("poll",          1, ["./test/poll"])
 
 runTest("forkexec",      2, ["./test/forkexec"])
 
+runTest("exec-repeat",      2, ["./test/exec-repeat"])
+
 # FIXME:  pthread_atfork doesn't compile on some architectures.
 #         If we add a configure test for pthread_atfork, we can
 #           set a Python variable in autotest_config.py.in

--- a/test/exec-repeat.c
+++ b/test/exec-repeat.c
@@ -1,0 +1,22 @@
+// Call as:  THIS_FILE a
+
+#include <unistd.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[3]) {
+  // This should allow this program to be called with no arguments.
+  // But the 'argv[3]' declaration causes DMTCP to fail because
+  //   getenv("DMTCP_HIJACK_LIBS") returns NULL in getUpdatedLdPreload().  Why?
+  char init_arg[2] = "a";
+  if (argc == 1) {
+    argv[1] = init_arg;
+    argv[2] = NULL;
+  } else {
+    sleep(1);
+  }
+
+  printf("argv[1]: %s (will exec now.)\n", argv[1]);
+  if (*argv[1] < 'z') argv[1][0]++;
+  execvp(argv[0], argv);
+  return 0;
+}


### PR DESCRIPTION
This adds the test, exec-repeat, based on the example code in issue #163.  This code uncovered a bug in which the client decides to exec at the same time as the coordinator requests a checkpoint.  That issue also describes a hack-ish fix.  However, it is not being proposed, since @karya0 is planning a better fix for the long term.

As a side note, this test is run as `./test/exec-repeat a`.  If the test were run as `test-repeated-exec`, then DMTCP fails because `getenv("DMTCP_HIJACK_LIBS") == NULL`, even though the executable runs fine without DMTCP.  The issue appears to be that the code declares `main()` with `char *argv[3]`, and under DMTCP, it doesn't like being passed zero args in this case.
