### PR TITLE
siginfo: Save/restore signal handlers using _real_syscall

### DIFF
--- a/src/siginfo.cpp
+++ b/src/siginfo.cpp
@@ -109,7 +109,7 @@ void SigInfo::saveSigHandlers()
   /* Now save all the signal handlers */
   JTRACE("saving signal handlers");
   for (sig = SIGRTMAX; sig > 0; --sig) {
-    if (sigaction (sig, NULL, &sigactions[sig]) < 0) {
+    if (_real_syscall(SYS_rt_sigaction, sig, NULL, &sigactions[sig], _NSIG / 8) < 0) {
       JASSERT(errno == EINVAL) (sig) (JASSERT_ERRNO)
         .Text("error saving signal action");
       memset (&sigactions[sig], 0, sizeof sigactions[sig]);
@@ -135,7 +135,7 @@ void SigInfo::restoreSigHandlers()
     JTRACE("restore signal handler for") (sig);
 #endif
 
-    JASSERT(_real_sigaction(sig, &sigactions[sig], NULL) == 0 || errno == EINVAL)
+    JASSERT(_real_syscall(SYS_rt_sigaction, sig, &sigactions[sig], NULL, _NSIG / 8) == 0 || errno == EINVAL)
       (sig) (JASSERT_ERRNO)
       .Text("error restoring signal handler");
   }


### PR DESCRIPTION
At the time of checkpoint, DMTCP saves all signal handlers using libc's
sigaction() call. Then, DMTCP saves the per-thread signal mask using
libc's pthread_sigmask() call.

On restart, DMTCP first restores the signal handlers of the process
using libc's sigaction() function. And finally, it restores the signal
mask using libc's pthread_sigmask() call.

The NPTL library uses SIGCANCEL (signal #32) and SIGSETXID (signal #33)
internally. The corresponding signal handlers are installed when the
library is initialized by the Linux dynamic linker/loader when loading
a target application that's linked against libc.

The root cause behind the issue is that libc prevents any request that has
anything to do with the two signals from going through to the kernel. In
some cases, libc throws an error, and in some other cases, it simply
ignores the request without any errors. In particular, using sigaction()
to read or write signal handlers for the two signals results in a EINVAL
error, and the call to pthread_sigmask() to read or write the signal
mask for the two signals is simply ignored by libc without any errors.

So, the solution is to not go to libc to read/write the signal handlers,
and to directly make a syscall.