### PR TITLE
Support for rsh command in dmtcp package. 

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -114,12 +114,14 @@
 #define LIBDL_BASE_FUNC_STR "dlinfo"
 #define ENV_VAR_DLSYM_OFFSET "DMTCP_DLSYM_OFFSET"
 #define ENV_VAR_DLSYM_OFFSET_M32 "DMTCP_DLSYM_OFFSET_M32"
+#define ENV_VAR_REMOTE_SHELL_CMD "DMTCP_REMOTE_SHELL_CMD"
 
 //this list should be kept up to date with all "protected" environment vars
 #define ENV_VARS_ALL \
     ENV_VAR_NAME_HOST,\
     ENV_VAR_NAME_PORT,\
     ENV_VAR_CKPT_INTR,\
+    ENV_VAR_REMOTE_SHELL_CMD,\
     ENV_VAR_ORIG_LD_PRELOAD,\
     ENV_VAR_HIJACK_LIBS,\
     ENV_VAR_HIJACK_LIBS_M32,\

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -665,18 +665,18 @@ void CoordinatorAPI::sendCkptFilename()
     msg.type = DMT_CKPT_FILENAME;
   }
   // Tell coordinator type of remote shell command used ssh/rsh
-  string shellType("");
+  const char* shellType = "";
   const char *remoteShellType = getenv(ENV_VAR_REMOTE_SHELL_CMD);
   if(remoteShellType != NULL) {
     shellType = remoteShellType;
   }
 
   JTRACE("recording filenames") (ckptFilename) (hostname) (shellType);
-  msg.extraBytes = ckptFilename.length() + 1 + hostname.length() + 1+ shellType.length() + 1;
+  msg.extraBytes = ckptFilename.length() + 1 + hostname.length() + 1+ strlen(shellType) + 1;
  
   _coordinatorSocket << msg;
   _coordinatorSocket.writeAll(ckptFilename.c_str(), ckptFilename.length() + 1);
-  _coordinatorSocket.writeAll(shellType.c_str(), shellType.length() + 1);
+  _coordinatorSocket.writeAll(shellType, strlen(shellType) + 1);
   _coordinatorSocket.writeAll(hostname.c_str(), hostname.length() + 1);
 }
 

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -658,16 +658,25 @@ void CoordinatorAPI::sendCkptFilename()
   // Tell coordinator to record our filename in the restart script
   string ckptFilename = ProcessInfo::instance().getCkptFilename();
   string hostname = jalib::Filesystem::GetCurrentHostname();
-  JTRACE("recording filenames") (ckptFilename) (hostname);
   DmtcpMessage msg;
   if (dmtcp_unique_ckpt_enabled && dmtcp_unique_ckpt_enabled()) {
     msg.type = DMT_UNIQUE_CKPT_FILENAME;
   } else {
     msg.type = DMT_CKPT_FILENAME;
   }
-  msg.extraBytes = ckptFilename.length() + 1 + hostname.length() + 1;
+  // Tell coordinator type of remote shell command used ssh/rsh
+  string shellType("");
+  const char *remoteShellType = getenv(ENV_VAR_REMOTE_SHELL_CMD);
+  if(remoteShellType != NULL) {
+    shellType = remoteShellType;
+  }
+
+  JTRACE("recording filenames") (ckptFilename) (hostname) (shellType);
+  msg.extraBytes = ckptFilename.length() + 1 + hostname.length() + 1+ shellType.length() + 1;
+ 
   _coordinatorSocket << msg;
   _coordinatorSocket.writeAll(ckptFilename.c_str(), ckptFilename.length() + 1);
+  _coordinatorSocket.writeAll(shellType.c_str(), shellType.length() + 1);
   _coordinatorSocket.writeAll(hostname.c_str(), hostname.length() + 1);
 }
 

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -552,13 +552,13 @@ void DmtcpCoordinator::onData(CoordClient *client)
       hostname = extraData + shellType.length() + 1 + ckptFilename.length() + 1;
 
       JTRACE ( "recording restart info with shellType" ) ( ckptFilename ) ( hostname ) (shellType);
-      if(shellType.empty())
+      if(shellType.empty()) {
         _restartFilenames[hostname].push_back ( ckptFilename );
-      else if(shellType == "rsh")
+      } else if(shellType == "rsh") {
         _rshCmdFileNames[hostname].push_back( ckptFilename );
-      else if(shellType == "ssh")
+      } else if(shellType == "ssh") {
         _sshCmdFileNames[hostname].push_back( ckptFilename );
-      else {
+      } else {
         JASSERT(0)(shellType)
           .Text("Shell command not supported. Report this to DMTCP community.");
       }

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -418,7 +418,9 @@ void DmtcpCoordinator::updateMinimumState(WorkerState oldState)
                                theCheckpointInterval,
                                thePort,
                                compId,
-                               _restartFilenames);
+                               _restartFilenames,
+                               _rshCmdFileNames,
+                               _sshCmdFileNames);
 
     if (exitAfterCkpt || exitAfterCkptOnce) {
       JNOTE("Checkpoint Done. Killing all peers.");
@@ -543,11 +545,23 @@ void DmtcpCoordinator::onData(CoordClient *client)
         .Text ( "extra data expected with DMT_CKPT_FILENAME message" );
       string ckptFilename;
       string hostname;
-      ckptFilename = extraData;
-      hostname = extraData + ckptFilename.length() + 1;
+      string shellType;
 
-      JTRACE ( "recording restart info" ) ( ckptFilename ) ( hostname );
-      _restartFilenames[hostname].push_back ( ckptFilename );
+      ckptFilename = extraData;
+      shellType = extraData + ckptFilename.length() + 1;
+      hostname = extraData + shellType.length() + 1 + ckptFilename.length() + 1;
+
+      JTRACE ( "recording restart info with shellType" ) ( ckptFilename ) ( hostname ) (shellType);
+      if(shellType.empty())
+        _restartFilenames[hostname].push_back ( ckptFilename );
+      else if(shellType == "rsh")
+        _rshCmdFileNames[hostname].push_back( ckptFilename );
+      else if(shellType == "ssh")
+        _sshCmdFileNames[hostname].push_back( ckptFilename );
+      else {
+        JASSERT(0)(shellType)
+          .Text("Shell command not supported. Report this to DMTCP community.");
+      }
     }
     break;
     case DMT_GET_CKPT_DIR:
@@ -1030,6 +1044,8 @@ bool DmtcpCoordinator::startCheckpoint()
     time(&ckptTimeStamp);
     JTIMER_START ( checkpoint );
     _restartFilenames.clear();
+    _rshCmdFileNames.clear();
+    _sshCmdFileNames.clear();
     JNOTE ( "starting checkpoint, suspending all nodes" )( s.numPeers );
     compId.incrementGeneration();
     JNOTE("Incremented computationGeneration") (compId.computationGeneration());

--- a/src/dmtcp_coordinator.h
+++ b/src/dmtcp_coordinator.h
@@ -114,6 +114,11 @@ namespace dmtcp
     protected:
       void writeRestartScript();
     private:
+
+      // Store whether rsh/ssh was used
+      map< string, vector<string> > _rshCmdFileNames;
+      map< string, vector<string> > _sshCmdFileNames;
+
       //map from hostname to checkpoint files
       map< string, vector<string> > _restartFilenames;
       map< pid_t, CoordClient* > _virtualPidToClientMap;

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -290,6 +290,7 @@ DmtcpWorker::DmtcpWorker()
           programName != "dmtcp_comand"       &&
           programName != "dmtcp_restart"      &&
           programName != "mtcp_restart"       &&
+          programName != "rsh"                &&
           programName != "ssh")
     (programName) .Text("This program should not be run under ckpt control");
 

--- a/src/execwrappers.cpp
+++ b/src/execwrappers.cpp
@@ -97,7 +97,7 @@ static bool isBlacklistedProgram(const char *path)
   }
 
   if (programName == "dmtcp_nocheckpoint" || programName == "dmtcp_command" ||
-      programName == "ssh") {
+      programName == "ssh" || programName == "rsh" ) {
     return true;
   }
   return false;

--- a/src/plugin/ipc/ssh/dmtcp_ssh.cpp
+++ b/src/plugin/ipc/ssh/dmtcp_ssh.cpp
@@ -146,16 +146,14 @@ int main(int argc, char *argv[], char *envp[])
    */
 
   shift;
-  while(true) {
+  while (true) {
     if ( strcmp(argv[0], "--noStrictHostKeyChecking") == 0 ) {
       noStrictHostKeyChecking = 1;
       shift;
-    }
-    else if ( strcmp(argv[0], "--rsh-slave") == 0 ) {
+    } else if ( strcmp(argv[0], "--rsh-slave") == 0 ) {
       isRshProcess = 1;
       shift;
-    }
-    else if ( strcmp(argv[0], "--ssh-slave")== 0 ) {
+    } else if ( strcmp(argv[0], "--ssh-slave")== 0 ) {
       isRshProcess = 0;
       shift;
     } else {

--- a/src/plugin/ipc/ssh/dmtcp_sshd.cpp
+++ b/src/plugin/ipc/ssh/dmtcp_sshd.cpp
@@ -109,26 +109,22 @@ int main(int argc, char *argv[], char *envp[])
   }
 
   shift;
-  while(true) { 
+  while (true) { 
     if ( argc > 1 && (strcmp(argv[0], "--listenAddr") == 0)) {
       dummySshdProcess(argv[1]);
       shift; shift;
       printf("ERROR: Not Implemented\n");
       assert(0);
-    }
-    else if ( argc > 1 && (strcmp(argv[0],"--host") == 0)) {
+    } else if ( argc > 1 && (strcmp(argv[0],"--host") == 0)) {
       host = argv[1];
       shift; shift;
-    }
-    else if ( argc > 1 && (strcmp(argv[0], "--port") == 0)) {
+    } else if ( argc > 1 && (strcmp(argv[0], "--port") == 0)) {
       port = atoi(argv[1]);
       shift; shift;
-    }
-    else if ( strcmp(argv[0], "--rsh-slave") == 0) {
+    } else if ( strcmp(argv[0], "--rsh-slave") == 0) {
       isRshProcess = 1;
       shift;
-    }
-    else if ( strcmp(argv[0], "--ssh-slave") == 0) {
+    } else if ( strcmp(argv[0], "--ssh-slave") == 0) {
       isRshProcess = 0;
       shift;
     } else {
@@ -155,10 +151,12 @@ int main(int argc, char *argv[], char *envp[])
    * dummy daemon which will launched by the same command. 
    */
 
-  if(isRshProcess)
+  if(isRshProcess) {
     setenv(ENV_VAR_REMOTE_SHELL_CMD, "rsh", 1);
-  else
+  }
+  else {
     setenv(ENV_VAR_REMOTE_SHELL_CMD, "ssh", 1);
+  }
 
   childPid = fork();
   if (childPid == 0) {

--- a/src/plugin/ipc/ssh/dmtcp_sshd.cpp
+++ b/src/plugin/ipc/ssh/dmtcp_sshd.cpp
@@ -11,12 +11,14 @@
 #include <assert.h>
 #include <string.h>
 #include "ssh.h"
+#include "util.h"
 #include "util_ipc.h"
 
 using dmtcp::Util::sendFd;
 
 static pid_t childPid = -1;
 static int remotePeerSock = -1;
+static int isRshProcess = 0; 
 
 // Connect to dmtcp_ssh process
 static void connectToRemotePeer(char *host, int port)
@@ -92,6 +94,9 @@ static void dummySshdProcess(char *listenAddr)
   exit(0);
 }
 
+//shift args
+#define shift argc--,argv++
+
 int main(int argc, char *argv[], char *envp[])
 {
   int in[2], out[2], err[2];
@@ -103,23 +108,33 @@ int main(int argc, char *argv[], char *envp[])
     exit(1);
   }
 
-  if (strcmp(argv[1], "--listenAddr") == 0) {
-    dummySshdProcess(argv[2]);
-    printf("ERROR: Not Implemented\n");
-    assert(0);
+  shift;
+  while(true) { 
+    if ( argc > 1 && (strcmp(argv[0], "--listenAddr") == 0)) {
+      dummySshdProcess(argv[1]);
+      shift; shift;
+      printf("ERROR: Not Implemented\n");
+      assert(0);
+    }
+    else if ( argc > 1 && (strcmp(argv[0],"--host") == 0)) {
+      host = argv[1];
+      shift; shift;
+    }
+    else if ( argc > 1 && (strcmp(argv[0], "--port") == 0)) {
+      port = atoi(argv[1]);
+      shift; shift;
+    }
+    else if ( strcmp(argv[0], "--rsh-slave") == 0) {
+      isRshProcess = 1;
+      shift;
+    }
+    else if ( strcmp(argv[0], "--ssh-slave") == 0) {
+      isRshProcess = 0;
+      shift;
+    } else {
+      break;
+    }
   }
-
-  if (strcmp(argv[1], "--host") != 0) {
-    printf("Missing --host argument");
-    assert(0);
-  }
-  host = argv[2];
-
-  if (strcmp(argv[3], "--port") != 0) {
-    printf("Missing --port argument");
-    exit(0);
-  }
-  port = atoi(argv[4]);
 
   connectToRemotePeer(host, port);
 
@@ -132,6 +147,18 @@ int main(int argc, char *argv[], char *envp[])
   if (pipe(err) != 0) {
     perror("Error creating pipe: ");
   }
+
+  /* Checkpoint database should have information about which command rsh/ssh
+   * lauched the daemon orginally on remote host. This information is required
+   * at 2 places, first in restart script which will launch the user process/
+   * dmtcp_sshd on remote host using the same command. Secondly launching
+   * dummy daemon which will launched by the same command. 
+   */
+
+  if(isRshProcess)
+    setenv(ENV_VAR_REMOTE_SHELL_CMD, "rsh", 1);
+  else
+    setenv(ENV_VAR_REMOTE_SHELL_CMD, "ssh", 1);
 
   childPid = fork();
   if (childPid == 0) {
@@ -146,7 +173,7 @@ int main(int argc, char *argv[], char *envp[])
     close(out[1]);
     close(err[1]);
 
-    execvp(argv[5], &argv[5]);
+    execvp(argv[0], &argv[0]);
     printf("%s:%d DMTCP Error detected. Failed to exec.", __FILE__, __LINE__);
     abort();
   }
@@ -161,7 +188,7 @@ int main(int argc, char *argv[], char *envp[])
 
   assert(dmtcp_ssh_register_fds);
   dmtcp_ssh_register_fds(true, child_stdinfd, child_stdoutfd, child_stderrfd,
-                         remotePeerSock, 0);
+                         remotePeerSock, 0, isRshProcess);
 
   client_loop(child_stdinfd, child_stdoutfd, child_stderrfd, remotePeerSock);
   int status;

--- a/src/plugin/ipc/ssh/dmtcp_sshd.cpp
+++ b/src/plugin/ipc/ssh/dmtcp_sshd.cpp
@@ -153,8 +153,7 @@ int main(int argc, char *argv[], char *envp[])
 
   if(isRshProcess) {
     setenv(ENV_VAR_REMOTE_SHELL_CMD, "rsh", 1);
-  }
-  else {
+  } else {
     setenv(ENV_VAR_REMOTE_SHELL_CMD, "ssh", 1);
   }
 

--- a/src/plugin/ipc/ssh/ssh.cpp
+++ b/src/plugin/ipc/ssh/ssh.cpp
@@ -185,8 +185,7 @@ static void createNewDmtcpSshdProcess()
 
     if(isRshProcess) {
       shellType = "rsh";
-    }
-    else {
+    } else {
       shellType = "ssh";
     }
 
@@ -334,8 +333,7 @@ static void prepareForExec(char *const argv[], char ***newArgv)
 
   if(isRshProcess) {
     prefix += " --rsh-slave ";
-  }
-  else {
+  } else {
     prefix += " --ssh-slave ";
   }
 
@@ -376,8 +374,7 @@ static void prepareForExec(char *const argv[], char ***newArgv)
   }
   if(isRshProcess) {
     new_argv[idx++] = const_cast<char*>("--rsh-slave");
-  }
-  else {
+  } else {
     new_argv[idx++] = const_cast<char*>("--ssh-slave");
   }
 
@@ -403,8 +400,7 @@ static void prepareForExec(char *const argv[], char ***newArgv)
   }
   if(isRshProcess) { 
     JNOTE("New rsh command") (newCommand);
-  }
-  else {
+  } else {
     JNOTE("New ssh command") (newCommand);
   }
   *newArgv = new_argv;

--- a/src/plugin/ipc/ssh/ssh.cpp
+++ b/src/plugin/ipc/ssh/ssh.cpp
@@ -183,10 +183,12 @@ static void createNewDmtcpSshdProcess()
 
     const char* shellType = NULL;
 
-    if(isRshProcess)
+    if(isRshProcess) {
       shellType = "rsh";
-    else
+    }
+    else {
       shellType = "ssh";
+    }
 
     argv[idx++] = const_cast<char*>(shellType);
 
@@ -330,10 +332,12 @@ static void prepareForExec(char *const argv[], char ***newArgv)
   }
   prefix += dmtcp_sshd_path + " ";
 
-  if(isRshProcess)
+  if(isRshProcess) {
     prefix += " --rsh-slave ";
-  else
+  }
+  else {
     prefix += " --ssh-slave ";
+  }
 
   JTRACE("Prefix")(prefix);
 
@@ -370,10 +374,12 @@ static void prepareForExec(char *const argv[], char ***newArgv)
   if (noStrictChecking) {
     new_argv[idx++] = const_cast<char*>("--noStrictHostKeyChecking");
   }
-  if(isRshProcess)
+  if(isRshProcess) {
     new_argv[idx++] = const_cast<char*>("--rsh-slave");
-  else
+  }
+  else {
     new_argv[idx++] = const_cast<char*>("--ssh-slave");
+  }
 
   new_argv[idx++] = (char*) dmtcp_nocheckpoint_path.c_str();
 
@@ -395,10 +401,12 @@ static void prepareForExec(char *const argv[], char ***newArgv)
       newCommand += ' ';
     }
   }
-  if(isRshProcess) 
+  if(isRshProcess) { 
     JNOTE("New rsh command") (newCommand);
-  else
+  }
+  else {
     JNOTE("New ssh command") (newCommand);
+  }
   *newArgv = new_argv;
   return;
 }
@@ -470,8 +478,9 @@ extern "C" int execve (const char *filename, char *const argv[],
     return _real_execve(filename, argv, envp);
   }
 
- if(jalib::Filesystem::BaseName(filename) == "rsh")
+ if(jalib::Filesystem::BaseName(filename) == "rsh") {
    isRshProcess = 1;
+ }
 
   updateCoordHost();
 
@@ -489,8 +498,9 @@ extern "C" int execvp (const char *filename, char *const argv[])
     return _real_execvp(filename, argv);
   }
 
- if(jalib::Filesystem::BaseName(filename) == "rsh")
+ if(jalib::Filesystem::BaseName(filename) == "rsh") {
    isRshProcess = 1;
+ }
 
   updateCoordHost();
 
@@ -510,8 +520,9 @@ extern "C" int execvpe (const char *filename, char *const argv[],
     return _real_execvpe(filename, argv, envp);
   }
 
- if(jalib::Filesystem::BaseName(filename) == "rsh") 
+ if(jalib::Filesystem::BaseName(filename) == "rsh") { 
    isRshProcess = 1;
+ }
 
   updateCoordHost();
 

--- a/src/plugin/ipc/ssh/ssh.cpp
+++ b/src/plugin/ipc/ssh/ssh.cpp
@@ -31,6 +31,7 @@ static int sshStderr = -1;
 static int sshSockFd = -1;
 static bool isSshdProcess = false;
 static int noStrictHostKeyChecking = 0;
+static int isRshProcess = 0 ;
 
 static bool sshPluginEnabled = false;
 
@@ -166,6 +167,7 @@ static void createNewDmtcpSshdProcess()
     dmtcp_sshd_path = Util::getPath("dmtcp_sshd");
   }
 
+    
   JASSERT(pipe(in) == 0) (JASSERT_ERRNO);
   JASSERT(pipe(out) == 0) (JASSERT_ERRNO);
   JASSERT(pipe(err) == 0) (JASSERT_ERRNO);
@@ -178,7 +180,16 @@ static void createNewDmtcpSshdProcess()
     int idx = 0;
 
     argv[idx++] = (char*) dmtcp_nocheckpoint_path.c_str();
-    argv[idx++] = const_cast<char*>("ssh");
+
+    const char* shellType = NULL;
+
+    if(isRshProcess)
+      shellType = "rsh";
+    else
+      shellType = "ssh";
+
+    argv[idx++] = const_cast<char*>(shellType);
+
     if (noStrictHostKeyChecking) {
       argv[idx++] = const_cast<char*>("-o");
       argv[idx++] = const_cast<char*>("StrictHostKeyChecking=no");
@@ -226,7 +237,7 @@ static void createNewDmtcpSshdProcess()
 }
 
 extern "C" void dmtcp_ssh_register_fds(int isSshd, int in, int out, int err,
-                                       int sock, int noStrictChecking)
+                                       int sock, int noStrictChecking, int rshProcess)
 {
   if (isSshd) { // dmtcp_sshd
     process_fd_event(SYS_close, STDIN_FILENO);
@@ -236,6 +247,7 @@ extern "C" void dmtcp_ssh_register_fds(int isSshd, int in, int out, int err,
     process_fd_event(SYS_close, in);
     process_fd_event(SYS_close, out);
     process_fd_event(SYS_close, err);
+    isRshProcess = rshProcess;
   }
   sshStdin = in;
   sshStdout = out;
@@ -254,9 +266,15 @@ static void prepareForExec(char *const argv[], char ***newArgv)
   while (argv[nargs++] != NULL);
 
   if (nargs < 3) {
+    if(!isRshProcess) {
     JNOTE("ssh with less than 3 args") (argv[0]) (argv[1]);
     *newArgv = (char**) argv;
     return;
+    } else if(nargs < 2) {
+        JNOTE("rsh with less than 2 args") (argv[0]);
+        *newArgv = (char**) argv;
+        return;
+      }
   }
 
   //find command part
@@ -311,6 +329,12 @@ static void prepareForExec(char *const argv[], char ***newArgv)
     prefix += dmtcp_args[i] + " ";
   }
   prefix += dmtcp_sshd_path + " ";
+
+  if(isRshProcess)
+    prefix += " --rsh-slave ";
+  else
+    prefix += " --ssh-slave ";
+
   JTRACE("Prefix")(prefix);
 
   // process command
@@ -338,17 +362,22 @@ static void prepareForExec(char *const argv[], char ***newArgv)
   }
 
   //now repack args
-  char** new_argv = (char**) JALLOC_HELPER_MALLOC(sizeof(char*) * (nargs + 10));
-  memset(new_argv, 0, sizeof(char*) * (nargs + 10));
+  char** new_argv = (char**) JALLOC_HELPER_MALLOC(sizeof(char*) * (nargs + 11));
+  memset(new_argv, 0, sizeof(char*) * (nargs + 11));
 
   size_t idx = 0;
   new_argv[idx++] = (char*) dmtcp_ssh_path.c_str();
   if (noStrictChecking) {
     new_argv[idx++] = const_cast<char*>("--noStrictHostKeyChecking");
   }
+  if(isRshProcess)
+    new_argv[idx++] = const_cast<char*>("--rsh-slave");
+  else
+    new_argv[idx++] = const_cast<char*>("--ssh-slave");
+
   new_argv[idx++] = (char*) dmtcp_nocheckpoint_path.c_str();
 
-  string newCommand = string(new_argv[0]) + " " + string(new_argv[1]) + " ";
+  string newCommand = string(new_argv[0]) + " " + string(new_argv[1]) + " " + string(new_argv[2]) + " ";
   for (size_t i = 0; i < commandStart; ++i) {
     new_argv[idx++] = ( char* ) argv[i];
     if (argv[i] != NULL) {
@@ -366,7 +395,10 @@ static void prepareForExec(char *const argv[], char ***newArgv)
       newCommand += ' ';
     }
   }
-  JNOTE("New ssh command") (newCommand);
+  if(isRshProcess) 
+    JNOTE("New rsh command") (newCommand);
+  else
+    JNOTE("New ssh command") (newCommand);
   *newArgv = new_argv;
   return;
 }
@@ -433,9 +465,13 @@ static void updateCoordHost() {
 extern "C" int execve (const char *filename, char *const argv[],
                        char *const envp[])
 {
-  if (jalib::Filesystem::BaseName(filename) != "ssh") {
+  if ((jalib::Filesystem::BaseName(filename) != "ssh") && 
+      (jalib::Filesystem::BaseName(filename) != "rsh")) {
     return _real_execve(filename, argv, envp);
   }
+
+ if(jalib::Filesystem::BaseName(filename) == "rsh")
+   isRshProcess = 1;
 
   updateCoordHost();
 
@@ -448,9 +484,13 @@ extern "C" int execve (const char *filename, char *const argv[],
 
 extern "C" int execvp (const char *filename, char *const argv[])
 {
-  if (jalib::Filesystem::BaseName(filename) != "ssh") {
+  if ((jalib::Filesystem::BaseName(filename) != "ssh") && 
+      (jalib::Filesystem::BaseName(filename) != "rsh")) {
     return _real_execvp(filename, argv);
   }
+
+ if(jalib::Filesystem::BaseName(filename) == "rsh")
+   isRshProcess = 1;
 
   updateCoordHost();
 
@@ -465,9 +505,13 @@ extern "C" int execvp (const char *filename, char *const argv[])
 extern "C" int execvpe (const char *filename, char *const argv[],
                          char *const envp[])
 {
-  if (jalib::Filesystem::BaseName(filename) != "ssh") {
+  if ((jalib::Filesystem::BaseName(filename) != "ssh") && 
+      (jalib::Filesystem::BaseName(filename) != "rsh")) {
     return _real_execvpe(filename, argv, envp);
   }
+
+ if(jalib::Filesystem::BaseName(filename) == "rsh") 
+   isRshProcess = 1;
 
   updateCoordHost();
 

--- a/src/plugin/ipc/ssh/ssh.h
+++ b/src/plugin/ipc/ssh/ssh.h
@@ -10,10 +10,12 @@
 #define _real_execvpe NEXT_FNC(execvpe)
 
 #define SSHD_BINARY "dmtcp_sshd"
+#define RSH_BINARY "rsh"
 #define SSHD_RECEIVE_FD 100
 
 extern "C" void dmtcp_ssh_register_fds(int isSshd, int in, int out, int err,
-                                       int sock, int noStrictHostKeyChecking)
+                                       int sock, int noStrictHostKeyChecking,
+                                       int rshProcess)
   __attribute((weak));
 
 void client_loop(int ssh_stdin, int ssh_stdout, int ssh_stderr, int remoteSock);

--- a/src/restartscript.cpp
+++ b/src/restartscript.cpp
@@ -226,7 +226,7 @@ static const char* singleHostProcessing =
 
 static const char* multiHostProcessing =
   "worker_ckpts_regexp=\\\n"
-  "\'[^:]*::[ \\t\\n]*\\([^ \\t\\n]\\+\\)[ \\t\\n]*:\\([a-z]\\+\\):[ \\t\\n]*\\([^:]\\+\\)\'\n\n"
+  "\'[^:]*::[ \\t\\n]*\\([^ \\t\\n]\\+\\)[ \\t\\n]*:\\([a-z]\\+\\):[ \\t\\n]*\\([^:]\\+\\)[ \\t\\n]*:\\([^:]\\+\\)\'\n\n"
 
   "worker_hosts=$(\\\n"
   "  echo $worker_ckpts | sed -e \'s/\'\"$worker_ckpts_regexp\"\'/\\1 /g\')\n"
@@ -234,6 +234,8 @@ static const char* multiHostProcessing =
   "  echo $worker_ckpts | sed -e \'s/\'\"$worker_ckpts_regexp\"\'/: \\2/g\')\n"
   "ckpt_files_groups=$(\\\n"
   "  echo $worker_ckpts | sed -e \'s/\'\"$worker_ckpts_regexp\"\'/: \\3/g\')\n"
+  "remote_cmd=$(\\\n"
+  "  echo $worker_ckpts | sed -e \'s/\'\"$worker_ckpts_regexp\"\'/: \\4/g\')\n"
   "\n"
   "if [ ! -z \"$hostfile\" ]; then\n"
   "  worker_hosts=$(\\\n"
@@ -257,6 +259,8 @@ static const char* multiHostProcessing =
   "\n"
   "  mode=$(echo $restart_modes | sed -e \'s/[^:]*:[ \\t\\n]*\\([^:]*\\).*/\\1/\')\n"
   "  restart_modes=$(echo $restart_modes | sed -e \'s/[^:]*:[^:]*//\')\n\n"
+  "  remote_shell_cmd=$(echo $remote_cmd | sed -e \'s/[^:]*:[ \\t\\n]*\\([^:]*\\).*/\\1/\')\n"
+  "  remote_cmd=$(echo $remote_cmd | sed -e \'s/[^:]*:[^:]*//\')\n\n"
   "  maybexterm=\n"
   "  maybebg=\n"
   "  case $mode in\n"
@@ -285,18 +289,18 @@ static const char* multiHostProcessing =
 
   "  check_local $worker_host\n"
   "  if [ \"$is_local_node\" -eq 1 -o \"$num_worker_hosts\" == \"1\" ]; then\n"
-  "    localhost_ckpt_files_group=\"$new_ckpt_files_group\"\n"
+  "    localhost_ckpt_files_group=\"$new_ckpt_files_group $localhost_ckpt_files_group\"\n"
   "    continue\n"
   "  fi\n"
 
   "  if [ -z $maybebg ]; then\n"
-  "    $maybexterm /usr/bin/ssh -t \"$worker_host\" \\\n"
+  "    $maybexterm /usr/bin/$remote_shell_cmd -t \"$worker_host\" \\\n"
   "      $dmt_rstr_cmd --coord-host \"$coord_host\""
                                              " --cord-port \"$coord_port\"\\\n"
   "      $ckpt_dir --join --interval \"$checkpoint_interval\" $tmpdir \\\n"
   "      $new_ckpt_files_group\n"
   "  else\n"
-  "    $maybexterm /usr/bin/ssh \"$worker_host\" \\\n"
+  "    $maybexterm /usr/bin/$remote_shell_cmd \"$worker_host\" \\\n"
   // In Open MPI 1.4, without this (sh -c ...), orterun hangs at the
   // end of the computation until user presses enter key.
   "      \"/bin/sh -c \'$dmt_rstr_cmd --coord-host $coord_host"
@@ -321,7 +325,9 @@ void writeScript(const string& ckptDir,
                  const uint32_t theCheckpointInterval,
                  const int thePort,
                  const UniquePid& compId,
-                 const map<string, vector<string> >& restartFilenames)
+                 const map<string, vector<string> >& restartFilenames,
+                 const map<string, vector<string> >& rshCmdFileNames,
+                 const map<string, vector<string> >& sshCmdFileNames)
 {
   ostringstream o;
   string uniqueFilename;
@@ -334,16 +340,27 @@ void writeScript(const string& ckptDir,
   o << "." << RESTART_SCRIPT_EXT;
   uniqueFilename = o.str();
 
-  const bool isSingleHost = (restartFilenames.size() == 1);
+  const bool isSingleHost = ((rshCmdFileNames.size() == 0) && (sshCmdFileNames.size() == 0) && (restartFilenames.size() == 1));
 
   map< string, vector<string> >::const_iterator host;
 
-  size_t numPeers;
+  size_t numPeers = 0;
   for (host = restartFilenames.begin();
        host != restartFilenames.end();
        host++) {
     numPeers += host->second.size();
   }
+  for (host = rshCmdFileNames.begin();
+       host != rshCmdFileNames.end();
+       host++) {
+    numPeers += host->second.size();
+  }
+  for (host = sshCmdFileNames.begin();
+       host != sshCmdFileNames.end();
+       host++) {
+    numPeers += host->second.size();
+  }
+
 
   vector<string>::const_iterator file;
 
@@ -366,6 +383,8 @@ void writeScript(const string& ckptDir,
   // Remove the trailing '\n'
   timestamp[strlen(timestamp) - 1] = '\0';
   fprintf ( fp, "ckpt_timestamp=\"%s\"\n\n", timestamp );
+
+  fprintf ( fp, "remote_shell_cmd=\"ssh\"\n\n");
 
   fprintf ( fp, "coord_host=$" ENV_VAR_NAME_HOST "\n"
                 "if test -z \"$" ENV_VAR_NAME_HOST "\"; then\n"
@@ -391,7 +410,8 @@ void writeScript(const string& ckptDir,
 
   fprintf ( fp, "# Number of hosts in the computation = %zu\n"
                 "# Number of processes in the computation = %zu\n\n",
-                restartFilenames.size(), numPeers );
+                (restartFilenames.size() + sshCmdFileNames.size() + rshCmdFileNames.size()), 
+                numPeers );
 
   if ( isSingleHost ) {
     JTRACE ( "Single HOST" );
@@ -409,17 +429,49 @@ void writeScript(const string& ckptDir,
   {
     fprintf ( fp, "%s",
               "# SYNTAX:\n"
-              "#  :: <HOST> :<MODE>: <CHECKPOINT_IMAGE> ...\n"
+              "#  :: <HOST> :<MODE>: <CHECKPOINT_IMAGE> ... :<REMOTE SHELL CMD>\n"
               "# Host names and filenames must not include \':\'\n"
               "# At most one fg (foreground) mode allowed; it must be last.\n"
               "# \'maybexterm\' and \'maybebg\' are set from <MODE>.\n");
 
     fprintf ( fp, "%s", "worker_ckpts=\'" );
+    for ( host=rshCmdFileNames.begin(); host!=rshCmdFileNames.end(); ++host ) {
+      fprintf ( fp, "\n :: %s :bg:", host->first.c_str() );
+      for ( file=host->second.begin(); file!=host->second.end(); ++file ) {
+        fprintf ( fp," %s", file->c_str() );
+      }
+      fprintf (fp, " : rsh");
+    }
+    for ( host=sshCmdFileNames.begin(); host!=sshCmdFileNames.end(); ++host ) {
+      fprintf ( fp, "\n :: %s :bg:", host->first.c_str() );
+      for ( file=host->second.begin(); file!=host->second.end(); ++file ) {
+        fprintf ( fp," %s", file->c_str() );
+      }
+      fprintf (fp, " : ssh");
+    }
+    string defaultShellType;
     for ( host=restartFilenames.begin(); host!=restartFilenames.end(); ++host ) {
       fprintf ( fp, "\n :: %s :bg:", host->first.c_str() );
       for ( file=host->second.begin(); file!=host->second.end(); ++file ) {
         fprintf ( fp," %s", file->c_str() );
       }
+
+      /* 
+       * Process which are launched on local machine without using rsh/ssh
+       * command are part of restartFilenames. So we have to choose default
+       * shell command for them.  Search if some process is launched on local
+       * machine via rsh/ssh command and use that, in case its not found
+       * give preference to ssh if no rsh command is absent.
+       */
+
+      if(sshCmdFileNames.find(host->first) != sshCmdFileNames.end())
+        defaultShellType = "ssh";
+      else if(rshCmdFileNames.find(host->first) != rshCmdFileNames.end())
+        defaultShellType = "rsh";
+      else {
+        defaultShellType = rshCmdFileNames.empty() ? "ssh" : "rsh";
+      }
+      fprintf (fp, " : %s", defaultShellType.c_str());
     }
     fprintf ( fp, "%s", "\n\'\n\n" );
 

--- a/src/restartscript.cpp
+++ b/src/restartscript.cpp
@@ -457,18 +457,18 @@ void writeScript(const string& ckptDir,
       }
 
       /* 
-       * Process which are launched on local machine without using rsh/ssh
-       * command are part of restartFilenames. So we have to choose default
-       * shell command for them.  Search if some process is launched on local
-       * machine via rsh/ssh command and use that, in case its not found
-       * give preference to ssh if no rsh command is absent.
+       * Process which are launched on local machine without using an rsh/ssh
+       * command are part of restartFilenames. So we have to choose the default
+       * shell command for them.  Search if some process is launched on the local
+       * machine via rsh/ssh command and use that. In case it's not found, give
+       * preference to ssh when no rsh command is found.
        */
 
-      if(sshCmdFileNames.find(host->first) != sshCmdFileNames.end())
+      if(sshCmdFileNames.find(host->first) != sshCmdFileNames.end()) {
         defaultShellType = "ssh";
-      else if(rshCmdFileNames.find(host->first) != rshCmdFileNames.end())
+      } else if(rshCmdFileNames.find(host->first) != rshCmdFileNames.end()) {
         defaultShellType = "rsh";
-      else {
+      } else {
         defaultShellType = rshCmdFileNames.empty() ? "ssh" : "rsh";
       }
       fprintf (fp, " : %s", defaultShellType.c_str());

--- a/src/restartscript.h
+++ b/src/restartscript.h
@@ -36,7 +36,9 @@ namespace RestartScript {
                    const uint32_t theCheckpointInterval,
                    const int thePort,
                    const UniquePid& compId,
-                   const map<string, vector<string> >& restartFilenames);
+                   const map<string, vector<string> >& restartFilenames,
+                   const map<string, vector<string> >& rshFilenames,
+                   const map<string, vector<string> >& sshFilenames);
 
 } // namespace dmtcp {
 } // namespace RestartScript {


### PR DESCRIPTION
This enhancement also take cares if both rsh/ssh are simultaneously used for launching processes attached to same coordinator. It maintains information of remote shell command used for each process. This information is stored in checkpoint database as well as restart script maintains list of processes lauched via particular remote shell command.

Architecture is exactly same, its just maintaining bookeeping information for each process shell type.

This was long pending support required for Veloce Integration
