### PR TITLE
dmtcp_coordinator: Fix checkpoint timing when using --exit-on-checkpoint

### DIFF
--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -422,6 +422,7 @@ void DmtcpCoordinator::updateMinimumState(WorkerState oldState)
 
     if (exitAfterCkpt || exitAfterCkptOnce) {
       JNOTE("Checkpoint Done. Killing all peers.");
+      JTIMER_STOP ( checkpoint );
       broadcastMessage(DMT_KILL_PEER);
       exitAfterCkptOnce = false;
     } else {
@@ -466,6 +467,7 @@ void DmtcpCoordinator::updateMinimumState(WorkerState oldState)
 
     if (exitAfterCkpt || exitAfterCkptOnce) {
       JNOTE("Checkpoint Done. Killing all peers.");
+      JTIMER_STOP ( checkpoint );
       broadcastMessage(DMT_KILL_PEER);
       exitAfterCkptOnce = false;
     } else {


### PR DESCRIPTION
This patch fixes an issue with the checkpoint time reported
by the coordinator when using the --exit-on-checkpoint flag.