### PR TITLE
This commit adds a new dmtcp API dmtcp_checkpoint_ckptDir which

### DIFF
--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -134,6 +134,12 @@ EXTERNC int dmtcp_checkpoint(VOID) __attribute__ ((weak));
 #define dmtcp_checkpoint() \
   (dmtcp_checkpoint ? dmtcp_checkpoint() : DMTCP_NOT_PRESENT)
 
+EXTERNC int dmtcp_checkpoint_ckptDir(const char* ckptDir)
+  __attribute__ ((weak));
+#define dmtcp_checkpoint_ckptDir(a) \
+  (dmtcp_checkpoint_ckptDir ? dmtcp_checkpoint_ckptDir(a) : DMTCP_NOT_PRESENT)
+
+
 /**
  * Prevent a checkpoint from starting until dmtcp_enable_checkpoint() is
  * called.

--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -134,12 +134,6 @@ EXTERNC int dmtcp_checkpoint(VOID) __attribute__ ((weak));
 #define dmtcp_checkpoint() \
   (dmtcp_checkpoint ? dmtcp_checkpoint() : DMTCP_NOT_PRESENT)
 
-EXTERNC int dmtcp_checkpoint_ckptDir(const char* ckptDir)
-  __attribute__ ((weak));
-#define dmtcp_checkpoint_ckptDir(a) \
-  (dmtcp_checkpoint_ckptDir ? dmtcp_checkpoint_ckptDir(a) : DMTCP_NOT_PRESENT)
-
-
 /**
  * Prevent a checkpoint from starting until dmtcp_enable_checkpoint() is
  * called.
@@ -196,6 +190,16 @@ EXTERNC int dmtcp_should_ckpt_open_files(void);
 
 EXTERNC int dmtcp_get_ckpt_signal(void);
 EXTERNC const char* dmtcp_get_uniquepid_str(void) __attribute__((weak));
+
+/*
+ * This API will set the checkpoint directory globally for all processes.
+ * This means that after this call ckpt files for all associated process 
+ * will get stored in common directory pointed by user.
+ */
+EXTERNC void dmtcp_set_global_ckpt_dir(const char* dir) __attribute__((weak));
+#define dmtcp_set_global_ckpt_dir(d) \
+  (dmtcp_set_global_ckpt_dir ? dmtcp_set_global_ckpt_dir(d) \
+                             : DMTCP_NOT_PRESENT)
 
 /*
  * ComputationID

--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -197,9 +197,7 @@ EXTERNC const char* dmtcp_get_uniquepid_str(void) __attribute__((weak));
  * will get stored in common directory pointed by user.
  */
 EXTERNC void dmtcp_set_global_ckpt_dir(const char* dir) __attribute__((weak));
-#define dmtcp_set_global_ckpt_dir(d) \
-  (dmtcp_set_global_ckpt_dir ? dmtcp_set_global_ckpt_dir(d) \
-                             : DMTCP_NOT_PRESENT)
+EXTERNC const char* dmtcp_get_global_ckpt_dir();
 
 /*
  * ComputationID

--- a/plugin/unique-ckpt/unique-ckpt.cpp
+++ b/plugin/unique-ckpt/unique-ckpt.cpp
@@ -16,7 +16,13 @@ extern "C" int dmtcp_unique_ckpt_enabled(void)
 
 void updateCkptDir()
 {
-  const char *ckptDir = dmtcp_get_ckpt_dir();
+  const char *ckptDir = NULL; 
+  string globalCkptDir = dmtcp_get_global_ckpt_dir();
+  if(globalCkptDir.empty())
+    ckptDir = dmtcp_get_ckpt_dir();
+  else
+    ckptDir = globalCkptDir.c_str();
+
   string baseDir;
   if (strstr(ckptDir, dmtcp_get_computation_id_str()) != NULL) {
     baseDir = jalib::Filesystem::DirName(ckptDir);

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -369,6 +369,49 @@ void CoordinatorAPI::updateCoordCkptDir(const char *dir)
   _coordinatorSocket.writeAll(dir, strlen(dir) + 1);
 }
 
+void CoordinatorAPI::updateCkptDirGlobally(const char *dir)
+{
+  JASSERT(dir != NULL);
+
+  jalib::JSocket _coordinatorSocket1 = createNewSocketToCoordinator(COORD_ANY);
+  if (!_coordinatorSocket1.isValid()) {
+    return;
+  }
+
+  DmtcpMessage msg(DMT_UPDATE_CKPT_DIR_FOR_ALL_PROCESS);
+  msg.extraBytes = strlen(dir) + 1;
+  _coordinatorSocket1 << msg;
+  _coordinatorSocket1.writeAll(dir, strlen(dir) + 1);
+
+  msg.poison();
+  _coordinatorSocket1 >> msg;
+  msg.assertValid();
+  JASSERT(msg.type == DMT_UPDATE_CKPT_DIR_FOR_ALL_PROCESS_RESULT) (msg.type);
+
+  _coordinatorSocket1.close();
+}
+
+string CoordinatorAPI::getGlobalCkptDir(void)
+{
+  // FIXME: Add a test for make-check.
+  char buf[PATH_MAX];
+  if (noCoordinator()) return "";
+  DmtcpMessage msg(DMT_GET_GLOBAL_CKPT_DIR);
+  _coordinatorSocket << msg;
+
+  msg.poison();
+  _coordinatorSocket >> msg;
+  msg.assertValid();
+  JASSERT(msg.type == DMT_GET_GLOBAL_CKPT_DIR_RESULT) (msg.type);
+
+  buf[0] = '\0';
+
+  if(msg.extraBytes > 0) {
+    _coordinatorSocket.readAll(buf, msg.extraBytes);
+  }
+  return buf;
+}
+
 void CoordinatorAPI::sendMsgToCoordinator(const DmtcpMessage &msg,
                                           const void *extraData,
                                           size_t len)

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -369,7 +369,7 @@ void CoordinatorAPI::updateCoordCkptDir(const char *dir)
   _coordinatorSocket.writeAll(dir, strlen(dir) + 1);
 }
 
-void CoordinatorAPI::updateCkptDirGlobally(const char *dir)
+void CoordinatorAPI::setGlobalCkptDir(const char *dir)
 {
   JASSERT(dir != NULL);
 
@@ -391,10 +391,9 @@ void CoordinatorAPI::updateCkptDirGlobally(const char *dir)
   _coordinatorSocket1.close();
 }
 
-string CoordinatorAPI::getGlobalCkptDir(void)
+char* CoordinatorAPI::getGlobalCkptDir(void)
 {
-  // FIXME: Add a test for make-check.
-  char buf[PATH_MAX];
+  static char buf[PATH_MAX];
   if (noCoordinator()) return "";
   DmtcpMessage msg(DMT_GET_GLOBAL_CKPT_DIR);
   _coordinatorSocket << msg;

--- a/src/coordinatorapi.h
+++ b/src/coordinatorapi.h
@@ -91,7 +91,9 @@ namespace dmtcp
                                      int *ckptInterval = NULL);
 
       void updateCoordCkptDir(const char *dir);
+      void updateCkptDirGlobally(const char *dir);
       string getCoordCkptDir(void);
+      string getGlobalCkptDir(void);
 
       void sendCkptFilename();
 

--- a/src/coordinatorapi.h
+++ b/src/coordinatorapi.h
@@ -91,9 +91,10 @@ namespace dmtcp
                                      int *ckptInterval = NULL);
 
       void updateCoordCkptDir(const char *dir);
-      void updateCkptDirGlobally(const char *dir);
       string getCoordCkptDir(void);
-      string getGlobalCkptDir(void);
+
+      void setGlobalCkptDir(const char *dir);
+      char* getGlobalCkptDir(void);
 
       void sendCkptFilename();
 

--- a/src/dmtcpmessagetypes.cpp
+++ b/src/dmtcpmessagetypes.cpp
@@ -155,6 +155,10 @@ ostream& dmtcp::operator << ( dmtcp::ostream& o, const DmtcpMessageType & s )
       OSHIFTPRINTF ( DMT_GET_CKPT_DIR )
       OSHIFTPRINTF ( DMT_GET_CKPT_DIR_RESULT )
       OSHIFTPRINTF ( DMT_UPDATE_CKPT_DIR )
+      OSHIFTPRINTF ( DMT_UPDATE_CKPT_DIR_FOR_ALL_PROCESS )
+      OSHIFTPRINTF ( DMT_UPDATE_CKPT_DIR_FOR_ALL_PROCESS_RESULT )
+      OSHIFTPRINTF ( DMT_GET_GLOBAL_CKPT_DIR )
+      OSHIFTPRINTF ( DMT_GET_GLOBAL_CKPT_DIR_RESULT )
 
       OSHIFTPRINTF ( DMT_USER_CMD )
       OSHIFTPRINTF ( DMT_USER_CMD_RESULT )
@@ -190,6 +194,7 @@ ostream& dmtcp::operator << ( dmtcp::ostream& o, const DmtcpMessageType & s )
       JASSERT ( false ) ( s ) .Text ( "Invalid Message Type" );
       //o << s;
   }
+
   return o;
 }
 

--- a/src/dmtcpmessagetypes.h
+++ b/src/dmtcpmessagetypes.h
@@ -48,6 +48,10 @@ namespace dmtcp
     DMT_GET_CKPT_DIR,
     DMT_GET_CKPT_DIR_RESULT,
     DMT_UPDATE_CKPT_DIR,
+    DMT_UPDATE_CKPT_DIR_FOR_ALL_PROCESS,
+    DMT_UPDATE_CKPT_DIR_FOR_ALL_PROCESS_RESULT,
+    DMT_GET_GLOBAL_CKPT_DIR,
+    DMT_GET_GLOBAL_CKPT_DIR_RESULT,
     DMT_CKPT_FILENAME,       // a slave sending it's checkpoint filename to coordinator
     DMT_UNIQUE_CKPT_FILENAME,// same as DMT_CKPT_FILENAME, except when
                              //   unique-ckpt plugin is being used.

--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -198,6 +198,11 @@ EXTERNC void dmtcp_set_global_ckpt_dir(const char* dir)
   }
 }
 
+EXTERNC const char* dmtcp_get_global_ckpt_dir()
+{
+  return CoordinatorAPI::instance().getGlobalCkptDir();
+}
+
 EXTERNC const char* dmtcp_get_coord_ckpt_dir(void)
 {
   static string dir;

--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -32,6 +32,7 @@
 
 #undef dmtcp_is_enabled
 #undef dmtcp_checkpoint
+#undef dmtcp_checkpoint_ckptDir
 #undef dmtcp_disable_ckpt
 #undef dmtcp_enable_ckpt
 #undef dmtcp_get_coordinator_status
@@ -127,6 +128,15 @@ EXTERNC int dmtcp_checkpoint()
     //	printf("\n\n\nError requesting checkpoint\n\n\n");
   }
 
+  return rv;
+}
+
+EXTERNC int dmtcp_checkpoint_ckptDir(const char* ckptDir)
+{
+  if (ckptDir != NULL) {
+    CoordinatorAPI::instance().updateCkptDirGlobally(ckptDir);
+  }
+  int rv = dmtcp_checkpoint();
   return rv;
 }
 

--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -32,9 +32,9 @@
 
 #undef dmtcp_is_enabled
 #undef dmtcp_checkpoint
-#undef dmtcp_checkpoint_ckptDir
 #undef dmtcp_disable_ckpt
 #undef dmtcp_enable_ckpt
+#undef dmtcp_set_global_ckpt_dir
 #undef dmtcp_get_coordinator_status
 #undef dmtcp_get_local_status
 #undef dmtcp_get_uniquepid_str
@@ -131,15 +131,6 @@ EXTERNC int dmtcp_checkpoint()
   return rv;
 }
 
-EXTERNC int dmtcp_checkpoint_ckptDir(const char* ckptDir)
-{
-  if (ckptDir != NULL) {
-    CoordinatorAPI::instance().updateCkptDirGlobally(ckptDir);
-  }
-  int rv = dmtcp_checkpoint();
-  return rv;
-}
-
 EXTERNC int dmtcp_get_coordinator_status(int *numPeers, int *isRunning)
 {
   int coordCmdStatus;
@@ -197,6 +188,13 @@ EXTERNC void dmtcp_set_ckpt_dir(const char* dir)
 {
   if (dir != NULL) {
     ProcessInfo::instance().setCkptDir(dir);
+  }
+}
+
+EXTERNC void dmtcp_set_global_ckpt_dir(const char* dir)
+{
+  if (dir != NULL) {
+    CoordinatorAPI::instance().setGlobalCkptDir(dir);
   }
 }
 

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -460,13 +460,6 @@ void DmtcpWorker::waitForStage1Suspend()
 
   waitForCoordinatorMsg ("SUSPEND", DMT_DO_SUSPEND);
 
-  string globalCkptDir = CoordinatorAPI::instance().getGlobalCkptDir();
-
-  if(!globalCkptDir.empty()) {
-    JTRACE("Setting global ckpt dir ")(globalCkptDir.c_str());
-    ProcessInfo::instance().setCkptDir(globalCkptDir.c_str());
-  }
-
   JTRACE("got SUSPEND message, preparing to acquire all ThreadSync locks");
   ThreadSync::acquireLocks();
 

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -460,6 +460,13 @@ void DmtcpWorker::waitForStage1Suspend()
 
   waitForCoordinatorMsg ("SUSPEND", DMT_DO_SUSPEND);
 
+  string globalCkptDir = CoordinatorAPI::instance().getGlobalCkptDir();
+
+  if(!globalCkptDir.empty()) {
+    JTRACE("Setting global ckpt dir ")(globalCkptDir.c_str());
+    ProcessInfo::instance().setCkptDir(globalCkptDir.c_str());
+  }
+
   JTRACE("got SUSPEND message, preparing to acquire all ThreadSync locks");
   ThreadSync::acquireLocks();
 


### PR DESCRIPTION
takes checkpoint directory name as argument and stores all checkpoint
files for all processes at common place. This is necessary for
DMTCP Veloce Integration as while checkpointing Veloce Software
also takes HDL checkpoint which is spread across multiple sub-directories.
So in order to consolidate complete database, it is necessary that
all possible database related files get stored at one place. This
is already present in Veloce Specific checkpointing, however missing
in DMTCP application initiated checkpointing.

There is an API to set the checkpoint directory but this API
only sets checkpoint directory for the calling process. Its too
cumbersome to make all process call same API everytime when
new checkpoint activity is initiated. So we need a support which
globally changes the checkpoint directory for all processes.