### PR TITLE
Improved error message/--help for --no-coordinator

### DIFF
--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -406,7 +406,7 @@ void CoordinatorAPI::sendMsgToCoordinator(const DmtcpMessage &msg,
 
 void CoordinatorAPI::recvMsgFromCoordinator(DmtcpMessage *msg, void **extraData)
 {
-  JASSERT(!noCoordinator());
+  JASSERT(!noCoordinator()).Text("internal error");
   if (sem_launch_first_time) {
     // Release user thread now that we've initialized the checkpoint thread.
     // This code is reached if the --no-coordinator flag is not used.
@@ -589,7 +589,10 @@ void CoordinatorAPI::connectToCoordOnStartup(CoordinatorMode mode,
 
 void CoordinatorAPI::createNewConnectionBeforeFork(string& progname)
 {
-  JASSERT(!noCoordinator());
+  JASSERT(!noCoordinator())
+    .Text("Process attempted to call fork() while in --no-coordinator mode\n"
+          "  Because the coordinator is embedded in a single process,\n"
+          "    DMTCP will not work with multiple processes.");
   struct sockaddr_storage addr;
   uint32_t len;
   SharedData::getCoordAddr((struct sockaddr *)&addr, &len);

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -70,6 +70,8 @@ static const char* theUsage =
   "  --no-coordinator\n"
   "              Execute the process in standalone coordinator-less mode.\n"
   "              Use dmtcp_command or --interval to request checkpoints.\n"
+  "              Note that this is incompatible with calls to fork(), since\n"
+  "              an embedded coordinator runs in the original process only.\n"
   "  -i, --interval SECONDS (environment variable DMTCP_CHECKPOINT_INTERVAL)\n"
   "              Time in seconds between automatic checkpoints.\n"
   "              0 implies never (manual ckpt only); if not set and no env var,\n"


### PR DESCRIPTION
`dmtcp_launch --no-coordinator` should fail when target application calls fork(), since the coordinator is embedded in a single process.  But our error message did not make it clear why this happens.  This improves the JASSERT message and also the documentation for `dmtcp_launch -h`.

This issue is discussed as issue #245.