### PR TITLE
pthread-mutex: allow checkpoints between locks and unlocks

### DIFF
--- a/include/virtualidtable.h
+++ b/include/virtualidtable.h
@@ -107,6 +107,8 @@ namespace dmtcp
           resetNextVirtualId();
         }
 
+        map<IdType, IdType> getMap() const { return _idMapTable; }
+
         bool getNewVirtualId(IdType *id) {
           bool res = false;
           _do_lock_tbl();

--- a/src/plugin/Makefile.am
+++ b/src/plugin/Makefile.am
@@ -129,6 +129,7 @@ __d_libdir__libdmtcp_pid_so_SOURCES =                                  \
 	pid/pidwrappers.cpp                                            \
 	pid/pidwrappers.h                                              \
 	pid/virtualpidtable.cpp                                        \
+	pid/pthread_mutex_wrappers.cpp                                 \
 	pid/virtualpidtable.h
 __d_libdir__libdmtcp_pid_so_LDFLAGS = $(dmtcp_ldflags)
 

--- a/src/plugin/Makefile.in
+++ b/src/plugin/Makefile.in
@@ -170,7 +170,8 @@ __d_libdir__libdmtcp_ipc_so_LINK = $(CXXLD) $(AM_CXXFLAGS) $(CXXFLAGS) \
 am___d_libdir__libdmtcp_pid_so_OBJECTS = pid/pid.$(OBJEXT) \
 	pid/pid_filewrappers.$(OBJEXT) pid/pid_miscwrappers.$(OBJEXT) \
 	pid/pid_syscallsreal.$(OBJEXT) pid/pidwrappers.$(OBJEXT) \
-	pid/virtualpidtable.$(OBJEXT)
+	pid/virtualpidtable.$(OBJEXT) \
+	pid/pthread_mutex_wrappers.$(OBJEXT)
 __d_libdir__libdmtcp_pid_so_OBJECTS =  \
 	$(am___d_libdir__libdmtcp_pid_so_OBJECTS)
 __d_libdir__libdmtcp_pid_so_LDADD = $(LDADD)

--- a/src/plugin/pid/pid.cpp
+++ b/src/plugin/pid/pid.cpp
@@ -196,11 +196,16 @@ extern "C" void dmtcp_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
       pidVirt_PrepareForExec(data);
       break;
 
+    case DMTCP_EVENT_WRITE_CKPT:
+      pruneUnlockedMutexesAtCheckpoint();
+      break;
+
     case DMTCP_EVENT_POST_EXEC:
       pidVirt_PostExec(data);
       break;
 
     case DMTCP_EVENT_RESTART:
+      patchMutexesPostRestart();
       pidVirt_PostRestart(data);
       break;
 

--- a/src/plugin/pid/pidwrappers.h
+++ b/src/plugin/pid/pidwrappers.h
@@ -66,6 +66,10 @@ struct user_desc {int dummy;}; /* <asm/ldt.h> is missing in Ubuntu 14.04 */
 // Keep in sync with dmtcp/src/constants.h
 #define ENV_VAR_VIRTUAL_PID "DMTCP_VIRTUAL_PID"
 
+/* Defined in pthread_mutex_wrappers.cpp */
+extern void patchMutexesPostRestart();
+extern void pruneUnlockedMutexesAtCheckpoint();
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/plugin/pid/pthread_mutex_wrappers.cpp
+++ b/src/plugin/pid/pthread_mutex_wrappers.cpp
@@ -75,7 +75,7 @@ pruneUnlockedMutexesAtCheckpoint()
   dmtcp::map<pthread_mutex_t*, int>::iterator it;
   for (it = mutexMap.begin(); it != mutexMap.end(); it++) {
     pthread_mutex_t* mutex = it->first;
-    if (it->second > 0) {
+    if (it->second > 0 && mutex->__data.__lock) {
       prunedMutexMap[mutex] = it->second;
     }
   }

--- a/src/plugin/pid/pthread_mutex_wrappers.cpp
+++ b/src/plugin/pid/pthread_mutex_wrappers.cpp
@@ -1,0 +1,105 @@
+/* FILE: pthread_mutex_wrappers.cpp
+ * AUTHOR: Rohan Garg
+ * EMAIL: rohgarg@ccs.neu.edu
+ * Copyright (C) 2015 Rohan Garg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <syscall.h>
+#include <sys/types.h>
+#include <vector>
+
+#include "jassert.h"
+#include "virtualpidtable.h"
+#include "pidwrappers.h"
+
+#define __real_pthread_mutex_lock    NEXT_FNC(pthread_mutex_lock)
+#define __real_pthread_mutex_unlock  NEXT_FNC(pthread_mutex_unlock)
+#define __real_syscall               NEXT_FNC(syscall)
+
+/* Globals structs */
+/* This maps mutex addresses to the virtual tid of the owner thread. */
+static dmtcp::map<pthread_mutex_t*, int> mutexMap;
+
+/* This maps addresses of mutexes that were locked at checkpoint time
+ * to the virtual tid of the owner thread.
+ */
+static dmtcp::map<pthread_mutex_t*, int> prunedMutexMap;
+
+/* File local functions  */
+static void
+patch_mutex_owner(pthread_mutex_t *mutex, pid_t newOwner)
+{
+  mutex->__data.__owner = newOwner;
+}
+
+/* Wrapper functions */
+extern "C" int
+pthread_mutex_lock(pthread_mutex_t *mutex)
+{
+  mutexMap[mutex] = dmtcp_gettid();
+  return __real_pthread_mutex_lock(mutex);
+}
+
+extern "C" int
+pthread_mutex_unlock(pthread_mutex_t *mutex)
+{
+  mutexMap[mutex] = 0;
+  return __real_pthread_mutex_unlock(mutex);
+}
+
+/* Global functions */
+/*
+ * This function is called on WRITE_CKPT event to prepare a list
+ * of mutexes that are still locked (at checkpoint time).
+ */
+void
+pruneUnlockedMutexesAtCheckpoint()
+{
+  dmtcp::map<pthread_mutex_t*, int>::iterator it;
+  for (it = mutexMap.begin(); it != mutexMap.end(); it++) {
+    pthread_mutex_t* mutex = it->first;
+    if (it->second > 0) {
+      prunedMutexMap[mutex] = it->second;
+    }
+  }
+}
+
+/*
+ * This function is called on RESTART event to patch the owners
+ * of all mutexes that were not unlocked at checkpoint time.
+ */
+void
+patchMutexesPostRestart()
+{
+  /* It is safe to directly access the PID virtual table here without
+   * any locks because we are called on the RESTART event where
+   * the only active thread is the checkpoint thread.
+   */
+  dmtcp::map<pid_t, pid_t> tidMap = dmtcp::VirtualPidTable::instance().getMap();
+  dmtcp::map<pthread_mutex_t*, int>::iterator it;
+  for (it = prunedMutexMap.begin(); it != prunedMutexMap.end(); it++) {
+    pthread_mutex_t* mutex = it->first;
+    JASSERT (mutex->__data.__lock) ((void*)mutex);
+    if (it->second > 0) {
+      patch_mutex_owner(mutex, tidMap[it->second]);
+    }
+  }
+  prunedMutexMap.clear();
+}


### PR DESCRIPTION
If a checkpoint is taken after a lock is acquired by an application but before
the application had a chance to release it, it can result in a deadlock on
restart. This patch fixes this race condition, and will allow checkpoints
between a lock and an unlock in the future. Detailed explanation follows.

libc caches the tid of the owner of a mutex, which is determined when acquiring
the lock, in its internal structure, and only the owner of the mutex can unlock
it.  As a result, on restart, the call to `pthread_mutex_unlock()` fails with an
EPERM.  If an application fails to check the result of the unlock, trying to
acquire the lock again will cause a deadlock. This patch fixes this problem by:
a) keeping track of the mutexes that were still locked at checkpoint time, and
b) patching the libc's internal mutex struct for all such mutexes.