### PR TITLE
sysvipc-plugin: Fix a bug in on_semget()

### DIFF
--- a/src/plugin/svipc/sysvipc.cpp
+++ b/src/plugin/svipc/sysvipc.cpp
@@ -423,18 +423,18 @@ int SysVShm::shmaddrToShmid(const void* shmaddr)
 /*
  * Semaphore
  */
-void SysVSem::on_semget(int semid, key_t key, int nsems, int semflg)
+void SysVSem::on_semget(int realSemId, key_t key, int nsems, int semflg)
 {
   _do_lock_tbl();
-  if (!_virtIdTable.realIdExists(semid)) {
-    //JASSERT(key == IPC_PRIVATE || (semflg & IPC_CREAT) != 0) (key) (semid);
-    JASSERT(_map.find(semid) == _map.end());
-    JTRACE ("Semid not found in table. Creating new entry") (semid);
+  if (!_virtIdTable.realIdExists(realSemId)) {
+    //JASSERT(key == IPC_PRIVATE || (semflg & IPC_CREAT) != 0) (key) (realSemId);
+    JTRACE ("Semid not found in table. Creating new entry") (realSemId);
     int virtId = getNewVirtualId();
-    updateMapping(virtId, semid);
-    _map[virtId] = new Semaphore (virtId, semid, key, nsems, semflg);
+    JASSERT(_map.find(virtId) == _map.end());
+    updateMapping(virtId, realSemId);
+    _map[virtId] = new Semaphore (virtId, realSemId, key, nsems, semflg);
   } else {
-    JASSERT(_map.find(semid) != _map.end());
+    JASSERT(_map.find(REAL_TO_VIRTUAL_SEM_ID(realSemId)) != _map.end());
   }
   _do_unlock_tbl();
 }

--- a/src/plugin/svipc/sysvipc.h
+++ b/src/plugin/svipc/sysvipc.h
@@ -137,7 +137,7 @@ namespace dmtcp
         : SysVIPC("SysVSem", getpid(), SYSV_SEM_ID) {}
 
       static SysVSem& instance();
-      virtual void on_semget(int semid, key_t key, int nsems, int semflg);
+      virtual void on_semget(int realSemId, key_t key, int nsems, int semflg);
       virtual void on_semctl(int semid, int semnum, int cmd, union semun arg);
       virtual void on_semop(int semid, struct sembuf *sops, unsigned nsops);
   };


### PR DESCRIPTION
The sysvipc class uses a STL map to map virtual semaphore
ids to semaphore objects. The on_semget() method, which is
called on every semget(), was using the the real semaphore
ids as keys to read the values, whereas the STL map maps
virtual sem. ids to semaphore objects.

This fixes issue #205.