### PR TITLE
Fix broken dmtcp_checkpoint() API

### DIFF
--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -500,3 +500,12 @@ EXTERNC int dmtcp_no_coordinator(void)
 {
   return CoordinatorAPI::noCoordinator();
 }
+
+void dmtcp::increment_counters(int isRestart)
+{
+  if (isRestart) {
+    numRestarts++;
+  } else {
+    numCheckpoints++;
+  }
+}

--- a/src/mtcpinterface.cpp
+++ b/src/mtcpinterface.cpp
@@ -89,6 +89,8 @@ void dmtcp::callbackPostCheckpoint(int isRestart,
 
   DmtcpWorker::waitForStage4Resume(isRestart);
 
+  increment_counters(isRestart);
+
   WorkerState::setCurrentState( WorkerState::RUNNING );
 
   DmtcpWorker::informCoordinatorOfRUNNINGState();

--- a/src/mtcpinterface.h
+++ b/src/mtcpinterface.h
@@ -38,5 +38,7 @@ namespace dmtcp
   //these next two are defined in dmtcpplugin.cpp
   void userHookTrampoline_preCkpt();
   void userHookTrampoline_postCkpt(bool isRestart);
+
+  void increment_counters(int isRestart);
 }
 #endif


### PR DESCRIPTION
The broken dmtcp_checkpoint() was reported separately by two DMTCP
users.

The commit 823d096 removed all references and the definition of the
function `dmtcp::userHookTrampoline_postCkpt()`.  The removal of
`userHookTrampoline_postCkpt` also removed calls that incremented the
static global variables `numRestarts` and `numCheckpoints`. Consequently,
the calls to `dmtcp_checkpoint()` would get stuck in a while loop in
`dmtcpplugin.cpp`.

This patch fixes the problem by adding a call to increment the global
counters post checkpoint.

Fixes issue #215.