### PR TITLE
configure: --enable-static-libstdcxx

### DIFF
--- a/configure
+++ b/configure
@@ -801,6 +801,7 @@ enable_experts_only_space1
 enable_experts_only
 enable_experts_only_after
 enable_m32
+enable_static_libstdcxx
 with_mpich
 '
       ac_precious_vars='build_alias
@@ -1480,6 +1481,10 @@ Optional Features:
   --enable-m32            Compile in 32 bit mode on 64 bit linux. (Works on
                           most, but not all programs, due to restrictions of
                           32-bit mode.)
+  --enable-static-libstdcxx
+                          Compile $CXX with -static-libstdc++. This allows
+                          DMTCP executables compiled on later distro to run
+                          correctly on earlier distros.)
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -5458,7 +5463,7 @@ $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "Failed to build C program with -m32
     Typically, this means that 32-bit glibc include files were not found.
     Consider installing gcc-multilib g++-multilib libc6-dev-i386 (Debian/Ubuntu)
-     or glibc-devel.i686 glibc-devel ibstdc++-devel.i686 (Red Hat/Fedora/CentOS)
+     or glibc-devel.i686 glibc-devel libstdc++-devel.i686(Red Hat/Fedora/CentOS)
      or glibc-devel-32bit (SUSE/OpenSUSE)
      or the equivalent packages for your Linux distro.
 See \`config.log' for more details" "$LINENO" 5; }
@@ -5506,7 +5511,7 @@ $as_echo "$cplusplus_m32" >&6; }
   if test "$cplusplus_m32" = "no"; then
     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "Failed to build C++ program with -m32
+as_fn_error $? "Failed to build $CXX program with -m32
     Typically, this means that 32-bit libstdc++.so was not found
     Consider installing gcc-multilib g++-multilib libc6-dev-i386 (Debian/Ubuntu)
      or glibc-devel.i686 glibc-devel ibstdc++-devel.i686 (Red Hat/Fedora/CentOS)
@@ -5517,6 +5522,80 @@ See \`config.log' for more details" "$LINENO" 5; }
 else
   M32=0
 
+fi
+
+# Check whether --enable-static_libstdcxx was given.
+if test "${enable_static_libstdcxx+set}" = set; then :
+  enableval=$enable_static_libstdcxx; use_static_libstdcxx=$enableval
+else
+  use_static_libstdcxx=no
+fi
+
+
+if test "$use_static_libstdcxx" = "yes"; then
+  CXXFLAGS="$CXXFLAGS -static-libstdc++"
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CXX compiles using -static-libstdc++" >&5
+$as_echo_n "checking whether $CXX compiles using -static-libstdc++... " >&6; }
+  ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+  #include <stdio.h>
+  #include <features.h>  /* This often causes a problem. */
+
+int
+main ()
+{
+
+  printf("Hello, world!\n");
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+  cplusplus_static_libstdcxx='yes'
+else
+  cplusplus_static_libstdcxx='no'
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+  ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $cplusplus_static_libstdcxx" >&5
+$as_echo "$cplusplus_static_libstdcxx" >&6; }
+  if test "$cplusplus_static_libstdcxx" = "no"; then
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "Failed to build $CXX program with -static-libstdc++
+    Typically, this means that you are missing a static package.
+    Consider installing libstdc++-static (Red Hat/Fedora/CentOS)
+     or the equivalent packages for your Linux distro.
+See \`config.log' for more details" "$LINENO" 5; }
+  fi
+
+  # We do this hack for cross-distro compatibility only if we already
+  #   requested the other hack, --enable-static-libstdcxx
+  OLDPATH="$PATH"
+  if test "$MKDIR_P" = "/usr/bin/mkdir -p" && \
+     test -x /bin/mkdir && test -x /usr/bin/mkdir && \
+     diff /bin/mkdir /usr/bin/mkdir > /dev/null; then
+    # Fedora prefers /usr/bin/mkdir to /bin/mkdir.  But on shared filesystems,
+    #   this creates a problem for Ubuntu, which supports only /bin/mkdir.
+    MKDIR_P="/bin/mkdir -p"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: --enable-static-libstdcxx: thread-safe \"mkdir -p\": $MKDIR_P" >&5
+$as_echo "$as_me: --enable-static-libstdcxx: thread-safe \"mkdir -p\": $MKDIR_P" >&6;}
+  fi
 fi
 
 #AC_ARG_ENABLE([allocator],
@@ -5622,8 +5701,8 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $has_pr_set_ptracer" >&5
 $as_echo "$has_pr_set_ptracer" >&6; }
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if process_vm_readv/process_vm_writev (CMA) available" >&5
-$as_echo_n "checking if process_vm_readv/process_vm_writev (CMA) available... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if process_vm_readv/process_vm_writev available" >&5
+$as_echo_n "checking if process_vm_readv/process_vm_writev available... " >&6; }
 if test "$cross_compiling" = yes; then :
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
@@ -5686,6 +5765,8 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
   conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
 
+# FIXME: MVAPICH started using process_vm_readv/writev when CMA became
+#   available in the Linux kernel.  But the name has_cma is probably a bad one.
 if test "$has_cma" == "yes"; then
 
 $as_echo "#define HAS_CMA 1" >>confdefs.h

--- a/configure.ac
+++ b/configure.ac
@@ -289,6 +289,48 @@ else
   AC_SUBST([M32], [0])
 fi
 
+AC_ARG_ENABLE([static_libstdcxx],
+            [AS_HELP_STRING([--enable-static-libstdcxx],
+                            [Compile $CXX with -static-libstdc++.
+                             This allows DMTCP executables compiled on later
+                             distro to run correctly on earlier distros.)])],
+            [use_static_libstdcxx=$enableval],
+            [use_static_libstdcxx=no])
+
+if test "$use_static_libstdcxx" = "yes"; then
+  CXXFLAGS="$CXXFLAGS -static-libstdc++"
+
+  AC_MSG_CHECKING([whether $CXX compiles using -static-libstdc++])
+  AC_LANG_PUSH([C++])
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+  #include <stdio.h>
+  #include <features.h>  /* This often causes a problem. */
+  ]], [[
+  printf("Hello, world!\n");
+  ]])], [cplusplus_static_libstdcxx='yes'], [cplusplus_static_libstdcxx='no'])
+  AC_LANG_POP([C++])
+  AC_MSG_RESULT([$cplusplus_static_libstdcxx])
+  if test "$cplusplus_static_libstdcxx" = "no"; then
+    AC_MSG_FAILURE([[Failed to build $CXX program with -static-libstdc++
+    Typically, this means that you are missing a static package.
+    Consider installing libstdc++-static (Red Hat/Fedora/CentOS)
+     or the equivalent packages for your Linux distro.]])
+  fi
+
+  # We do this hack for cross-distro compatibility only if we already
+  #   requested the other hack, --enable-static-libstdcxx
+  OLDPATH="$PATH"
+  if test "$MKDIR_P" = "/usr/bin/mkdir -p" && \
+     test -x /bin/mkdir && test -x /usr/bin/mkdir && \
+     diff /bin/mkdir /usr/bin/mkdir > /dev/null; then
+    # Fedora prefers /usr/bin/mkdir to /bin/mkdir.  But on shared filesystems,
+    #   this creates a problem for Ubuntu, which supports only /bin/mkdir.
+    MKDIR_P="/bin/mkdir -p"
+    AC_MSG_NOTICE(
+      [--enable-static-libstdcxx: thread-safe "mkdir -p": $MKDIR_P])
+  fi
+fi
+
 #AC_ARG_ENABLE([allocator],
 #            [AS_HELP_STRING([--enable-allocator],
 #                            [cause DMTCP to use a custom allocator based on mmap

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -104,8 +104,6 @@ __d_libdir__libdmtcp_so_SOURCES = dmtcpworker.cpp threadsync.cpp \
 
 __d_libdir__libdmtcp_so_LDFLAGS = -shared -Xlinker -znow
 
-#dmtcp_nocheckpoint_LDFLAGS = -static
-
 # Note that an ELF object uses libsyscallsreal.a or libnohijack.a
 #  but not both.  libnohijack.a has stub definitions for same symbols.
 __d_libdir__libdmtcp_so_LDADD = libdmtcpinternal.a libjalib.a \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -581,8 +581,6 @@ __d_libdir__libdmtcp_so_SOURCES = dmtcpworker.cpp threadsync.cpp \
 
 __d_libdir__libdmtcp_so_LDFLAGS = -shared -Xlinker -znow
 
-#dmtcp_nocheckpoint_LDFLAGS = -static
-
 # Note that an ELF object uses libsyscallsreal.a or libnohijack.a
 #  but not both.  libnohijack.a has stub definitions for same symbols.
 __d_libdir__libdmtcp_so_LDADD = libdmtcpinternal.a libjalib.a \
@@ -593,7 +591,7 @@ __d_bindir__dmtcp_coordinator_LDADD = libdmtcpinternal.a libjalib.a \
 			  libnohijack.a -lpthread -lrt
 
 __d_bindir__dmtcp_launch_LDADD = libdmtcpinternal.a libjalib.a \
-			  libnohijack.a -ldl -lpthread -lrt
+			  libnohijack.a -lpthread -lrt -ldl
 
 __d_bindir__dmtcp_restart_LDADD = libdmtcpinternal.a libjalib.a \
 			  libnohijack.a -lpthread -lrt -ldl


### PR DESCRIPTION
  This configure option causes $CXX to use the g++ flag `-static-libstdc++`
  When a newer and older distro share a filesystem, and when
  g++ builds on the newer distro, then the executable fails on
  the older distro.  This should fix it.

An explanation of the problem occurs here:
  https://hosunghwang.wordpress.com/2015/07/15/libstdc-so-6-library-mismatch-problem-and-solution/
(except that the author meant to refer to `-static-libstdc++` at the end of the article).

I haven't yet found a testing machine with the right packages to test this.  So, it's not yet ready to be pushed in.