### PR TITLE
clang-3.4 failed on launch, & on restart; fixed

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -427,10 +427,14 @@ for (; x>0; x--) for (; y>0; y--);
 
 #if defined(__i386__) || defined(__x86_64__)
   asm volatile (CLEAN_FOR_64_BIT(mov %0,%%esp;)
+#ifndef __clang__
                 /* This next assembly language confuses gdb.  Set a future
                    future breakpoint, or attach after this point, if in gdb.
-		   It's here to force a hard error early, in case of a bug.*/
+                   It's here to force a hard error early, in case of a bug.*/
                 CLEAN_FOR_64_BIT(xor %%ebp,%%ebp)
+#else
+                /* Even with -O0, clang-3.4 uses register ebp after this statement. */
+#endif
                 : : "g" (stack_ptr) : "memory");
 #elif defined(__arm__)
   asm volatile ("mov sp,%0\n\t"


### PR DESCRIPTION
This is joint work between Pranay Surana and myself.  There were two bugs, due to weaker support from clang.  This provides workarounds.  It was tested against clang-3.4.

1. dmtcp.h : clang-3.4.1 was converting some static local variables into weak variables when they were inside the function `dmtcp_event_hook()`, which is declared weak.  It appears that clang-3.4.2 fixes this.

2. mtcp_restart.c : This is compiled with -O0.  Apparently, clang uses the ebp/rbp register in the epilog to `estart_fast_path()`, and we were zeroing it out just before returning.