### PR TITLE
Add test if environ saved across ckpt/restart

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -793,6 +793,8 @@ runTest("stale-fd",      2, ["./test/stale-fd"])
 
 runTest("poll",          1, ["./test/poll"])
 
+runTest("environ",       1, ["./test/environ"])
+
 runTest("forkexec",      2, ["./test/forkexec"])
 
 # FIXME:  pthread_atfork doesn't compile on some architectures.

--- a/test/environ.c
+++ b/test/environ.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+int main() {
+  int counter = 0;
+  setenv("ABC", "abc", 1);
+  while (1) {
+    if (counter++ % 1000000 == 0) {
+      printf("b"); fflush(stdout);
+    }
+    if (strcmp(getenv("ABC"), "abc") != 0) {
+      printf("\nEnvironment was not preserved across checkpoint/restart.\n");
+      exit(1);
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
Test if environ is saved across a checkpoint/restart.