### PR TITLE
Added support for non-blocking connect.

### DIFF
--- a/src/plugin/ipc/ipc.h
+++ b/src/plugin/ipc/ipc.h
@@ -36,10 +36,6 @@
 #define DRAINER_CHECK_FREQ 0.1
 #define DRAINER_WARNING_FREQ 10
 
-//at least one of these must be enabled:
-#define HANDSHAKE_ON_CONNECT    0
-#define HANDSHAKE_ON_CHECKPOINT 1
-
 #define _real_socket NEXT_FNC(socket)
 #define _real_bind NEXT_FNC(bind)
 #define _real_close NEXT_FNC(close)

--- a/src/plugin/ipc/socket/socketconnection.h
+++ b/src/plugin/ipc/socket/socketconnection.h
@@ -77,6 +77,7 @@ namespace dmtcp
         TCP_LISTEN,
         TCP_ACCEPT,
         TCP_CONNECT,
+        TCP_CONNECT_IN_PROGRESS,
         TCP_PREEXISTING,
         TCP_EXTERNAL_CONNECT
       };
@@ -93,7 +94,8 @@ namespace dmtcp
       void onBind(const struct sockaddr* addr, socklen_t len);
       void onListen(int backlog);
       void onConnect(const struct sockaddr *serv_addr = NULL,
-                     socklen_t addrlen = 0);
+                     socklen_t addrlen = 0,
+                     bool connectInProgress = false);
       /*onAccept*/
       TcpConnection(const TcpConnection& parent,
                     const ConnectionIdentifier& remote);

--- a/src/plugin/ipc/socket/socketconnlist.cpp
+++ b/src/plugin/ipc/socket/socketconnlist.cpp
@@ -66,7 +66,6 @@ void SocketConnList::drain()
 
 void SocketConnList::preCkpt()
 {
-#if HANDSHAKE_ON_CHECKPOINT == 1
   //handshake is done after one barrier after drain
   JTRACE("beginning handshakes");
   DmtcpUniqueProcessId coordId = dmtcp_get_coord_id();
@@ -87,7 +86,6 @@ void SocketConnList::preCkpt()
     }
   }
   JTRACE("handshaking done");
-#endif
   _hasIPv4Sock = _hasIPv6Sock = _hasUNIXSock = false;
   // Now check if we have IPv4, IPv6, or UNIX domain sockets to restore.
   for (iterator i = begin(); i != end(); ++i) {

--- a/src/plugin/ipc/socket/socketwrappers.cpp
+++ b/src/plugin/ipc/socket/socketwrappers.cpp
@@ -74,54 +74,21 @@ extern "C" int connect(int sockfd, const struct sockaddr *serv_addr,
                        socklen_t addrlen)
 {
   DMTCP_PLUGIN_DISABLE_CKPT(); // The lock is released inside the macro.
+
   int ret = _real_connect(sockfd,serv_addr,addrlen);
-
-  //no blocking connect... need to hang around until it is writable
-  if (ret < 0 && errno == EINPROGRESS)
-  {
-    fd_set wfds;
-    struct timeval tv;
-    int retval;
-
-    FD_ZERO(&wfds);
-    FD_SET(sockfd, &wfds);
-
-    tv.tv_sec = 15;
-    tv.tv_usec = 0;
-
-    retval = select(sockfd+1, NULL, &wfds, NULL, &tv);
-    /* Don't rely on the value of tv now! */
-
-    if (retval == -1)
-      perror("select()");
-    else if (FD_ISSET(sockfd, &wfds))
-    {
-      int val = -1;
-      socklen_t sz = sizeof(val);
-      getsockopt(sockfd,SOL_SOCKET,SO_ERROR,&val,&sz);
-      if (val==0) ret = 0;
-    }
-    else
-      JTRACE("No data within 15 seconds.");
-  }
-
-  if (ret != -1 && dmtcp_is_running_state() && !_doNotProcessSockets) {
+  if ((ret != -1 || errno == EINPROGRESS) &&
+      dmtcp_is_running_state() &&
+      !_doNotProcessSockets) {
     TcpConnection *con =
       (TcpConnection*) SocketConnList::instance().getConnection(sockfd);
     if (con == NULL) {
       JTRACE("Connect operation on unsupported socket type.");
     } else {
-      con->onConnect(serv_addr, addrlen);
-
-#if HANDSHAKE_ON_CONNECT == 1
-      JTRACE("connected, sending 1-way handshake") (sockfd) (con->id());
-      con->sendHandshake(sockfd, DmtcpWorker::instance().coordinatorId());
-      JTRACE("1-way handshake sent");
-#else
+      con->onConnect(serv_addr, addrlen, (ret == -1 && errno == EINPROGRESS));
       JTRACE("connected") (sockfd) (con->id());
-#endif
     }
   }
+
   DMTCP_PLUGIN_ENABLE_CKPT();
   return ret;
 }
@@ -180,13 +147,7 @@ static void process_accept(int ret, int sockfd, struct sockaddr *addr,
   }
   SocketConnList::instance().add(ret, con);
 
-#if HANDSHAKE_ON_CONNECT == 1
-  JTRACE("accepted, waiting for 1-way handshake") (sockfd) (con->id());
-  con->recvHandshake(ret, DmtcpWorker::instance().coordinatorId());
-  JTRACE("1-way handshake received") (con->getRemoteId());
-#else
   JTRACE("accepted incoming connection") (sockfd) (con->id());
-#endif
 }
 
 extern "C" int accept(int sockfd, struct sockaddr *addr,


### PR DESCRIPTION
Added a new TCP type, TCP_CONNECT_IN_PROGRESS, that indicates a
non-blocking connect. During drain, we call select() to check whether
the socket is writable or not. If it's still not writable after 60
seconds, we mark the socket as external and continue.