### PR TITLE
Code for early armv8 w/ pthread was failing on new armv8's (now fixed)

### DIFF
--- a/src/syscallsreal.c
+++ b/src/syscallsreal.c
@@ -44,6 +44,9 @@
 #include <ctype.h>
 #include <assert.h>
 #include "syscallwrappers.h"
+#if __aarch64__
+# include "dlsym_default.h"
+#endif
 #include "trampolines.h"
 
 typedef int (*funcptr_t) ();


### PR DESCRIPTION
It was tested on HiKey 96 boards, running 8-core Cortex-A53 SoC.
The early armv8 code fails on this.  But the standard code works.

@rohgarg, this is the patch that we discussed.  Could you review this pull request, and approve it if it agrees with what we proposed?  Thanks.