### PR TITLE
restartscript: Fix dmtcp_restart_script.sh symbolic link set up

### DIFF
--- a/src/restartscript.cpp
+++ b/src/restartscript.cpp
@@ -524,7 +524,7 @@ void writeScript(const string& ckptDir,
     JTRACE("linking \"dmtcp_restart_script.sh\" filename to uniqueFilename")
       (filename) (dirname) (uniqueFilename);
     // FIXME:  Handle error case of symlink()
-    JWARNING(symlinkat(uniqueFilename.c_str(), dirfd, filename.c_str()) == 0);
+    JWARNING(symlinkat(basename(uniqueFilename.c_str()), dirfd, filename.c_str()) == 0) (JASSERT_ERRNO);
     JASSERT(close(dirfd) == 0);
   }
 }


### PR DESCRIPTION
The dmtcp_set_coord_ckpt_dir("dirname") API is used to specify
the location where the restart scripts are written.

This patch fixes an issue with the API where specifying a
relative path would set up the dmtcp_restart_script.sh symbolic
link incorrectly. If a relative path, say ./a/b/c, was specified,
DMTCP would create the symbolic link (in the ./a/b/c directory)
that pointed to ./a/b/c/dmtcp_restart_script_XXX.sh instead
of ./dmtcp_restart_script_XXX.sh.