### PR TITLE
Minor polishing suggested by warnings from clang

### DIFF
--- a/src/mtcp/mtcp_check_vdso.ic
+++ b/src/mtcp/mtcp_check_vdso.ic
@@ -94,7 +94,7 @@ static void * get_at_sysinfo(char **environ) {
   stack = (void **)&my_environ[-1];
   if (*stack != NULL) {
     MTCP_PRINTF("This should be argv[argc] == NULL and it's not.\n"
-	"NO &argv[argc], stack: %p\n", stack);
+        "NO &argv[argc], stack: %p\n", stack);
     mtcp_sys_exit(1);
   }
 #endif
@@ -305,19 +305,19 @@ void mtcp_check_vdso(char **environ)
       int i = mtcp_sys_readlink("/proc/self/exe", runtime, PATH_MAX);
       if ( i != -1)
       { char *argv[MAX_ARGS+1];
-	struct rlimit rlim;
+        struct rlimit rlim;
 
-	/* "make" has the capability to raise RLIMIT_STACK to infinity.
-	 * This is a problem.  When the kernel (2.6.24 or later) detects this,
-	 * it falls back to an older "standard" memory layout for libs.
-	 *
-	 * "standard" memory layout puts [vdso] segment in low memory, which
-	 *  MTCP currently doesn't handle properly.
-	 *
-	 * glibc:nptl/sysdeps/<ARCH>/pthreaddef.h defines the default stack for
-	 *  pthread_create to be ARCH_STACK_DEFAULT_SIZE if rlimit is set to be
-	 *  unlimited. We follow the same default.
-	 */
+        /* "make" has the capability to raise RLIMIT_STACK to infinity.
+         * This is a problem.  When the kernel (2.6.24 or later) detects this,
+         * it falls back to an older "standard" memory layout for libs.
+         *
+         * "standard" memory layout puts [vdso] segment in low memory, which
+         *  MTCP currently doesn't handle properly.
+         *
+         * glibc:nptl/sysdeps/<ARCH>/pthreaddef.h defines the default stack for
+         *  pthread_create to be ARCH_STACK_DEFAULT_SIZE if rlimit is set to be
+         *  unlimited. We follow the same default.
+         */
 //#ifdef __x86_64__
 //# define ARCH_STACK_DEFAULT_SIZE (32 * 1024 * 1024)
 //#else
@@ -329,25 +329,25 @@ void mtcp_check_vdso(char **environ)
          *  has to do with VDSO. The location of VDSO section conflicts with the
          *  location of process libraries and hence it is unmapped which causes
          *  failure during the restarting phase. If we set the stack limit to
-         *  256 MB or higher, we donot see this bug.
+         *  256 MB or higher, we do not see this bug.
          * It Should also be noted that the process will call setrlimit to set
          *  the resource limits to their pre-checkpoint values.
          */
 #define ARCH_STACK_DEFAULT_SIZE (256 * 1024 * 1024)
 
         int rlimit_failed = 0;
-	if ( -1 == mtcp_sys_getrlimit(RLIMIT_STACK, &rlim) ||
+        if ( -1 == mtcp_sys_getrlimit(RLIMIT_STACK, &rlim) ||
              ( rlim.rlim_cur = rlim.rlim_max = ARCH_STACK_DEFAULT_SIZE,
-	       rlimit_failed |= mtcp_sys_setrlimit(RLIMIT_STACK, &rlim),
-	       rlimit_failed |= mtcp_sys_getrlimit(RLIMIT_STACK, &rlim),
-	       rlimit_failed || rlim.rlim_max == RLIM_INFINITY )
-	   ) {
+               rlimit_failed |= mtcp_sys_setrlimit(RLIMIT_STACK, &rlim),
+               rlimit_failed |= mtcp_sys_getrlimit(RLIMIT_STACK, &rlim),
+               rlimit_failed || rlim.rlim_max == RLIM_INFINITY )
+           ) {
           MTCP_PRINTF("Failed to reduce RLIMIT_STACK below RLIM_INFINITY\n");
-	  mtcp_sys_exit(1);
-	}
-	write_args(argv, "/proc/self/cmdline");
+          mtcp_sys_exit(1);
+        }
+        write_args(argv, "/proc/self/cmdline");
         runtime[i] = '\0';
-	setenv_oldpers(oldpers, environ);
+        setenv_oldpers(oldpers, environ);
         mtcp_sys_execve(runtime, argv, environ);
       }
       if (-1 == mtcp_sys_personality(oldpers)) /* reset if we couldn't exec */

--- a/src/mtcp/mtcp_check_vdso.ic
+++ b/src/mtcp/mtcp_check_vdso.ic
@@ -335,11 +335,12 @@ void mtcp_check_vdso(char **environ)
          */
 #define ARCH_STACK_DEFAULT_SIZE (256 * 1024 * 1024)
 
+        int rlimit_failed = 0;
 	if ( -1 == mtcp_sys_getrlimit(RLIMIT_STACK, &rlim) ||
              ( rlim.rlim_cur = rlim.rlim_max = ARCH_STACK_DEFAULT_SIZE,
-	       mtcp_sys_setrlimit(RLIMIT_STACK, &rlim),
-	       mtcp_sys_getrlimit(RLIMIT_STACK, &rlim),
-	       rlim.rlim_max == RLIM_INFINITY )
+	       rlimit_failed |= mtcp_sys_setrlimit(RLIMIT_STACK, &rlim),
+	       rlimit_failed |= mtcp_sys_getrlimit(RLIMIT_STACK, &rlim),
+	       rlimit_failed || rlim.rlim_max == RLIM_INFINITY )
 	   ) {
           MTCP_PRINTF("Failed to reduce RLIMIT_STACK below RLIM_INFINITY\n");
 	  mtcp_sys_exit(1);

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -60,6 +60,15 @@
 #include "mtcp_header.h"
 #include "tlsutil.h"
 
+/* The use of NO_OPTIMIZE is deprecated and will be removed, since we
+ * compile mtcp_restart.c with the -O0 flag already.
+ */
+#ifdef __clang__
+# define NO_OPTIMIZE __attribute__((optnone)) /* Supported only in late 2014 */
+#else
+# define NO_OPTIMIZE __attribute__((optimize(0)))
+#endif
+
 void mtcp_check_vdso(char **environ);
 
 #define BINARY_NAME "mtcp_restart"
@@ -155,7 +164,7 @@ void *memcpy(void *dest, const void *src, size_t n) {
 }
 
 #define shift argv++; argc--;
-__attribute__((optimize(0)))
+NO_OPTIMIZE
 int main(int argc, char *argv[], char **environ)
 {
   char *ckptImage = NULL;
@@ -290,7 +299,7 @@ MTCP_PRINTF("Attach for debugging.");
   return 0;  /* Will not reach here, but need to satisfy the compiler */
 }
 
-__attribute__((optimize(0)))
+NO_OPTIMIZE
 static void restore_brk(VA saved_brk, VA restore_begin, VA restore_end)
 {
   int mtcp_sys_errno;
@@ -351,7 +360,7 @@ static void restore_brk(VA saved_brk, VA restore_begin, VA restore_end)
   }
 }
 
-__attribute__((optimize(0)))
+NO_OPTIMIZE
 static void restart_fast_path()
 {
   int mtcp_sys_errno;
@@ -447,7 +456,7 @@ for (; x>0; x--) for (; y>0; y--);
   /* NOTREACHED */
 }
 
-__attribute__((optimize(0)))
+NO_OPTIMIZE
 static void restart_slow_path()
 {
   restorememoryareas(&rinfo);
@@ -505,7 +514,7 @@ static void mtcp_simulateread(int fd, MtcpHeader *mtcpHdr)
   }
 }
 
-__attribute__((optimize(0)))
+NO_OPTIMIZE
 static void restorememoryareas(RestoreInfo *rinfo_ptr)
 {
   int mtcp_sys_errno;
@@ -580,7 +589,7 @@ static void restorememoryareas(RestoreInfo *rinfo_ptr)
   restore_info.post_restart();
 }
 
-__attribute__((optimize(0)))
+NO_OPTIMIZE
 static void unmap_memory_areas_and_restore_vdso(RestoreInfo *rinfo)
 {
   /* Unmap everything except this image, vdso, vvar and vsyscall. */
@@ -780,7 +789,7 @@ static void readmemoryareas(int fd)
 #endif
 }
 
-__attribute__((optimize(0)))
+NO_OPTIMIZE
 static int read_one_memory_area(int fd)
 {
   int mtcp_sys_errno;
@@ -915,7 +924,7 @@ static int read_one_memory_area(int fd)
   return 0;
 }
 
-__attribute__((optimize(0)))
+NO_OPTIMIZE
 static void adjust_for_smaller_file_size(Area *area, int fd)
 {
   int mtcp_sys_errno;
@@ -1002,7 +1011,7 @@ void restore_libc(ThreadTLSInfo *tlsInfo, int tls_pid_offset,
 #endif
 }
 
-__attribute__((optimize(0)))
+NO_OPTIMIZE
 static int doAreasOverlap(VA addr1, size_t size1, VA addr2, size_t size2)
 {
   VA end1 = (char*)addr1 + size1;
@@ -1010,7 +1019,7 @@ static int doAreasOverlap(VA addr1, size_t size1, VA addr2, size_t size2)
   return (addr1 >= addr2 && addr1 < end2) || (addr2 >= addr1 && addr2 < end1);
 }
 
-__attribute__((optimize(0)))
+NO_OPTIMIZE
 static int hasOverlappingMapping(VA addr, size_t size)
 {
   int mtcp_sys_errno;
@@ -1032,7 +1041,7 @@ static int hasOverlappingMapping(VA addr, size_t size)
   return ret;
 }
 
-__attribute__((optimize(0)))
+NO_OPTIMIZE
 static void getTextAddr(VA *text_addr, size_t *size)
 {
   int mtcp_sys_errno;

--- a/src/plugin/ipc/file/fileconnection.h
+++ b/src/plugin/ipc/file/fileconnection.h
@@ -129,7 +129,8 @@ namespace dmtcp
         , _path(path)
         , _fileAlreadyExists(false)
         , _flags(flags)
-        , _mode(mode)
+        /* No method uses _mode yet.  Stop compiler from issuing warning. */
+        /* , _mode(mode) */
       {
          _type = type;
       }
@@ -166,7 +167,8 @@ namespace dmtcp
       int32_t       _fileAlreadyExists;
       int32_t       _rmtype;
       int64_t       _flags;
-      int64_t       _mode;
+      /* No method uses _mode yet.  Stop compiler from issuing warning. */
+      /* int64_t       _mode; */
       int64_t       _offset;
       uint64_t      _st_dev;
       uint64_t      _st_ino;

--- a/src/procselfmaps.cpp
+++ b/src/procselfmaps.cpp
@@ -29,10 +29,10 @@ using namespace dmtcp;
 
 
 ProcSelfMaps::ProcSelfMaps()
-  : fd(-1),
-    dataIdx(0),
+  : dataIdx(0),
     numAreas(0),
-    numBytes(0)
+    numBytes(0),
+    fd(-1)
 {
   char buf[4096];
   fd = _real_open("/proc/self/maps", O_RDONLY);

--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -589,7 +589,7 @@ bool SharedData::getCkptLeaderForFile(dev_t devnum, ino_t inode, void *id)
   if (sharedDataHeader == NULL) initialize();
   JASSERT(id != NULL);
   if (sharedDataHeader->numInodeConnIdMaps > 0) {
-    for (size_t i = sharedDataHeader->numInodeConnIdMaps - 1; i >= 0; i--) {
+    for (int i = sharedDataHeader->numInodeConnIdMaps - 1; i >= 0; i--) {
       InodeConnIdMap& map = sharedDataHeader->inodeConnIdMap[i];
       if (map.devnum == devnum && map.inode== inode) {
         memcpy(id, map.id, sizeof(map.id));


### PR DESCRIPTION
All of these changes were suggested by warnings when compiling
with the clang-3.4 compiler.  Most are self-explanatory.

Here are reasons for two of the more obscure changes:

1. shareddata.cpp :  size_t -> int
    size_t is an unsigned data type.  So, the i>=0 condition is always true.
    This is a bug, since we want to allow i-- to cause i to become negative, and return false in that case.

2. procselfmaps.cpp
    ProcSelfMaps::ProcSelfMaps() initializes the private field members in a certain order.  But in include/procselfmaps.h, those fields were declared in a different order.
    Clang warns about this.  Now the initialization respects the order in which the fields were declared.