### PR TITLE
Fix for 809b4fd1; eliminates warning for 'struct msqid_ds'

### DIFF
--- a/src/nosyscallsreal.c
+++ b/src/nosyscallsreal.c
@@ -26,6 +26,10 @@
 // #define GNU_SRC
 // #define __USE_UNIX98
 
+// FIXME:  See comment in syscallwrappers.h about how to remove the need for
+//         this extra declaration.
+#define FOR_SYSCALLSREAL_C
+
 #include <pthread.h>
 // We should not need dlopen/dlsym
 // #include <dlfcn.h>


### PR DESCRIPTION
Modifies `nosyscallsreal.c`.  This eliminates the following warning message:
```
In file included from nosyscallsreal.c:46:0:
syscallwrappers.h:476:47: warning: ‘struct msqid_ds’ declared inside parameter list
   int _real_msgctl(int msqid, int cmd, struct msqid_ds *buf);
```