### PR TITLE
Handle conflicting msgrcv type for SLES10

### DIFF
--- a/src/plugin/svipc/sysvipcwrappers.cpp
+++ b/src/plugin/svipc/sysvipcwrappers.cpp
@@ -26,6 +26,7 @@
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include <stdarg.h>
+#include <sys/msg.h>
 
 #undef msgrcv
 


### PR DESCRIPTION
This one-line fix should be trivial to review.

A DMTCP user had reported that in Fall, 2015.  This fix was buried in the larger PR #238, but this fix should be added to DMTCP-2.4.5.  So, I'm separating this out as a separate PR.