### PR TITLE
modify-env plugin now warns if no "dmtcp_env.txt"

### DIFF
--- a/plugin/modify-env/modify-env.c
+++ b/plugin/modify-env/modify-env.c
@@ -30,6 +30,7 @@
 char * read_dmtcp_env_file(char *file, int size);
 int readAndSetEnv(char *buf, int size);
 int readall(int fd, char *buf, int maxCount);
+extern void warning(const char *warning_part1, const char *warning_part2);
 
 EXTERNC int dmtcp_modify_env_enabled() { return 1; }
 
@@ -49,7 +50,21 @@ void dmtcp_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
   case DMTCP_EVENT_RESTART:
   { int size = 12288;
     char *buf = read_dmtcp_env_file("dmtcp_env.txt", size);
-    readAndSetEnv(buf, size);
+    if (buf != NULL) { // If env_file exists
+      readAndSetEnv(buf, size);
+    } else { // else env_file doesn't exist (buf == NULL)
+#if 0
+      // FIXME:  This "if" condition to check environ var. always triggers,
+      //   even if environ var. was never present.  Uncomment this when fixed.
+      if (!getenv("DMTCP_QUIET") &&
+          strcmp(getenv("DMTCP_QUIET")[0], "0") != 0) {
+#endif
+        warning("modify-env plugin: Couldn't open ",
+                "\"dmtcp_env.txt\"\n");
+#if 0
+      }
+#endif
+    }
     break;
   }
   default:
@@ -62,34 +77,38 @@ void dmtcp_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
 #define readEOF ((char)-1)
 
 char * read_dmtcp_env_file(char *file, int size) {
+  // FIXME: WHAT DOES THIS DO?
   // We avoid using malloc.
   char *buf = mmap(NULL, size, PROT_READ | PROT_WRITE,
                    MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   if (buf == MAP_FAILED) {
-    perror("mmap");
+    warning("mmap: ", strerror(errno));
     exit(1);
   }
 #ifdef STANDALONE
   int fd = open(file, O_RDONLY);
+  if (fd < 0) {
+    warning("open: ", strerror(errno));
+    exit(1);
+  }
 #else
   char pathname[512];
   if (strlen(dmtcp_get_ckpt_dir()) > sizeof(pathname)-1-sizeof(file)) {
-    fprintf(stderr, "%s:%d : Pathname of ckpt dir is too long: %s\n",
-            __FILE__, __LINE__, dmtcp_get_ckpt_dir());
+    warning(__FILE__ ": Pathname of ckpt dir is too long: ",
+            dmtcp_get_ckpt_dir() /* , "\n" */ );
     exit(1);
   }
   strcpy(pathname, dmtcp_get_ckpt_dir());
   strcpy(pathname + strlen(dmtcp_get_ckpt_dir()), "/");
   strcpy(pathname + strlen(dmtcp_get_ckpt_dir()) + strlen("/"), file);
   int fd = open(pathname, O_RDONLY);
-#endif
   if (fd < 0) {
-    perror("open");
-    exit(1);
+    return NULL;
   }
+#endif
   int count = readall(fd, buf, size);
   if (count < 0) {
-    perror("read");
+    warning("read: ", strerror(errno));
     exit(1);
   }
   *(buf+count) = readEOF;
@@ -133,7 +152,7 @@ int readAndSetEnv(char *buf, int size) {
           strcpy(nameChanged_end, nameBuf);
           nameChanged_end += strlen(nameBuf) + 1;
         } else {
-          fprintf(stderr, "modify-env.c: Too many '$' name expansions\n");
+          warning("", "modify-env.c: Too many '$' name expansions\n");
         }
         // Get ready for next name-value pair
         isStringMode = 0;
@@ -202,7 +221,7 @@ int readall(int fd, char *buf, int maxCount) {
   int count = 0;
   while (1) {
     if (count + 100 > maxCount) {
-      fprintf(stderr, "Environment file is too large.\n");
+      warning("", "Environment file is too large.\n");
       return -1;
     }
     int numRead = read(fd, buf+count, 100); // read up to 100 char's at once

--- a/plugin/modify-env/warning.cpp
+++ b/plugin/modify-env/warning.cpp
@@ -1,0 +1,8 @@
+#include  "../../jalib/jassert.h"
+
+extern "C"
+void warning(const char * warning_part1, const char * warning_part2) {
+  dmtcp::string warning("modify_env.c: ");
+  warning = warning + warning_part1 + warning_part2;
+  JWARNING(false).Text(warning.c_str());
+}


### PR DESCRIPTION
The title shows what this PR does.

Ideally, the code would also check if the `"DMTCP_QUIET"` environment variable was set prior to checkpoint.  But when the code calls `getenv("DMTCP_QUIET")` at restart time, the result always points to an unmapped address.  (Note that prior to checkpoint, DMTCP sets this environment variable to the string "0" if the environment variable had not been set.  But the pointer to the string "0" is being corrupted when the plugin tries to test for it during restart.)

Therefore, the current code has commented out the test for `"DMTCP_QUIET"`.