### PR TITLE
dmtcp_launch --quiet is now truly quiet

### DIFF
--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -436,6 +436,7 @@ void CoordinatorAPI::startNewCoordinator(CoordinatorMode mode)
     char *modeStr = (char *)"--daemon";
     char * args[] = {
       (char*)coordinator.c_str(),
+      (char*)"--quiet",
       (char*)"--exit-on-last",
       modeStr,
       NULL

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -437,6 +437,7 @@ void CoordinatorAPI::startNewCoordinator(CoordinatorMode mode)
     char * args[] = {
       (char*)coordinator.c_str(),
       (char*)"--quiet",
+      /* If we wish to also suppress coordinator warnings, call --quiet twice */
       (char*)"--exit-on-last",
       modeStr,
       NULL

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -64,6 +64,7 @@
 #include "lookup_service.h"
 #include "syscallwrappers.h"
 #include "util.h"
+#include "../jalib/jassert.h"
 #include "../jalib/jconvert.h"
 #include "../jalib/jtimer.h"
 #include "../jalib/jfilesystem.h"
@@ -121,7 +122,7 @@ static const char* theUsage =
   "      Time in seconds between automatic checkpoints\n"
   "      (default: 0, disabled)\n"
   "  -q, --quiet \n"
-  "      Skip startup message.\n"
+  "      Skip startup msg; Skip NOTE msgs; if given twice, also skip WARNINGs\n"
   "  --help:\n"
   "      Print this message and exit.\n"
   "  --version:\n"
@@ -1786,6 +1787,7 @@ int main ( int argc, char** argv )
       return 1;
     }else if(s == "-q" || s == "--quiet"){
       quiet = true;
+      jassert_quiet++;
       shift;
     }else if(s=="--exit-on-last"){
       exitOnLast = true;

--- a/src/util_init.cpp
+++ b/src/util_init.cpp
@@ -220,7 +220,7 @@ void Util::initializeLogFile(string tmpDir, string procname, string prevLogPath)
   if (getenv(ENV_VAR_QUIET)) {
     jassert_quiet = *getenv(ENV_VAR_QUIET) - '0';
   } else {
-    jassert_quiet = 0;
+    // jassert.cpp initializes jassert_quiet to 0
   }
 #ifdef QUIET
   jassert_quiet = 2;


### PR DESCRIPTION
- The problem was that launch called the coordinator, which  was not quiet.
- The first step was to revert most of commit 7bdf16b3, which had
    made the --quiet flag do nothing.
- The second step was to look for 'JASSERT_STDERR <<' in dmtcp_coordinator.cpp
    and wrap it in 'if (! quiet)'.

**QUESTION:**
In coordinatorapi.cpp::439, we always pass on the flat ``--quiet`` if ``dmtcp_launch`` is starting a new coordinator.  We do this because the coordinator will be in the same window as the target process, and we don't want the coordinator output interfering.  We did this even if `dmtcp_launch` was not called with ``--quiet``.  I like this policy, and this PR continues that policy.  Are we agreed on this?