### PR TITLE
Add tests for mutex (esp. recursive mutex)

### DIFF
--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -154,6 +154,12 @@ dmtcp4: dmtcp4.c
 dmtcp5: dmtcp5.c
 	-$(CC) -o $@ $< $(CFLAGS) -lpthread
 
+pthread%: pthread%.c
+	-$(CC) -o $@ $< $(CFLAGS) -lpthread
+
+mutex%: mutex%.c
+	-$(CC) -o $@ $< $(CFLAGS) -lpthread
+
 # FIXME:  We should create a test in configure.ac to see if this compiles.
 ifeq (${DO_PTHREAD_ATFORK},yes)
 libpthread_atfork1.so: pthread_atfork1.c
@@ -182,9 +188,6 @@ else
 cma: cma.c
 	@ echo "#cma: Skipping test for cma.  CMA requires Linux 3.2 or later."
 endif
-
-pthread%: pthread%.c
-	-$(CC) -o $@ $< $(CFLAGS) -lpthread
 
 posix-mq%: posix-mq%.c
 	-$(CC) -o $@ $< $(CFLAGS) -lrt

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -797,6 +797,20 @@ runTest("environ",       1, ["./test/environ"])
 
 runTest("forkexec",      2, ["./test/forkexec"])
 
+runTest("realpath",      1, ["./test/realpath"])
+runTest("pthread1",      1, ["./test/pthread1"])
+runTest("pthread2",      1, ["./test/pthread2"])
+S=10*DEFAULT_S
+runTest("pthread3",      1, ["./test/pthread2 80"])
+S=DEFAULT_S
+runTest("pthread4",      1, ["./test/pthread4"])
+runTest("pthread5",      1, ["./test/pthread5"])
+
+runTest("mutex1",        1, ["./test/mutex1"])
+runTest("mutex2",        1, ["./test/mutex2"])
+runTest("mutex3",        1, ["./test/mutex3"])
+runTest("mutex4",        1, ["./test/mutex4"])
+
 # FIXME:  pthread_atfork doesn't compile on some architectures.
 #         If we add a configure test for pthread_atfork, we can
 #           set a Python variable in autotest_config.py.in
@@ -885,15 +899,6 @@ if old_ld_library_path:
   os.environ['LD_LIBRARY_PATH'] = old_ld_library_path
 else:
   del os.environ['LD_LIBRARY_PATH']
-
-runTest("realpath",      1, ["./test/realpath"])
-runTest("pthread1",      1, ["./test/pthread1"])
-runTest("pthread2",      1, ["./test/pthread2"])
-S=10*DEFAULT_S
-runTest("pthread3",      1, ["./test/pthread2 80"])
-S=DEFAULT_S
-runTest("pthread4",      1, ["./test/pthread4"])
-runTest("pthread5",      1, ["./test/pthread5"])
 
 # Most of the remaining tests are on 64-bit processes.
 if USE_M32:

--- a/test/mutex1.c
+++ b/test/mutex1.c
@@ -1,0 +1,54 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <pthread.h>
+#include "dmtcp.h"
+
+// This code uses dmtcp_mutex_trylock() and dmtcp_mutex_unlock().
+// We could alternatively have used pthread_mutex_locak/unlock,
+//   but in this case, it will simply hang on restart, and our
+//   current autotest can't check for processes that live, but hang.
+// This code tests on a recursive mutex, since a recursive mutex
+//   must check the owner when locking.
+
+int main() {
+  // DMTCP and native differ when this is not initialized.  Why?
+  // DMTCP crashed on lock with ESRCH
+  int counter = 0;
+
+  pthread_mutex_t mutex;
+  pthread_mutexattr_t attr;
+  pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+  pthread_mutex_init(&mutex, &attr);
+
+  dmtcp_disable_ckpt();
+  while (1) {
+    int rc;
+    rc = pthread_mutex_trylock(&mutex);
+    if (rc != 0) {
+      printf("pthread_mutex_trylock (recursive): %s\nn",
+             strerror(rc));
+      exit(1);
+    }
+    dmtcp_enable_ckpt();
+    if (counter++ % 1000000 == 0) {
+      printf("b"); fflush(stdout);
+    }
+    dmtcp_disable_ckpt();
+    rc = pthread_mutex_trylock(&mutex);
+    if (rc != 0) {
+      printf("pthread_mutex_trylock (recursive): %s\n\n",
+             strerror(rc));
+      exit(1);
+    }
+    rc = pthread_mutex_unlock(&mutex);
+    rc = pthread_mutex_unlock(&mutex);
+    if (rc != 0) {
+      printf("pthread_mutex_unlock (recursive): %s\n\n",
+             strerror(rc));
+      exit(1);
+    }
+  }
+  return 0;
+}

--- a/test/mutex2.c
+++ b/test/mutex2.c
@@ -1,0 +1,51 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <pthread.h>
+#include "dmtcp.h"
+
+// WE CAN ALTERNATELY USE trylock, and timedlock with a timeout of zerotime.
+// They do the same thing, and we can test both methods in the same code.
+// But it's better to make them separate tests, so that we always
+// // fail if just one of them causes a problem.
+
+int main() {
+  int counter = 0;
+  struct timespec zerotime;
+  zerotime.tv_sec = 0;
+  zerotime.tv_nsec = 0;
+
+  pthread_mutex_t mutex;
+  pthread_mutexattr_t attr;
+  pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+  pthread_mutex_init(&mutex, &attr);
+
+  dmtcp_disable_ckpt();
+  while (1) {
+    int rc;
+    rc = pthread_mutex_timedlock(&mutex, &zerotime);
+    if (rc != 0) {
+      printf("pthread_mutex_trylock: %s\n\n",
+             strerror(rc));
+      exit(1);
+    }
+    dmtcp_enable_ckpt();
+    if (counter++ % 1000000 == 0) {
+      printf("b"); fflush(stdout);
+    }
+    dmtcp_disable_ckpt();
+    // zerotime means either succeed in locking or fail immediately.
+    rc = pthread_mutex_timedlock(&mutex, &zerotime);
+    if (rc != 0) {
+      printf("pthread_mutex_trylock (recursive): %s\n\n",
+             strerror(rc));
+      exit(1);
+    }
+    rc = pthread_mutex_unlock(&mutex);
+    rc = pthread_mutex_unlock(&mutex);
+    if (rc == -1) perror("pthread_mutex_unlock");
+  }
+  return 0;
+}

--- a/test/mutex3.c
+++ b/test/mutex3.c
@@ -1,0 +1,48 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <pthread.h>
+#include "dmtcp.h"
+
+// This code uses dmtcp_mutex_trylock() and dmtcp_mutex_unlock().
+// We could alternatively have used pthread_mutex_locak/unlock,
+//   but in this case, it will simply hang on restart, and our
+//   current autotest can't check for processes that live, but hang.
+// NOTE:  This test specializes in testing an error-checking mutex,
+//   since na error-checking must check the owner when unlocking.
+//   (In contrsst, a recursive mutex will check the owner when locking.)
+
+int main() {
+  // DMTCP and native differ when this is not initialized.  Why?
+  // DMTCP crashed on lock with ESRCH
+  int counter = 0;
+
+  pthread_mutex_t mutex;
+  pthread_mutexattr_t attr;
+  pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+  pthread_mutex_init(&mutex, &attr);
+
+  dmtcp_disable_ckpt();
+  while (1) {
+    int rc;
+    rc = pthread_mutex_trylock(&mutex);
+    if (rc != 0) {
+      printf("pthread_mutex_trylock (error-checking): %s\n\n",
+             strerror(rc));
+      exit(1);
+    }
+    dmtcp_enable_ckpt();
+    if (counter++ % 1000000 == 0) {
+      printf("b"); fflush(stdout);
+    }
+    dmtcp_disable_ckpt();
+    rc = pthread_mutex_unlock(&mutex);
+    if (rc != 0) {
+      printf("pthread_mutex_unlock (error-checking): %s\n\n",
+             strerror(rc));
+      exit(1);
+    }
+  }
+  return 0;
+}

--- a/test/mutex4.c
+++ b/test/mutex4.c
@@ -1,0 +1,63 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <pthread.h>
+#include "dmtcp.h"
+
+// This code uses dmtcp_mutex_trylock() and dmtcp_mutex_unlock().
+// We could alternatively have used pthread_mutex_locak/unlock,
+//   but in this case, it will simply hang on restart, and our
+//   current autotest can't check for processes that live, but hang.
+// NOTE:  This test specializes in testing an error-checking mutex,
+//   since na error-checking must check the owner when unlocking.
+//   (In contrsst, a recursive mutex will check the owner when locking.)
+//   This version runs with two threads instead of just one thread.
+
+pthread_mutex_t mutex;
+void *mutex_loop(void *arg);
+
+int main() {
+  pthread_mutexattr_t attr;
+  pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+  pthread_mutex_init(&mutex, &attr);
+
+  pthread_t thread1, thread2;
+  pthread_create(&thread1, NULL, mutex_loop, NULL);
+  pthread_create(&thread2, NULL, mutex_loop, NULL);
+  // This will block forever.  mutex_loop() doesn't return.
+  pthread_join(thread1, NULL);
+  pthread_join(thread2, NULL);
+  return 0;
+}
+
+void *mutex_loop(void *arg /* NOTUSED */) {
+  int counter = 0;
+
+  struct timespec hundredth_second;
+  hundredth_second.tv_sec = 0;
+  hundredth_second.tv_nsec = 10000000; /* 10,000,000 */
+
+  while (1) {
+    int rc;
+    rc = pthread_mutex_lock(&mutex);
+    if (rc != 0) {
+      printf("pthread_mutex_lock (error-checking): %s\n\n",
+             strerror(rc));
+      exit(1);
+    }
+    // Wait a little to optimize chances of checkpoint occurring here.
+    nanosleep(&hundredth_second, NULL);
+    if (counter++ % 50 == 0) {
+      printf("b"); fflush(stdout);
+    }
+    rc = pthread_mutex_unlock(&mutex);
+    if (rc != 0) {
+      printf("pthread_mutex_unlock (error-checking): %s\n\n",
+             strerror(rc));
+      exit(1);
+    }
+  }
+  return NULL;
+}


### PR DESCRIPTION
These tests for autotest will be used to test the new mutex wrapper code in PR #282.  The tests will fail without PR #282.  So, this should not be pushed in until PR #282 has been pushed.

These tests are for recursive mutexes only.  In my cursory testing, I didn't see a bug appear with normal mutexes.  @rohgarg and @ankitcse07 report that they have an example of a bug that also affects normal mutexes.  I will add a test file for normal mutexes into this pull request when I find those examples again (or when they re-send them to me :-) ).