### PR TITLE
Clean up test/plugin/*/Makefile: make check

### DIFF
--- a/test/plugin/applic-delayed-ckpt/Makefile
+++ b/test/plugin/applic-delayed-ckpt/Makefile
@@ -36,9 +36,9 @@ check: ${LIBNAME}.so applic
 	@ echo ""
 	@ sleep 3
 	@ echo "============ TESTING ./applic WITH DMTCP ================="
-	# Kill any old coordinator on this port, just in case.
+	# Kill an old coordinator on this port if present, just in case.
 	@ ${DMTCP_ROOT}/bin/dmtcp_command --quit --quiet \
-	  --coord-port ${DEMO_PORT} || true
+	  --coord-port ${DEMO_PORT} 2>/dev/null || true
 	# --interval 2 flag will write checkpoint every two seconds.
 	${DMTCP_ROOT}/bin/dmtcp_launch --quiet --coord-port ${DEMO_PORT} \
 	  --interval 2 --with-plugin $$PWD/${LIBNAME}.so ./applic &

--- a/test/plugin/applic-initiated-ckpt/Makefile
+++ b/test/plugin/applic-initiated-ckpt/Makefile
@@ -36,9 +36,9 @@ check: ${LIBNAME}.so applic
 	@ echo ""
 	@ sleep 3
 	@ echo "============ TESTING ./applic WITH DMTCP ================="
-	# Kill any old coordinator on this port, just in case.
+	# Kill an old coordinator on this port if present, just in case.
 	@ ${DMTCP_ROOT}/bin/dmtcp_command --quit --quiet \
-	  --coord-port ${DEMO_PORT} || true
+	  --coord-port ${DEMO_PORT} 2>/dev/null || true
 	${DMTCP_ROOT}/bin/dmtcp_launch --quiet --coord-port ${DEMO_PORT} \
 	  --with-plugin $$PWD/${LIBNAME}.so ./applic
 	@ echo ""

--- a/test/plugin/example-db/Makefile
+++ b/test/plugin/example-db/Makefile
@@ -27,9 +27,9 @@ default: ${LIBNAME}.so
 ${DMTCP_ROOT}/test/dmtcp1: ${DMTCP_ROOT}/test
 	cd ${DMTCP_ROOT}/test; make dmtcp1
 check: ${LIBNAME}.so ${DMTCP_ROOT}/test/dmtcp1
-	# Kill any old coordinator on this port, just in case.
+	# Kill an old coordinator on this port if present, just in case.
 	@ ${DMTCP_ROOT}/bin/dmtcp_command --quit --quiet \
-	  --coord-port ${DEMO_PORT} || true
+	  --coord-port ${DEMO_PORT} 2>/dev/null || true
 	# Begin test
 	${DMTCP_ROOT}/bin/dmtcp_coordinator --coord-port ${DEMO_PORT} \
 	  --daemon --exit-on-last -i 5

--- a/test/plugin/example/Makefile
+++ b/test/plugin/example/Makefile
@@ -26,9 +26,9 @@ default: ${LIBNAME}.so
 ${DMTCP_ROOT}/test/dmtcp1: ${DMTCP_ROOT}/test
 	cd ${DMTCP_ROOT}/test; make dmtcp1
 check: ${LIBNAME}.so ${DMTCP_ROOT}/test/dmtcp1
-	# Kill any old coordinator on this port, just in case.
+	# Kill an old coordinator on this port if present, just in case.
 	@ ${DMTCP_ROOT}/bin/dmtcp_command --quit --quiet \
-	  --coord-port ${DEMO_PORT} || true
+	  --coord-port ${DEMO_PORT} 2>/dev/null || true
 	# Note that full path of plugin (using $$PWD in this case) is required.
 	${DMTCP_ROOT}/bin/dmtcp_launch --coord-port ${DEMO_PORT} --interval 5 \
 	  --with-plugin $$PWD/${LIBNAME}.so ${DMTCP_ROOT}/test/dmtcp1

--- a/test/plugin/sleep1/Makefile
+++ b/test/plugin/sleep1/Makefile
@@ -26,9 +26,9 @@ default: ${LIBNAME}.so
 ${DMTCP_ROOT}/test/dmtcp1: ${DMTCP_ROOT}/test
 	cd ${DMTCP_ROOT}/test; make dmtcp1
 check: ${LIBNAME}.so ${DMTCP_ROOT}/test/dmtcp1
-	# Kill any old coordinator on this port, just in case.
+	# Kill an old coordinator on this port if present, just in case.
 	@ ${DMTCP_ROOT}/bin/dmtcp_command --quit --quiet \
-	  --coord-port ${DEMO_PORT} || true
+	  --coord-port ${DEMO_PORT} 2>/dev/null || true
 	${DMTCP_ROOT}/bin/dmtcp_launch --coord-port ${DEMO_PORT} --interval 5 \
 	  --with-plugin $$PWD/${LIBNAME}.so ${DMTCP_ROOT}/test/dmtcp1
 

--- a/test/plugin/sleep2/Makefile
+++ b/test/plugin/sleep2/Makefile
@@ -29,9 +29,9 @@ ${DMTCP_ROOT}/test/dmtcp1: ${DMTCP_ROOT}/test
 ../sleep1/libdmtcp_sleep1.so: ../sleep1
 	cd ../sleep1; make libdmtcp_sleep1.so
 check: ${LIBNAME}.so ../sleep1/libdmtcp_sleep1.so ${DMTCP_ROOT}/test/dmtcp1
-	# Kill any old coordinator on this port, just in case.
+	# Kill an old coordinator on this port if present, just in case.
 	@ ${DMTCP_ROOT}/bin/dmtcp_command --quit --quiet \
-	  --coord-port ${DEMO_PORT} || true
+	  --coord-port ${DEMO_PORT} 2>/dev/null || true
 	${DMTCP_ROOT}/bin/dmtcp_launch --coord-port ${DEMO_PORT} --interval 5 \
 	  --with-plugin \
 		$$PWD/../sleep1/libdmtcp_sleep1.so:$$PWD/${LIBNAME}.so \


### PR DESCRIPTION
We kill an old coordinator using dmtcp_command at the beginning of 'make check'.  But a JWARNING message goes to stderr.  This patch redirects:  2>/dev/null

An alternative would be to add a`--quiet` flag to `dmtcp_command`.  But that seems like overkill to me.