### PR TITLE
threadlist.cpp: Fix compilation error for prctl

### DIFF
--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -7,7 +7,7 @@
 #include <sys/resource.h>
 #include <linux/version.h>
 #include "config.h"
-#ifdef HAS_PR_SET_PTRACER
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,11) || defined(HAS_PR_SET_PTRACER)
 # include <sys/prctl.h>
 #endif
 #include "threadlist.h"


### PR DESCRIPTION
The issue arose due to a recent commit: 0523b46, in which
procname related code (from src/procname.cpp) was moved into the
stopthisthread signal handler (in src/threadlist.cpp), but the
relevant header file: `<sys/prctl.h>` that is required for prctl()
was never moved out of the conditional in threadlist.cpp. This
results in a compilation failure on RHEL-5.8.