### PR TITLE
dmtcp-api: Expose some existing functions

### DIFF
--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -180,10 +180,18 @@ EXTERNC void dmtcp_get_local_ip_addr(struct in_addr *in);
 EXTERNC const char* dmtcp_get_tmpdir(void);
 //EXTERNC void dmtcp_set_tmpdir(const char *);
 
-EXTERNC const char* dmtcp_get_ckpt_dir(void);
-EXTERNC void dmtcp_set_ckpt_dir(const char *);
-EXTERNC const char* dmtcp_get_coord_ckpt_dir(void);
-EXTERNC void dmtcp_set_coord_ckpt_dir(const char* dir);
+EXTERNC const char* dmtcp_get_ckpt_dir(void) __attribute ((weak));
+#define dmtcp_get_ckpt_dir() \
+ (dmtcp_get_ckpt_dir ? dmtcp_get_ckpt_dir() : NULL)
+EXTERNC int dmtcp_set_ckpt_dir(const char *) __attribute ((weak));
+#define dmtcp_set_ckpt_dir(d) \
+ (dmtcp_set_ckpt_dir ? dmtcp_set_ckpt_dir(d) : DMTCP_NOT_PRESENT)
+EXTERNC const char* dmtcp_get_coord_ckpt_dir(void) __attribute__ ((weak));
+#define dmtcp_get_coord_ckpt_dir() \
+ (dmtcp_get_coord_ckpt_dir ? dmtcp_get_coord_ckpt_dir() : NULL)
+EXTERNC int dmtcp_set_coord_ckpt_dir(const char* dir) __attribute__ ((weak));
+#define dmtcp_set_coord_ckpt_dir(d) \
+ (dmtcp_set_coord_ckpt_dir ? dmtcp_set_coord_ckpt_dir(d) : DMTCP_NOT_PRESENT)
 EXTERNC const char* dmtcp_get_ckpt_filename(void) __attribute__((weak));
 EXTERNC const char* dmtcp_get_ckpt_files_subdir(void);
 EXTERNC int dmtcp_should_ckpt_open_files(void);

--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -38,6 +38,10 @@
 #undef dmtcp_get_local_status
 #undef dmtcp_get_uniquepid_str
 #undef dmtcp_get_ckpt_filename
+#undef dmtcp_set_coord_ckpt_dir
+#undef dmtcp_get_coord_ckpt_dir
+#undef dmtcp_set_ckpt_dir
+#undef dmtcp_get_ckpt_dir
 
 using namespace dmtcp;
 
@@ -183,11 +187,12 @@ EXTERNC const char* dmtcp_get_ckpt_dir()
   return tmpdir.c_str();
 }
 
-EXTERNC void dmtcp_set_ckpt_dir(const char* dir)
+EXTERNC int dmtcp_set_ckpt_dir(const char* dir)
 {
   if (dir != NULL) {
     ProcessInfo::instance().setCkptDir(dir);
   }
+  return DMTCP_IS_PRESENT;
 }
 
 EXTERNC const char* dmtcp_get_coord_ckpt_dir(void)
@@ -197,11 +202,12 @@ EXTERNC const char* dmtcp_get_coord_ckpt_dir(void)
   return dir.c_str();
 }
 
-EXTERNC void dmtcp_set_coord_ckpt_dir(const char* dir)
+EXTERNC int dmtcp_set_coord_ckpt_dir(const char* dir)
 {
   if (dir != NULL) {
     CoordinatorAPI::instance().updateCoordCkptDir(dir);
   }
+  return DMTCP_IS_PRESENT;
 }
 
 EXTERNC void dmtcp_set_ckpt_file(const char *filename)


### PR DESCRIPTION
Many functions declared in dmtcp.h are not really usable by
an end-user because they are not correctly declared.

This patch fixes the issue for functions related to setting
the checkpoint directory path and the coordinator scripts
directory path.