### PR TITLE
Fix race in: dmtcp_launch --no-coordinator tcsh

### DIFF
--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -62,7 +62,8 @@ static Thread *ckptThread = NULL;
 static int numUserThreads = 0;
 static int originalstartup;
 
-static sem_t sem_start;
+extern bool sem_launch_first_time;
+extern sem_t sem_launch; // allocated in coordinatorapi.cpp
 static sem_t semNotifyCkptThread;
 static sem_t semWaitForCkptThreadSignal;
 
@@ -160,7 +161,7 @@ void ThreadList::init()
   motherofall_tlsInfo = &motherofall->tlsInfo;
   updateTid(motherofall);
 
-  sem_init(&sem_start, 0, 0);
+  sem_init(&sem_launch, 0, 0);
   sem_init(&semNotifyCkptThread, 0, 0);
   sem_init(&semWaitForCkptThreadSignal, 0, 0);
 
@@ -175,9 +176,9 @@ void ThreadList::init()
    * don't run the checkpoint thread and user thread at the same time.
    */
   errno = 0;
-  while (-1 == sem_wait(&sem_start) && errno == EINTR)
+  while (-1 == sem_wait(&sem_launch) && errno == EINTR)
     errno = 0;
-  sem_destroy(&sem_start);
+  sem_destroy(&sem_launch);
 }
 
 /*****************************************************************************
@@ -296,6 +297,11 @@ static void *checkpointhread (void *dummy)
 
   ckptThread = curThread;
   ckptThread->state = ST_CKPNTHREAD;
+  // Important:  we set this in the ckpt thread to avoid a race,
+  //     since: (i) the ckpt thread must read this; and (ii) if we had
+  //     set it earlier, it could be invoked and modified earlier
+  //     inside a generic command like CoordinatorAPI::recvMsgFromCoordi).
+  sem_launch_first_time = true;
 
   /* For checkpoint thread, we want to block delivery of all but some special
    * signals
@@ -324,8 +330,6 @@ static void *checkpointhread (void *dummy)
 
   Thread_SaveSigState(ckptThread);
   TLSInfo_SaveTLSState(&ckptThread->tlsInfo);
-  /* Release user thread after we've initialized. */
-  sem_post(&sem_start);
 
   /* Set up our restart point.  I.e., we get jumped to here after a restore. */
 #ifdef SETJMP


### PR DESCRIPTION
More generally, sem_launch (formerly sem_start) was being posted too early,
while the checkpoint thread was still active

See github issue #247 for further background on this PR.