### PR TITLE
Remove single host processing from restart script.

### DIFF
--- a/src/restartscript.cpp
+++ b/src/restartscript.cpp
@@ -197,34 +197,7 @@ static const char* cmdlineArgHandler =
   "fi\n\n"
 ;
 
-static const char* singleHostProcessing =
-  "ckpt_files=\"\"\n"
-  "if [ ! -z \"$DMTCP_RESTART_DIR\" ]; then\n"
-  "  for tmp in $given_ckpt_files; do\n"
-  "    ckpt_files=\"$DMTCP_RESTART_DIR/$(basename $tmp) $ckpt_files\"\n"
-  "  done\n"
-  "else\n"
-  "  ckpt_files=$given_ckpt_files\n"
-  "fi\n\n"
-
-  "coordinator_info=\"--coord-host $coord_host --coord-port $coord_port\"\n"
-
-  "tmpdir=\n"
-  "if [ ! -z \"$DMTCP_TMPDIR\" ]; then\n"
-  "  tmpdir=\"--tmpdir $DMTCP_TMPDIR\"\n"
-  "fi\n\n"
-
-  "ckpt_dir=\n"
-  "if [ ! -z \"$DMTCP_CKPT_DIR\" ]; then\n"
-  "  ckpt_dir=\"--ckptdir $DMTCP_CKPT_DIR\"\n"
-  "fi\n\n"
-
-  "exec $dmt_rstr_cmd $coordinator_info $ckpt_dir \\\n"
-  "  $maybejoin --interval \"$checkpoint_interval\" $tmpdir $noStrictChecking \\\n"
-  "  $ckpt_files\n"
-;
-
-static const char* multiHostProcessing =
+static const char* rstrtCmdProcessing =
   "worker_ckpts_regexp=\\\n"
   "\'[^:]*::[ \\t\\n]*\\([^ \\t\\n]\\+\\)[ \\t\\n]*:\\([a-z]\\+\\):[ \\t\\n]*\\([^:]\\+\\)\'\n\n"
 
@@ -334,8 +307,6 @@ void writeScript(const string& ckptDir,
   o << "." << RESTART_SCRIPT_EXT;
   uniqueFilename = o.str();
 
-  const bool isSingleHost = (restartFilenames.size() == 1);
-
   map< string, vector<string> >::const_iterator host;
 
   size_t numPeers;
@@ -393,19 +364,6 @@ void writeScript(const string& ckptDir,
                 "# Number of processes in the computation = %d\n\n",
                 restartFilenames.size(), numPeers );
 
-  if ( isSingleHost ) {
-    JTRACE ( "Single HOST" );
-
-    host=restartFilenames.begin();
-    ostringstream o;
-    for ( file=host->second.begin(); file!=host->second.end(); ++file ) {
-      o << " " << *file;
-    }
-    fprintf ( fp, "given_ckpt_files=\"%s\"\n\n", o.str().c_str());
-
-    fprintf ( fp, "%s", singleHostProcessing );
-  }
-  else
   {
     fprintf ( fp, "%s",
               "# SYNTAX:\n"
@@ -504,7 +462,7 @@ void writeScript(const string& ckptDir,
                   "\n\n"
              );
 
-    fprintf ( fp, "%s", multiHostProcessing );
+    fprintf ( fp, "%s", rstrtCmdProcessing);
   }
 
   fclose ( fp );


### PR DESCRIPTION
We need to use the RM plugin processing even it's a single-host computation.
Not 100% sure if multiple host processing can cover the single host case, but it looks good from my tests.
