### PR TITLE
Default for epoll_wait ret shouldn't assume ckpt

### DIFF
--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -1698,7 +1698,9 @@ void DmtcpCoordinator::eventLoop(bool daemon)
       continue;
     }
 
-    JASSERT(nfds != -1) (JASSERT_ERRNO);
+    // alarm() is not always the only source of interrupts.
+    // For example, any signal, including signal 0 or SIGWINCH can cause this.
+    JASSERT(nfds != -1 || errno == EINTR) (JASSERT_ERRNO);
 
     for (int n = 0; n < nfds; ++n) {
       void *ptr = events[n].data.ptr;


### PR DESCRIPTION
This is a two-line pull request.  There was a danger of a stray signal (signal 0, SIGWINCH) being interpreted by the DMTCP coordinator as a request to perform a checkpoint.

Could someone check my reasoning here?