### PR TITLE
Allow more time for shared-memory tests

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -821,8 +821,12 @@ runTest("frisbee",       3, ["./test/frisbee "+p1+" localhost "+p2,
 POST_LAUNCH_SLEEP=DEFAULT_POST_LAUNCH_SLEEP
 os.environ['DMTCP_GZIP'] = "0"
 
+# On an NFS filesystem, a race can manifest late on the second restart,
+# due to a slow coordinator.
+S=10*DEFAULT_S
 runTest("shared-memory1", 2, ["./test/shared-memory1"])
 runTest("shared-memory2", 2, ["./test/shared-memory2"])
+S=DEFAULT_S
 
 runTest("sysv-shm1",     2, ["./test/sysv-shm1"])
 runTest("sysv-shm2",     2, ["./test/sysv-shm2"])


### PR DESCRIPTION
The commit message and associated autotest comment (below) say it all:

    # On an NFS filesystem, a race can manifest late on the second restart,
    # due to a slow coordinator.

The error exposed on second restart is described in https://github.com/dmtcp/dmtcp/issues/167#issuecomment-130439439.

I set `S=10*DEFAULT_S` for this test to expose the bug.

This is needed to expose a pre-existing bug.  Pull request #170 fixed some bugs associated with shared-memory, but we didn't notice this additional bug due to the lack of an appropriate test.
