### PR TITLE
Make --enable-debug work again

### DIFF
--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -4,7 +4,10 @@ OPENMP_CFLAGS=@OPENMP_CFLAGS@
 OPENMP_CXXFLAGS=@OPENMP_CXXFLAGS@
 CC = @CC@
 M32=@M32@
-CFLAGS = @CFLAGS@
+# Unfortunately, there is a name clash for 'DEBUG'.
+# --enable-debug intends to set 'DEBUG' in src, but sets it everywhere.
+# Here in 'test', we use 'DEBUG' for one-off tests.  So, we unset 'DEBUG'.
+CFLAGS = @CFLAGS@ -UDEBUG
 CPPFLAGS = @CPPFLAGS@
 CXX = @CXX@
 CXXFLAGS = @CXXFLAGS@


### PR DESCRIPTION
@karya0 and @rohgarg, There is one issue to note here, in a fix to test/Makefile.in.  The `--enable-debug` flag was intended to set the `DEBUG` macro in the `src` directory.  But since `DEBUG` is also used in the test directory, and maybe elsewhere, we end up turning on `DEBUG` where we don't intend to.

This bug fix adds `-UDEBUG` to `CFLAGS` in `test/Makefile.in`, to turn off any previous `-DDEBUG` flag.

 A different and probably better bug fix would be to create a configure variable, `@DEBUG@`.  We would then write:

    CFLAGS = @DEBUG@ @CFLAGS@
in `src/Makefile.in` and all of its subdirectories.  But in `test/Makefile.in`, we would use only:

    CFLAGS = @DEBUG@ @CFLAGS@
Then, `test/Makefile.in` would set `@DEBUG@` instead of modifying `@CFLAGS@`.  This alternative bug fix actually seems like a better one to me.  But before I do that, I'd like to get a review, and agreement on this solution.  Thanks for reviewing this.