### PR TITLE
Fix close() wrapper in ipc plugin

### DIFF
--- a/src/plugin/ipc/ipc.cpp
+++ b/src/plugin/ipc/ipc.cpp
@@ -67,7 +67,7 @@ extern "C" int close(int fd)
 
   DMTCP_PLUGIN_DISABLE_CKPT();
   int rv = _real_close(fd);
-  if (rv == 0 && dmtcp_is_running_state()) {
+  if (rv == 0) {
     process_fd_event(SYS_close, fd);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();


### PR DESCRIPTION
@karya0 suggested this commit based on the logic below.  However, note that this commit causes the shared-fd1 and shared-fd2 tests to fail.  @karya0, for the reasons stated below, we need this commit.  Could you fix this commit to handle the shared-fd case?

This removes the test of dmtcp_is_running_state().  Earlier, it would refuse to call process_fd_event() at checkpoint time in a plugin, in case it was opened within a plugin, and the fd was not entered into the connection list.  But the fnc process_fd_event() will do the check later,
and will skip this if fd is not in the connection list.
This caused a bug because the application might open a file, and a plugin might have to close it (at checkpoint time) and re-open it (at resume/restart).  This happened with PMI_Init() and PMI_Finalize().  We finalize before checkpointing and init again (perhaps to a different fd) at resume/restart.  This happens in the batch-queue plugin.