### PR TITLE
Fix for bbb0332 (decl. of msgrcv for SLES10 lost)

### DIFF
--- a/src/plugin/pid/pidwrappers.h
+++ b/src/plugin/pid/pidwrappers.h
@@ -51,7 +51,16 @@ struct user_desc {int dummy;}; /* <asm/ldt.h> is missing in Ubuntu 14.04 */
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include <sys/sem.h>
-#include <sys/msg.h>
+// FIXME:   We define _real_msgctl() in terms of msgctl() here.  So,
+//          we need sys/msg.h.  But sys/msg.h also declares msgrcv().
+//          SLES 10 declares msgrcv() one way, and others define it differently.
+//          So, we need this patch.  Do we really need msgctl() defined here?
+//          (pidwrappers.cpp doesn't use msgctl().)
+// msgrcv has confliciting return types on some systems (e.g. SLES 10)
+// So, we temporarily rename it so that type declarations are not for msgrcv.
+#define msgrcv msgrcv_glibc
+# include <sys/msg.h>
+#undef msgrcv
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <sys/epoll.h>

--- a/src/syscallsreal.c
+++ b/src/syscallsreal.c
@@ -25,6 +25,10 @@
 // #define GNU_SRC
 // #define __USE_UNIX98
 
+// FIXME:  See comment in syscallsreal.h about how to remove the need for
+//         this extra declaration.
+#define FOR_SYSCALLSREAL_C
+
 #include <malloc.h>
 #include <pthread.h>
 #include <dlfcn.h>

--- a/src/syscallwrappers.h
+++ b/src/syscallwrappers.h
@@ -22,6 +22,11 @@
 #ifndef SYSCALLWRAPPERS_H
 #define SYSCALLWRAPPERS_H
 
+// FIXME:  Why are we adding all these includes here, if we're declaring
+//         only our own _real_XXX() functions?  Some *wrappers.cpp files
+//         use these includes.  But, then we should split up these includes
+//         among the individual *wrappers.cpp files that actually need them,
+//         and not declare every possible include in one giant .h file.
 #include <features.h>
 #include <pthread.h>
 #include <stdio.h>
@@ -34,7 +39,15 @@
 #include <stdarg.h>
 #include <sys/shm.h>
 #include <sys/sem.h>
-#include <sys/msg.h>
+// FIXME:  The SLES 10 (glibc-2.4) declaration for msgctl differs from
+//         our wrapper's declaration, which uses the POSIX declaration.
+//         If for syscallsreal.c, use the local (e.g., SLES 10) decl.
+//         Otherwise, skip declaration, and use decl. in pidwrappers.h
+//         or in syscallwrappers.h.  The correct solution should be to fix
+//         the way that *wrappers.h get their decl. of msgctl().
+#ifdef FOR_SYSCALLSREAL_C
+# include <sys/msg.h>
+#endif
 #ifdef __cplusplus
 # include <sys/stat.h>
 #else


### PR DESCRIPTION
I added a small change to sysvipcwrappers.cpp.  This is a hack.  But for the 2.4.2 release, this is a minimal change, and we don't want to risk breaking DMTCP.

The story is that in the commit bbb0332, there was no chance to test for SLES10.  This commit
broke SLES10, which was using glibc version 2.4.  The declaration of msgrcv() changed after glibc-2.4.  Our wrapper for msgrcv() has to use either the SLES10 declaration, or the current POSIX declaration.

Prior to commit bbb0332, we had a scheme for doing this (`#define msgrcv msgrcv_glibc` before `#include <sys/msg.h>`, so that `msg.h` doesn't declare msgrcv().  Then our own wrapper can declare msgrcv() the same way for everybody.

This minimal fix brings back the logic prior to commit bbb0332.  After the 2.4.2 release, we can simplify the logic.  Currently, we have two DMTCP .h files that try to include almost everything available in glibc, and our .cpp files then include these "giant" .h file.  This is a bad idea.  The glibc include files should be included only where they are needed, and not almost everywhere.