### PR TITLE
IB: Fix the memory leak when freeing device list.

### DIFF
--- a/contrib/infiniband/ibv_internal.h
+++ b/contrib/infiniband/ibv_internal.h
@@ -12,6 +12,14 @@ struct dev_list_info {
   struct ibv_device ** real_dev_list;
 };
 
+/*
+ * On restart, the real resouces inside the internal structures below
+ * are recreated. However, the old real resources are not released,
+ * thus leading to a memory leak. Currenly we do not handle this memory
+ * leak, because the memory leak is tiny, and destroying those resources
+ * at checkpoint time will affect the performance.
+ */
+
 //! A wrapper around a device
 struct internal_ibv_dev {
   struct ibv_device user_dev;

--- a/contrib/infiniband/ibv_internal.h
+++ b/contrib/infiniband/ibv_internal.h
@@ -1,19 +1,23 @@
 /*! \file ibv_internal.h */
 #include <infiniband/verbs.h>
+#include <stdbool.h>
 #include "ibvidentifier.h"
 #include "lib/list.h"
 #include "debug.h"
+
+struct dev_list_info {
+  int num_devices;
+  bool in_free;
+  struct ibv_device ** user_dev_list;
+  struct ibv_device ** real_dev_list;
+};
 
 //! A wrapper around a device
 struct internal_ibv_dev {
   struct ibv_device user_dev;
   struct ibv_device * real_dev;
-};
-
-struct address_pair {
-  void *user;
-  void *real;
-  struct list_elem elem;
+  bool in_use;
+  struct dev_list_info * list_info;
 };
 
 //! A wrapper around a context

--- a/contrib/infiniband/ibvctx.c
+++ b/contrib/infiniband/ibvctx.c
@@ -775,6 +775,8 @@ struct ibv_device ** _get_device_list(int * num_devices) {
     exit(1);
   }
 
+  memset(user_list, 0, (_dmtcp_num_devices + 1) * sizeof(struct ibv_device *));
+
   int i;
   for (i = 0; i < _dmtcp_num_devices; i++) {
     struct internal_ibv_dev * dev = (struct internal_ibv_dev *) malloc(sizeof(struct internal_ibv_dev));
@@ -977,12 +979,22 @@ void _ack_async_event(struct ibv_async_event * event)
  */
 void _free_device_list(struct ibv_device ** list)
 {
+  int i;
+  struct list_elem * e = list_begin(&dev_list);
+
   NEXT_IBV_FNC(ibv_free_device_list)(_dev_list);
 
-/*  for (i = 0; i < _dmtcp_num_devices; i++) {
-    free(list[i]);
+  for (i = 0; i < _dmtcp_num_devices; i++) {
+    struct internal_ibv_dev * dev = ibv_device_to_internal(list[i]);
+    struct list_elem * w = e;
+    struct address_pair * pair = list_entry(e, struct address_pair, elem);
+
+    e = list_next(e);
+    list_remove(w);
+    free(pair);
+    free(dev);
   }
-*/
+
   free(list);
 }
 


### PR DESCRIPTION
The memory leak leads to a weird segfault during MPI_Finalize().