### PR TITLE
Fix for #320. Robustify parsing of readelf call used to find the loader

### DIFF
--- a/configure
+++ b/configure
@@ -7208,7 +7208,7 @@ fi
 if test "$use_m32" = "yes"; then
   interp=/lib/ld-linux.so.2
 elif test -x /usr/bin/readelf -a -r /usr/bin/readelf; then
-  interp=`/usr/bin/readelf -aW /usr/bin/readelf | grep interpreter | \
+  interp=`/usr/bin/readelf -aW /usr/bin/readelf | grep 'interpreter.*]' | \
           sed -e 's^.* interpreter: \(.*\)]^\1^'`
 elif test `uname -m` == x86_64; then
   interp=/lib64/ld-linux-x86-64.so.2

--- a/configure.ac
+++ b/configure.ac
@@ -523,7 +523,7 @@ fi
 if test "$use_m32" = "yes"; then
   interp=/lib/ld-linux.so.2
 elif test -x /usr/bin/readelf -a -r /usr/bin/readelf; then
-  interp=`/usr/bin/readelf -aW /usr/bin/readelf | grep interpreter | \
+  interp=`/usr/bin/readelf -aW /usr/bin/readelf | grep 'interpreter.*]' | \
           sed -e 's^.* interpreter: \(.*\)]^\1^'`
 elif test `uname -m` == x86_64; then
   interp=/lib64/ld-linux-x86-64.so.2


### PR DESCRIPTION
Based on suggestion from @gc00, this appears to resolve #320 for my test case.  