### PR TITLE
sysvipcwrappers: Fix {IPC|SEM}_INFO cases for semctl

### DIFF
--- a/src/plugin/svipc/sysvipcwrappers.cpp
+++ b/src/plugin/svipc/sysvipcwrappers.cpp
@@ -222,15 +222,21 @@ int semctl(int semid, int semnum, int cmd, ...)
   va_start (arg, cmd);
   uarg = va_arg (arg, union semun);
   va_end (arg);
+  int ret = -1;
+
+  if (cmd == SEM_INFO || cmd == IPC_INFO) {
+    return _real_semctl(semid, semnum, cmd, uarg);
+  }
 
   DMTCP_PLUGIN_DISABLE_CKPT();
   int realId = VIRTUAL_TO_REAL_SEM_ID(semid);
-  JASSERT(realId != -1);
-  int ret = _real_semctl(realId, semnum, cmd, uarg);
+  JASSERT(realId != -1) (semid) (semnum) (cmd);
+  ret = _real_semctl(realId, semnum, cmd, uarg);
   if (ret != -1) {
     SysVSem::instance().on_semctl(semid, semnum, cmd, uarg);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
+
   return ret;
 }
 /******************************************************************************


### PR DESCRIPTION
An application can call semctl({IPC|SEM}_INFO) directly to
fetch the information about system-wide semaphore limits
and parameters. In this case, the values of the first two
arguments to semctl() -- semid and semnum -- are irrelevant,
and the application can pass invalid or negative values.
Consequently, DMTCP will assert and exit if it tries to get
the real ids for such invalid values.

This patch adds a case for these two commands in the semctl
wrapper to avoid the above mentioned problem.