### PR TITLE
threadwrappers: Fix segfault when clone call fails

### DIFF
--- a/src/threadwrappers.cpp
+++ b/src/threadwrappers.cpp
@@ -114,7 +114,7 @@ extern "C" int __clone(int (*fn) (void *arg), void *child_stack, int flags,
   if (tid == -1) {
     JTRACE("Clone call failed")(JASSERT_ERRNO);
     ThreadSync::decrementUninitializedThreadCount();
-    delete thread;
+    ThreadList::threadIsDead(thread);
   } else {
     DmtcpWorker::eventHook(DMTCP_EVENT_THREAD_CREATED, NULL);
   }


### PR DESCRIPTION
This is a duplicate of PR #330 for the 2.5 branch.