### PR TITLE
Fix for bug, under NFS, exposed by shared-memory1

### DIFF
--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -676,7 +676,7 @@ void FileConnection::refill(bool isRestart)
 
   if (!_ckpted_file) {
     int tempfd;
-    if (_type == FILE_DELETED && (_flags & O_WRONLY)) {
+    if (_type == FILE_DELETED && (_flags & (O_WRONLY | O_RDWR))) {
       tempfd = _real_open(_path.c_str(), _fcntlFlags | O_CREAT, 0600);
       JASSERT(tempfd != -1) (_path) (JASSERT_ERRNO) .Text("open() failed");
       JASSERT(truncate(_path.c_str(), _st_size) ==  0)


### PR DESCRIPTION
This bug fix will address the first half of issue #167 (shared-memory1 on NFS machines).  It does *not* address the second half of the issue (from the 16-core test machine).  (The second half of the issue concerns a spurious JWARNING.) 

This is a patch to the logic of commit e03f2727ef8fdde45d79 in pull request #170.

@karya0, could you please ta look at this one-line fix, since it concerns your code?  Thanks.