### PR TITLE
Improve coordinator logic

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -64,8 +64,12 @@
 #define INITIAL_VIRTUAL_PID         40000
 #define MAX_VIRTUAL_PID             400000000
 
-#define DEFAULT_HOST                "127.0.0.1"
-#define DEFAULT_PORT                7779
+// NEEDED FOR STRINGIFY(DEFAULT_PORT)
+#define QUOTE(arg) #arg
+#define STRINGIFY(arg) QUOTE(arg)
+
+#define DEFAULT_HOST "127.0.0.1"
+#define DEFAULT_PORT 7779
 #define UNINITIALIZED_PORT          -1 /* used with getCoordHostAndPort() */
 
 // Match up this definition with the one in plugin/ptrace/ptracewrappers.cpp

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -483,7 +483,7 @@ CoordinatorAPI::createNewConnToCoord(CoordinatorMode mode)
   if (mode & COORD_JOIN) {
     _coordinatorSocket = createNewSocketToCoordinator(mode);
     JASSERT(isValid()) (JASSERT_ERRNO)
-    .Text("Coordinator not found, but --join was specified. Exiting.");
+     .Text("Coordinator not found, but --join-coordinator specified. Exiting.");
   } else if (mode & COORD_NEW) {
     startNewCoordinator(mode);
     _coordinatorSocket = createNewSocketToCoordinator(mode);

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -435,12 +435,14 @@ CoordinatorAPI::startNewCoordinator(CoordinatorMode mode)
   jalib::JServerSocket coordinatorListenerSocket(jalib::JSockAddr::ANY,
                                                  port, 128);
   JASSERT(coordinatorListenerSocket.isValid())
-    (coordinatorListenerSocket.port()) (JASSERT_ERRNO)
-    .Text("Failed to create listen socket."
-          "If msg is \"Address already in use\", this may be an old"
-          "coordinator."
-          "Kill other coordinators and try again in a minute or so.");
-
+    (coordinatorListenerSocket.port()) (JASSERT_ERRNO) (host) (port)
+    .Text("Failed to create socket to coordinator port."
+          "\nIf msg is \"Address already in use\","
+             " this may be an old coordinator."
+          "\nEither try again a few seconds or a minute later,"
+          "\nOr kill other coordinators on this host and port:"
+          "\n    dmtcp_command ---coord-host XXX --coord-port XXX"
+          "\nOr specify --join-coordinator if joining existing computation.");
   // Now dup the sockfd to
   coordinatorListenerSocket.changeFd(PROTECTED_COORD_FD);
   CoordinatorAPI::setCoordPort(coordinatorListenerSocket.port());
@@ -480,7 +482,7 @@ CoordinatorAPI::createNewConnToCoord(CoordinatorMode mode)
 {
   if (mode & COORD_JOIN) {
     _coordinatorSocket = createNewSocketToCoordinator(mode);
-    JASSERT(_coordinatorSocket != -1) (JASSERT_ERRNO)
+    JASSERT(isValid()) (JASSERT_ERRNO)
     .Text("Coordinator not found, but --join was specified. Exiting.");
   } else if (mode & COORD_NEW) {
     startNewCoordinator(mode);
@@ -540,6 +542,17 @@ CoordinatorAPI::sendRecvHandshake(DmtcpMessage msg,
     JASSERT(false) (*compId)
     .Text("Connection rejected by the coordinator.\n"
           " Reason: This process has a different computation group.");
+  }
+  // Coordinator also prints this, but its stderr may go to /dev/null
+  if (msg.type == DMT_REJECT_NOT_RESTARTING) {
+    string coordinatorHost = ""; // C++ magic code; "" to be invisibly replaced
+    int coordinatorPort;
+    getCoordHostAndPort(COORD_ANY, coordinatorHost, &coordinatorPort);
+    JNOTE ("\n\n*** Computation not in RESTARTING or CHECKPOINTED state."
+        "\n***Can't join the existing coordinator, as it is serving a"
+        "\n***different computation.  Consider launching a new coordinator."
+        "\n***Consider, also, checking with:  dmtcp_command --status")
+        (coordinatorPort);
   }
   JASSERT(msg.type == DMT_ACCEPT)(msg.type);
   return msg;

--- a/src/dmtcp_command.cpp
+++ b/src/dmtcp_command.cpp
@@ -38,7 +38,8 @@ static const char *theUsage =
   "  -h, --coord-host HOSTNAME (environment variable DMTCP_COORD_HOST)\n"
   "              Hostname where dmtcp_coordinator is run (default: localhost)\n"
   "  -p, --coord-port PORT_NUM (environment variable DMTCP_COORD_PORT)\n"
-  "              Port where dmtcp_coordinator is run (default: 7779)\n"
+  "              Port where dmtcp_coordinator is run (default: "
+                                                  STRINGIFY(DEFAULT_PORT) ")\n"
   "  --help\n"
   "              Print this message and exit.\n"
   "  --version\n"
@@ -212,9 +213,7 @@ main(int argc, char **argv)
     return 2;
   }
 
-#define QUOTE(arg)     # arg
-#define STRINGIFY(arg) QUOTE(arg)
-  if (*cmd == 's' || *cmd == 'l') {
+  if(*cmd == 's'){
     printf("Coordinator:\n");
     char *host = getenv(ENV_VAR_NAME_HOST);
     if (host == NULL) {

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -914,9 +914,8 @@ DmtcpCoordinator::validateRestartingWorkerProcess(
     compId = hello_remote.compGroup;
     numPeers = hello_remote.numPeers;
     JASSERT(gettimeofday(&tv, NULL) == 0);
-
-    // Get the resolution down to 100 mili seconds.
-    curTimeStamp = (tv.tv_sec << 4) | (tv.tv_usec / (100 * 1000));
+    // Get the resolution down to 100 milliseconds.
+    curTimeStamp = (tv.tv_sec << 4) | (tv.tv_usec / (100*1000));
     JNOTE("FIRST dmtcp_restart connection.  Set numPeers. Generate timestamp")
       (numPeers) (curTimeStamp) (compId);
     JTIMER_START(restart);

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -104,7 +104,7 @@ static const char *theUsage =
   "Coordinates checkpoints between multiple processes.\n\n"
   "Options:\n"
   "  -p, --coord-port PORT_NUM (environment variable DMTCP_COORD_PORT)\n"
-  "      Port to listen on (default: 7779)\n"
+  "      Port to listen on (default: " STRINGIFY(DEFAULT_PORT) ")\n"
   "  --port-file filename\n"
   "      File to write listener port number.\n"
   "      (Useful with '--port 0', which is used to assign a random port)\n"

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -56,7 +56,8 @@ static const char *theUsage =
   "  -h, --coord-host HOSTNAME (environment variable DMTCP_COORD_HOST)\n"
   "              Hostname where dmtcp_coordinator is run (default: localhost)\n"
   "  -p, --coord-port PORT_NUM (environment variable DMTCP_COORD_PORT)\n"
-  "              Port where dmtcp_coordinator is run (default: 7779)\n"
+  "              Port where dmtcp_coordinator is run (default: "
+                                                  STRINGIFY(DEFAULT_PORT) ")\n"
   "  --port-file FILENAME\n"
   "              File to write listener port number.  (Useful with\n"
   "              '--coord-port 0', which is used to assign a random port)\n"
@@ -395,11 +396,12 @@ processArgs(int *orig_argc,
        getenv(ENV_VAR_NAME_PORT)[0]== '\0') &&
       allowedModes != COORD_NEW) {
     allowedModes = COORD_NEW;
-    // Use static; some compilers will save "7779" on local stack otherwise.
-    static const char *default_port = "7779";
+    // Use static; some compilers save string const on local stack otherwise.
+    static const char *default_port = STRINGIFY(DEFAULT_PORT);
     setenv(ENV_VAR_NAME_PORT, default_port, 1);
     JTRACE("No port specified\n"
-           "Setting mode to --new-coordinator --coord-port 7779");
+           "Setting mode to --new-coordinator --coord-port "
+           STRINGIFY(DEFAULT_PORT));
   }
   *tmpDir_p = Util::calcTmpDir(tmpdir_arg);
   *orig_argc = argc;

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -66,7 +66,8 @@ static const char *theUsage =
   "  -h, --coord-host HOSTNAME (environment variable DMTCP_COORD_HOST)\n"
   "              Hostname where dmtcp_coordinator is run (default: localhost)\n"
   "  -p, --coord-port PORT_NUM (environment variable DMTCP_COORD_PORT)\n"
-  "              Port where dmtcp_coordinator is run (default: 7779)\n"
+  "              Port where dmtcp_coordinator is run (default: "
+                                                  STRINGIFY(DEFAULT_PORT) ")\n"
   "  --port-file FILENAME\n"
   "              File to write listener port number.\n"
   "              (Useful with '--port 0', in order to assign a random port)\n"
@@ -809,9 +810,10 @@ main(int argc, char **argv)
        getenv(ENV_VAR_NAME_PORT)[0]== '\0') &&
       allowedModes != COORD_NEW) {
     allowedModes = COORD_NEW;
-    setenv(ENV_VAR_NAME_PORT, "7779", 1);
+    setenv(ENV_VAR_NAME_PORT, STRINGIFY(DEFAULT_PORT), 1);
     JTRACE("No port specified\n"
-           "Setting mode to --new-coordinator --coord-port 7779");
+           "Setting mode to --new-coordinator --coord-port "
+                                                  STRINGIFY(DEFAULT_PORT));
   }
 
   tmpDir = Util::calcTmpDir(tmpdir_arg);

--- a/src/restartscript.cpp
+++ b/src/restartscript.cpp
@@ -257,7 +257,7 @@ static const char *multiHostProcessing =
 
   "maybejoin=\n"
   "if [ \"$num_worker_hosts\" != \"1\" ]; then\n"
-  "  maybejoin='--join'\n"
+  "  maybejoin='--join-coordinator'\n"
   "fi\n\n"
 
   "for worker_host in $worker_hosts\n"
@@ -308,8 +308,9 @@ static const char *multiHostProcessing =
   "  if [ -z $maybebg ]; then\n"
   "    $maybexterm /usr/bin/ssh -t \"$worker_host\" \\\n"
   "      $dmt_rstr_cmd --coord-host \"$coord_host\""
-  " --cord-port \"$coord_port\" \"$coord_logfile\"\\\n"
-  "      $ckpt_dir --join --interval \"$checkpoint_interval\" $tmpdir \\\n"
+                                             " --cord-port \"$coord_port\"\\\n"
+  "      $ckpt_dir --join-coordinator --interval \"$checkpoint_interval\""
+                                             " $tmpdir \\\n"
   "      $new_ckpt_files_group\n"
   "  else\n"
   "    $maybexterm /usr/bin/ssh \"$worker_host\" \\\n"
@@ -317,8 +318,9 @@ static const char *multiHostProcessing =
   // In Open MPI 1.4, without this (sh -c ...), orterun hangs at the
   // end of the computation until user presses enter key.
   "      \"/bin/sh -c \'$dmt_rstr_cmd --coord-host $coord_host"
-  " --coord-port $coord_port $coord_logfile\\\n"
-  "      $ckpt_dir --join --interval \"$checkpoint_interval\" $tmpdir \\\n"
+                                                " --coord-port $coord_port\\\n"
+  "      $ckpt_dir --join-coordinator --interval \"$checkpoint_interval\""
+                                                " $tmpdir \\\n"
   "      $new_ckpt_files_group\'\" &\n"
   "  fi\n\n"
   "done\n\n"
@@ -486,8 +488,8 @@ writeScript(const string &ckptDir,
             "        . $DMTCP_SRUN_HELPER_SYNCFILE\n"
             "        pass_slurm_helper_contact \"$DMTCP_LAUNCH_CKPTS\"\n"
             "        rm $DMTCP_SRUN_HELPER_SYNCFILE\n"
-            "        dmtcp_restart --join --coord-host $DMTCP_COORD_HOST"
-            " --coord-port $DMTCP_COORD_PORT"
+            "        dmtcp_restart --join-coordinator"
+            " --coord-host $DMTCP_COORD_HOST --coord-port $DMTCP_COORD_PORT"
             " $DMTCP_LAUNCH_CKPTS\n"
             "      else\n"
             "        DMTCP_REMLAUNCH_0_0=\"$DMTCP_REMLAUNCH_0_0"


### PR DESCRIPTION
There are three commits.  It will be easier to review by reading one at a time:
1.  Warn on restart if coord already running prev comp
2.  If --coord-port unspecified, use --new-coordinator 
   - Prev., if no coord mode specified, `--any-coordinator` was the default.
     This could cause `--join-coordinator` to be invoked.
     This caused unexpected behavior when the user was unaware of a curr. coord.
   - Changing -`-join` to `--join-coordinator`, but still recognizing `--join` for now.
3.  Use macro:  7779 -> `STRINGIFY(DEFAULT_PORT)`
