### PR TITLE
Remove reference to deprecated install-hooks api in python example

### DIFF
--- a/contrib/python/dmtcp.py
+++ b/contrib/python/dmtcp.py
@@ -19,7 +19,6 @@ try:
     checkpoint        = libdmtcp.dmtcp_checkpoint;
     disableCkpt       = libdmtcp.dmtcp_disable_ckpt;
     enableCkpt        = libdmtcp.dmtcp_enable_ckpt;
-    installHooks      = libdmtcp.dmtcp_install_hooks;
 
     getCkptFilename   = libdmtcp.dmtcp_get_ckpt_filename
     getCkptFilename.restype = c_char_p


### PR DESCRIPTION
823d096 removed the dmtcp_install_hooks function entirely, so this
should be gone as well.