### PR TITLE
Fix prev. bug in multi-arch logic

### DIFF
--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -369,7 +369,10 @@ static void runMtcpRestart(int is32bitElf, int fd, ProcessInfo *pInfo)
 
   static string mtcprestart = Util::getPath ("mtcp_restart");
 
-#if defined(CONFIG_M32)
+#if defined(__x86_64__) || defined(__aarch64__) || defined(CONFIG_M32)
+  // FIXME: This is needed for CONFIG_M32 only because getPath("mtcp_restart")
+  //        fails to return the absolute path for mtcprestart.  We should fix
+  //        the bug in Util::getPath() and remove CONFIG_M32 condition in #if.
   if (is32bitElf) {
     mtcprestart = Util::getPath("mtcp_restart-32", is32bitElf);
   }


### PR DESCRIPTION
Fixes ee6c20df4 (i.e., better fix for 7a3086bbc62)

As the FIXME says,
```
// FIXME: This is needed for CONFIG_M32 only because getPath("mtcp_restart")
//        fails to return the absolute path for mtcprestart.  We should fix
//        the bug in Util::getPath() and remove CONFIG_M32 condition in #if.
```

The logic will use `lib/dmtcp/32/lib/dmtcp/mtcp_restart-m32`, when it should use `lib/dmtcp/mtcp_restart` in the case of standalone 32-bit DMTCP.  This is a minimal fix, to go into DMTCP 2.4.4.  A full fix can go into DMTCP 2.5.0.

I'm also pushing this in without review, because it is needed now for PR #274 .
