### PR TITLE
Fix the bug when dlopen() is used to open ib verbs

### DIFF
--- a/contrib/infiniband/Makefile.in
+++ b/contrib/infiniband/Makefile.in
@@ -47,7 +47,7 @@ DMTCP_INCLUDE_PATH = $(top_srcdir)/include
 JALIB_PATH = $(top_srcdir)/jalib
 
 INCLUDES = -I$(JALIB_PATH) -I$(DMTCP_INCLUDE_PATH)
-LIB_LDFLAGS = -shared -Wl,--unresolved-symbols=ignore-all
+LIB_LDFLAGS = -libverbs -shared -Wl,--unresolved-symbols=ignore-all
 
 override CFLAGS += -fPIC
 override CXXFLAGS += -fPIC

--- a/contrib/infiniband/README
+++ b/contrib/infiniband/README
@@ -1,6 +1,9 @@
 This plugin supports checkpointing of applications over InfiniBand.
 (By default, DMTCP provides checkpoint-restart for TCP (socket-based networks.)
 
+Currently this plugin supports the standard OFED verbs API for InfiniBand,
+but vendor-specific InfiniBand APIs are not supported.
+
 This is the work of Jiajun Cao et al.  Please report bugs to
 dmtcp@ccs.neu.edu as well as to jiajun using his account at ccs.neu.edu.
 
@@ -17,9 +20,7 @@ To do so:
   ./configure --enable-infiniband-support
   make clean
   make
-  # Replace next line with absolute path to your contrib/infiniband directory.
-  bin/dmtcp_launch \
-    --with-plugin <DMTCP_ROOT>/contrib/infiniband/libdmtcp_infiniband.so
+  bin/dmtcp_launch --ib ./a.out
 
 EXPERTS ONLY: libibtrace.so can also be built
 

--- a/contrib/infiniband/infinibandwrappers.c
+++ b/contrib/infiniband/infinibandwrappers.c
@@ -15,7 +15,15 @@
 void *dlopen(const char *filename, int flag) {
   if (filename) {
     if (strstr(filename, "libibverbs.so")) {
-      return RTLD_DEFAULT;
+      void *handle = NEXT_FNC(dlopen)("libdmtcp_infiniband.so", flag);
+      if (handle == NULL) {
+        fprintf(stderr,
+                "\n*** Please either add $DMTCP_PATH$/lib/dmtcp "
+                "to LD_LIBRARY_PATH,\n"
+                "*** or else include an absolute pathname "
+                "for libdmtcp_infiniband.so\n\n");
+      }
+      return handle;
     }
   }
   return NEXT_FNC(dlopen)(filename, flag);


### PR DESCRIPTION
We link the plugin with the verbs library, and when the application
calls dlopen() to open libibverbs.so, we dlopen() the plugin in
the wrapper for dlopen(), so that all subsequent verbs calls will
fall in our verbs wrappers.