### PR TITLE
Fixes configure bug for interpreter=`...`

### DIFF
--- a/configure
+++ b/configure
@@ -7209,7 +7209,7 @@ fi
 if test "$use_m32" = "yes"; then
   interp=/lib/ld-linux.so.2
 elif test -x /usr/bin/readelf -a -r /usr/bin/readelf; then
-  interp=`/usr/bin/readelf -aW /usr/bin/readelf | grep interpreter | \
+  interp=`/usr/bin/readelf -aW /usr/bin/readelf | grep 'interpreter.*]' | \
           sed -e 's^.* interpreter: \(.*\)]^\1^'`
 elif test `uname -m` == x86_64; then
   interp=/lib64/ld-linux-x86-64.so.2

--- a/configure.ac
+++ b/configure.ac
@@ -524,7 +524,7 @@ fi
 if test "$use_m32" = "yes"; then
   interp=/lib/ld-linux.so.2
 elif test -x /usr/bin/readelf -a -r /usr/bin/readelf; then
-  interp=`/usr/bin/readelf -aW /usr/bin/readelf | grep interpreter | \
+  interp=`/usr/bin/readelf -aW /usr/bin/readelf | grep 'interpreter.*]' | \
           sed -e 's^.* interpreter: \(.*\)]^\1^'`
 elif test `uname -m` == x86_64; then
   interp=/lib64/ld-linux-x86-64.so.2


### PR DESCRIPTION
In configure.ac (and configure), on older versions of readelf, `/usr/bin/readelf -aW /usr/bin/readelf | grep interpreter` produced two hits for the possible name of the ELF interpreter.  Now we do `/usr/bin/readelf -aW /usr/bin/readelf | grep 'interpreter.*]'` to capture only the intended match.

This is a fix for issue #320.  It should be pushed into both 3.0 and into 2.4.5.  I will label it for milestone 2.4.5, since that's the earlier version needing this fix.  However, this commit is the one that is applied to the 3.0 branch.