### PR TITLE
execwrapper.cpp: Fix null pointer dereference when env is NULL

### DIFF
--- a/src/execwrappers.cpp
+++ b/src/execwrappers.cpp
@@ -407,8 +407,10 @@ static string getUpdatedLdPreload(const char* filename,
 static vector<string> copyEnv(char *const envp[])
 {
   vector<string> result;
-  for (size_t i = 0; envp[i] != NULL; i++) {
-    result.push_back(envp[i]);
+  if (envp) {
+    for (size_t i = 0; envp[i] != NULL; i++) {
+      result.push_back(envp[i]);
+    }
   }
   return result;
 }


### PR DESCRIPTION
This patch fixes a bug in the `copyEnv()` code where we
would dereference a NULL pointer if the environment
argument of an `execve()` call was NULL.