### PR TITLE
Fix Makefile for prev commit:  3a53d4f676ed

### DIFF
--- a/plugin/Makefile.am
+++ b/plugin/Makefile.am
@@ -83,7 +83,7 @@ dist_bin_SCRIPTS += batch-queue/dmtcp_rm_loclaunch
 #
 libdmtcp_PROGRAMS += $(d_libdir)/libdmtcp_modify-env.so
 __d_libdir__libdmtcp_modify_env_so_SOURCES =                           \
-	modify-env/modify-env.c
+	modify-env/modify-env.c modify-env/warning.cpp
 __d_libdir__libdmtcp_modify_env_so_LDFLAGS = $(dmtcp_ldflags)
 __d_libdir__libdmtcp_modify_env_so_LDADD = $(LDADD)
 

--- a/plugin/Makefile.in
+++ b/plugin/Makefile.in
@@ -144,13 +144,14 @@ __d_libdir__libdmtcp_batch_queue_so_DEPENDENCIES =  \
 __d_libdir__libdmtcp_batch_queue_so_LINK = $(CXXLD) $(AM_CXXFLAGS) \
 	$(CXXFLAGS) $(__d_libdir__libdmtcp_batch_queue_so_LDFLAGS) \
 	$(LDFLAGS) -o $@
-am___d_libdir__libdmtcp_modify_env_so_OBJECTS = modify-env.$(OBJEXT)
+am___d_libdir__libdmtcp_modify_env_so_OBJECTS = modify-env.$(OBJEXT) \
+	warning.$(OBJEXT)
 __d_libdir__libdmtcp_modify_env_so_OBJECTS =  \
 	$(am___d_libdir__libdmtcp_modify_env_so_OBJECTS)
 __d_libdir__libdmtcp_modify_env_so_DEPENDENCIES =  \
 	$(am__DEPENDENCIES_1)
-__d_libdir__libdmtcp_modify_env_so_LINK = $(CCLD) $(AM_CFLAGS) \
-	$(CFLAGS) $(__d_libdir__libdmtcp_modify_env_so_LDFLAGS) \
+__d_libdir__libdmtcp_modify_env_so_LINK = $(CXXLD) $(AM_CXXFLAGS) \
+	$(CXXFLAGS) $(__d_libdir__libdmtcp_modify_env_so_LDFLAGS) \
 	$(LDFLAGS) -o $@
 am___d_libdir__libdmtcp_unique_ckpt_so_OBJECTS =  \
 	unique-ckpt.$(OBJEXT)
@@ -470,7 +471,7 @@ __d_bindir__dmtcp_srun_helper_SOURCES = \
 	batch-queue/dmtcp_srun_helper.cpp
 
 __d_libdir__libdmtcp_modify_env_so_SOURCES = \
-	modify-env/modify-env.c
+	modify-env/modify-env.c modify-env/warning.cpp
 
 __d_libdir__libdmtcp_modify_env_so_LDFLAGS = $(dmtcp_ldflags)
 __d_libdir__libdmtcp_modify_env_so_LDADD = $(LDADD)
@@ -617,7 +618,7 @@ $(d_libdir)/libdmtcp_batch-queue.so$(EXEEXT): $(__d_libdir__libdmtcp_batch_queue
 
 $(d_libdir)/libdmtcp_modify-env.so$(EXEEXT): $(__d_libdir__libdmtcp_modify_env_so_OBJECTS) $(__d_libdir__libdmtcp_modify_env_so_DEPENDENCIES) $(EXTRA___d_libdir__libdmtcp_modify_env_so_DEPENDENCIES) $(d_libdir)/$(am__dirstamp)
 	@rm -f $(d_libdir)/libdmtcp_modify-env.so$(EXEEXT)
-	$(AM_V_CCLD)$(__d_libdir__libdmtcp_modify_env_so_LINK) $(__d_libdir__libdmtcp_modify_env_so_OBJECTS) $(__d_libdir__libdmtcp_modify_env_so_LDADD) $(LIBS)
+	$(AM_V_CXXLD)$(__d_libdir__libdmtcp_modify_env_so_LINK) $(__d_libdir__libdmtcp_modify_env_so_OBJECTS) $(__d_libdir__libdmtcp_modify_env_so_LDADD) $(LIBS)
 
 $(d_libdir)/libdmtcp_unique-ckpt.so$(EXEEXT): $(__d_libdir__libdmtcp_unique_ckpt_so_OBJECTS) $(__d_libdir__libdmtcp_unique_ckpt_so_DEPENDENCIES) $(EXTRA___d_libdir__libdmtcp_unique_ckpt_so_DEPENDENCIES) $(d_libdir)/$(am__dirstamp)
 	@rm -f $(d_libdir)/libdmtcp_unique-ckpt.so$(EXEEXT)
@@ -713,6 +714,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/rm_utils.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/slurm_helper.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/unique-ckpt.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/warning.Po@am__quote@
 
 .c.o:
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(COMPILE) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $<
@@ -923,6 +925,20 @@ rm_pmi.obj: batch-queue/rm_pmi.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='batch-queue/rm_pmi.cpp' object='rm_pmi.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o rm_pmi.obj `if test -f 'batch-queue/rm_pmi.cpp'; then $(CYGPATH_W) 'batch-queue/rm_pmi.cpp'; else $(CYGPATH_W) '$(srcdir)/batch-queue/rm_pmi.cpp'; fi`
+
+warning.o: modify-env/warning.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT warning.o -MD -MP -MF $(DEPDIR)/warning.Tpo -c -o warning.o `test -f 'modify-env/warning.cpp' || echo '$(srcdir)/'`modify-env/warning.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/warning.Tpo $(DEPDIR)/warning.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='modify-env/warning.cpp' object='warning.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o warning.o `test -f 'modify-env/warning.cpp' || echo '$(srcdir)/'`modify-env/warning.cpp
+
+warning.obj: modify-env/warning.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT warning.obj -MD -MP -MF $(DEPDIR)/warning.Tpo -c -o warning.obj `if test -f 'modify-env/warning.cpp'; then $(CYGPATH_W) 'modify-env/warning.cpp'; else $(CYGPATH_W) '$(srcdir)/modify-env/warning.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/warning.Tpo $(DEPDIR)/warning.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='modify-env/warning.cpp' object='warning.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o warning.obj `if test -f 'modify-env/warning.cpp'; then $(CYGPATH_W) 'modify-env/warning.cpp'; else $(CYGPATH_W) '$(srcdir)/modify-env/warning.cpp'; fi`
 
 unique-ckpt.o: unique-ckpt/unique-ckpt.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT unique-ckpt.o -MD -MP -MF $(DEPDIR)/unique-ckpt.Tpo -c -o unique-ckpt.o `test -f 'unique-ckpt/unique-ckpt.cpp' || echo '$(srcdir)/'`unique-ckpt/unique-ckpt.cpp


### PR DESCRIPTION
This fixes an earlier commit to provide warnings when using plugin/modify-env