### PR TITLE
Change size_t variable from %d to %zu (& %zd->%zu)

### DIFF
--- a/src/restartscript.cpp
+++ b/src/restartscript.cpp
@@ -389,8 +389,8 @@ void writeScript(const string& ckptDir,
                 "which $dmt_rstr_cmd > /dev/null 2>&1 || exit 1\n\n",
                 jalib::Filesystem::GetProgramDir().c_str());
 
-  fprintf ( fp, "# Number of hosts in the computation = %zd\n"
-                "# Number of processes in the computation = %d\n\n",
+  fprintf ( fp, "# Number of hosts in the computation = %zu\n"
+                "# Number of processes in the computation = %zu\n\n",
                 restartFilenames.size(), numPeers );
 
   if ( isSingleHost ) {


### PR DESCRIPTION
size_t variable requires format of %zu.  One occurrence had `%zd` and the other occurrence had `%d`.

Note that while this is part of C99,  But C++ compilers tend to support this, since they need to read C-based include files.