### PR TITLE
Build dlopen2 test correctly

### DIFF
--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -194,19 +194,20 @@ posix-mq%: posix-mq%.c
 inotify%: inotify%.c
 	-$(CC) -o $@ $< $(CFLAGS) -lpthread
 
-# dlopen will dlopen/dlclose libdlopen-lib[12].so
+# dlopen1 will dlopen/dlclose libdlopen-lib[12].so
 libdlopen-lib1.so: dlopen1.c
 	${CC} ${CFLAGS} -shared -fPIC  -DLIB1 -o libdlopen-lib1.so $<
 libdlopen-lib2.so: dlopen1.c
 	${CC} ${CFLAGS} -shared -fPIC  -DLIB2 -o libdlopen-lib2.so $<
-dlopen%: dlopen%.c libdlopen-lib1.so libdlopen-lib2.so
+dlopen1: dlopen1.c libdlopen-lib1.so libdlopen-lib2.so
 	${CC} $(CFLAGS) -o $@ $< -ldl
 
+# dlopen2 will dlopen/dlclose libdlopen-lib[34].so
 libdlopen-lib3.so: dlopen2.cpp
 	${CXX} ${CXXFLAGS} -shared -fPIC -DLIB3 -o libdlopen-lib3.so $<
 libdlopen-lib4.so: dlopen2.cpp
 	${CXX} ${CXXFLAGS} -shared -fPIC -DLIB4 -o libdlopen-lib4.so $<
-dlopen%: dlopen%.cpp libdlopen-lib4.so libdlopen-lib4.so
+dlopen2: dlopen2.cpp libdlopen-lib3.so libdlopen-lib4.so
 	${CXX} ${CXXFLAGS} -o $@ $< -ldl
 
 %.class: %.java

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -872,6 +872,7 @@ else:
 runTest("dlopen1",        1, ["./test/dlopen1"])
 # Disable the dlopen2 test until we can figure out a way to handle calls to
 # fork/exec/wait during library intialization with dlopen().
+# This seems to affect Travis CI of github, but not Ubuntu-12.04
 #if not USE_M32:
 #  runTest("dlopen2",        1, ["./test/dlopen2"])
 if old_ld_library_path:
@@ -879,7 +880,7 @@ if old_ld_library_path:
 else:
   del os.environ['LD_LIBRARY_PATH']
 
-runTest("realpath",        1, ["./test/realpath"])
+runTest("realpath",      1, ["./test/realpath"])
 runTest("pthread1",      1, ["./test/pthread1"])
 runTest("pthread2",      1, ["./test/pthread2"])
 S=10*DEFAULT_S

--- a/test/dlopen1.c
+++ b/test/dlopen1.c
@@ -1,5 +1,6 @@
 /* To compile, use -DLIB1 to create libdlopen-lib1.so, -DLIB2 for
- * libdlopen-lib2.so, and define neither to create executable.
+ *   libdlopen-lib2.so, and define neither to create executable.
+ * To run, do:  LD_LIBRARY_PATH=. ./dlopen1
  */
 
 #if !defined(LIB1) && !defined(LIB2)

--- a/test/dlopen2.cpp
+++ b/test/dlopen2.cpp
@@ -1,5 +1,6 @@
-/* To compile, use -DLIB1 to create libdlopen-lib3.so, -DLIB2 for
+/* To compile, use -DLIB3 to create libdlopen-lib3.so, -DLIB4 for
  * libdlopen-lib4.so, and define neither to create executable.
+ * To run, do:  LD_LIBRARY_PATH=. ./dlopen2
  */
 
 # include <dlfcn.h>


### PR DESCRIPTION
Fixes test/Makefile.in (It wasn't building libdlopen-lib3.so due to a typo).
It also polishes the dlopen1/dlopen2 tests.