### PR TITLE
Remove stray src/config.h for greater robustness

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -103,7 +103,12 @@ display-config:
 	    grep '\$$ .*configure ' config.log | sed -e 's^\$$^^'; \
 	   fi
 
+# Remove any stray src/config.h files that may still exist.
+# If the developer accidentally leaves an old src/config.h in place (e.g.,
+#   after examining an old revision when this really existed), then some
+#   source code would pull in src/config.h in preference to include/config.h
 dmtcp:
+	rm -f src/config.h
 	cd src && $(MAKE)
 ifeq ($(M32),1)
 	cd lib/dmtcp && ln -s 32/lib/dmtcp/* ./


### PR DESCRIPTION
The diff of the file is short and self-explanatory.  To see what we're trying to protect against, add
a new file src/config.h that includes just one line:

    #error "TESTING.  WE SHOULD NEVER REACH HERE."
and do:  `make clean && make -j`

Such a bug actually happened to me, because I was playing with different revisions of DMTCP, and
ended up with a stray src/config.h that was left over from before the commit of March 24, 2015: 68bf006838740db5ea1bfedeff76cfa1e05c04d7 .  By deleting a stray src/config.h on builds, we avoid such brittleness.