### PR TITLE
Fix race while reading /proc/self/maps for ckpt

### DIFF
--- a/include/procselfmaps.h
+++ b/include/procselfmaps.h
@@ -32,6 +32,7 @@ class ProcSelfMaps
     size_t numAreas;
     size_t numBytes;
     int fd;
+    int numAllocExpands;
 };
 
 }

--- a/jalib/jalloc.cpp
+++ b/jalib/jalloc.cpp
@@ -27,6 +27,10 @@
 #include "jalib.h"
 #include "jalloc.h"
 
+// Make highest chunk size large; avoid a raw_alloc calling mmap()
+//   during /proc/self/maps
+#define MAX_CHUNKSIZE (4*1024)
+
 using namespace jalib;
 
 extern "C" int fred_record_replay_enabled() __attribute__ ((weak));
@@ -107,8 +111,9 @@ public:
   enum { N=_N };
   JFixedAllocStack() {
     if (_blockSize == 0) {
-      _blockSize = 10*1024;
+      _blockSize = 4*MAX_CHUNKSIZE;
       _root = NULL;
+      _numExpands = 0;
     }
   }
 
@@ -154,9 +159,27 @@ public:
     } while (!__sync_bool_compare_and_swap(&_root, item->next, item));
   }
 
+  int numExpands() {
+    return _numExpands;
+  }
+
+  void preExpand() {
+    // Force at least numChunks chunks to become free.
+    const int numAllocs = 10;
+    void *allocatedItem[numAllocs];
+    for (int i=0; i<numAllocs; i++) {
+      allocatedItem[i] = allocate();
+    }
+    // if (_root == NULL) { expand(); }
+    for (int i=0; i<numAllocs; i++) {
+      deallocate(allocatedItem[i]);
+    }
+  }
+
 protected:
   //allocate more raw memory when stack is empty
   void expand() {
+    _numExpands++;
     if (_root != NULL &&
         fred_record_replay_enabled && fred_record_replay_enabled()) {
       // TODO: why is expand being called? If you see this message, raise lvl2
@@ -192,6 +215,7 @@ private:
   FreeItem* volatile _root;
   size_t _blockSize;
   char padding[128];
+  int volatile _numExpands;
 };
 
 } // namespace jalib
@@ -199,7 +223,10 @@ private:
 jalib::JFixedAllocStack<64>   lvl1;
 jalib::JFixedAllocStack<256>  lvl2;
 jalib::JFixedAllocStack<1024> lvl3;
-jalib::JFixedAllocStack<2048> lvl4;
+#if MAX_CHUNKSIZE <= 1024
+# error MAX_CHUNKSIZE must be larger
+#endif
+jalib::JFixedAllocStack<MAX_CHUNKSIZE> lvl4;
 
 void jalib::JAllocDispatcher::initialize(void)
 {
@@ -243,6 +270,18 @@ void jalib::JAllocDispatcher::deallocate(void* ptr, size_t n)
   if(n <= lvl3.N) lvl3.deallocate(ptr); else
   if(n <= lvl4.N) lvl4.deallocate(ptr); else
   _dealloc_raw(ptr, n);
+}
+int jalib::JAllocDispatcher::numExpands()
+{
+  return lvl1.numExpands() + lvl2.numExpands() +
+         lvl3.numExpands() + lvl4.numExpands();
+}
+void jalib::JAllocDispatcher::preExpand()
+{
+  lvl1.preExpand();
+  lvl2.preExpand();
+  lvl3.preExpand();
+  lvl4.preExpand();
 }
 
 #else

--- a/jalib/jalloc.h
+++ b/jalib/jalloc.h
@@ -47,6 +47,8 @@ namespace jalib
         _p-=1;
         JAllocDispatcher::deallocate(_p, *_p+sizeof(size_t));
       }
+      static int numExpands();
+      static void preExpand();
   };
 
   class JAlloc {

--- a/src/procselfmaps.cpp
+++ b/src/procselfmaps.cpp
@@ -32,9 +32,25 @@ ProcSelfMaps::ProcSelfMaps()
   : dataIdx(0),
     numAreas(0),
     numBytes(0),
-    fd(-1)
+    fd(-1),
+    numAllocExpands(0)
 {
   char buf[4096];
+  // NOTE: preExpand() verifies that we have at least 10 chunks pre-allocated
+  //   for each level of the allocator.  See jalib/jalloc.cpp:preExpand().
+  //   It assumes no allocation larger than jalloc.cpp:MAX_CHUNKSIZE.
+  //   Ideally, we would have followed the MTCP C code, and not allocated
+  //   any memory bewteen the constructor and destructor of ProcSelfMaps.
+  //   But since C++ is biased toward frequent mallocs (e.g., dynamic vectors),
+  //   we try to compensate here for the weaknesses of C++.
+  // If we use this /proc/self/maps for checkpointing, we must not mmap
+  //   as part of the allocator prior to writing the memory to the ckpt image.
+  jalib::JAllocDispatcher::preExpand();
+  numAllocExpands = jalib::JAllocDispatcher::numExpands();
+  // FIXME:  Also, any memory allocated and not freed since the calls to
+  //   setcontext() on the various threads will be a memory leak on restart.
+  //   We should check for that.
+
   fd = _real_open("/proc/self/maps", O_RDONLY);
   JASSERT(fd != -1) (JASSERT_ERRNO);
   ssize_t numRead = 0;
@@ -79,6 +95,13 @@ ProcSelfMaps::~ProcSelfMaps()
   dataIdx = 0;
   numAreas = 0;
   numBytes = 0;
+  // Verify that JAlloc doesn't expand memory (via mmap)
+  //   while reading /proc/self/maps.
+  // FIXME:  Change from JWARNING to JASSERT when we have confidence in this.
+  JWARNING(numAllocExpands == jalib::JAllocDispatcher::numExpands())
+          (numAllocExpands)(jalib::JAllocDispatcher::numExpands())
+          .Text("JAlloc: memory expanded through call to mmap()."
+                "  Inconsistent JAlloc will be a problem on restart");
 }
 
 bool ProcSelfMaps::isValidData()

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -54,8 +54,18 @@ EXTERNC int dmtcp_infiniband_enabled(void) __attribute__((weak));
 
 static const int END_OF_NSCD_AREAS = -1;
 
+// FIXME:  Why do we create two global variable here?  They should at least
+//         be static (file-private), and preferably local to a function.
 ProcSelfMaps *procSelfMaps = NULL;
 vector<ProcMapsArea> *nscdAreas = NULL;
+// FIXME:  If we allocate in the middle of reading
+//         /proc/self/maps, we modify the mapping.  But whenever we
+//         add to nscdAreas, we risk allocating memory.  So, we're depending
+//         on this memory being smaller than any pre-allocated memory,
+//         so that the memory allocator does not call mmap in the middle
+//         of reading /proc/self/maps.  A better design would be to create
+//         an nscdArea method of the ProcSelfMaps class, and that
+//         class can then be careful about allocating memory.
 
 
 /* Internal routines */
@@ -259,7 +269,7 @@ void mtcp_writememoryareas(int fd)
   delete procSelfMaps;
   procSelfMaps = NULL;
 
-  /* It's now safe to do this, since we're done using mtcp_readmapsline() */
+  /* It's now safe to do this, since we're done using writememoryarea() */
   remap_nscd_areas(*nscdAreas);
 
   area.addr = NULL; // End of data


### PR DESCRIPTION
If the JAlloc allocator expands its memory, it will call mmap().  If this happens while reading `/proc/self/maps`, it will create a bug on restart.  The allocator will have saved a pointer to the freshly mmap'ed memory, but since it was mmap'ed after reading `/proc/self/maps` and before we copied memory into the checkpoint image, we will have a dangling pointer into memory that has not been saved.

This bug appears when doing either of:
```
make -j AUTOTEST=--stress check-pthread5
make -j AUTOTEST=--stress check-shared-memory1
```