### PR TITLE
Skip saving text area to ckpt image

### DIFF
--- a/include/procmapsarea.h
+++ b/include/procmapsarea.h
@@ -47,14 +47,13 @@
 
 #define DELETED_FILE_SUFFIX " (deleted)"
 
-/* Let MTCP_PROT_ZERO_PAGE be a unique bit mask
- * This assumes: PROT_READ == 0x1, PROT_WRITE == 0x2, and PROT_EXEC == 0x4
- */
-#define MTCP_PROT_ZERO_PAGE (PROT_EXEC << 2)
-
 #define FILENAMESIZE 1024
 
 typedef char * VA; /* VA = virtual address */
+
+typedef enum ProcMapsAreaProperties {
+  DMTCP_ZERO_PAGE = 0x0001,
+} ProcMapsAreaProperties;
 
 typedef union ProcMapsArea {
   struct {
@@ -94,6 +93,9 @@ typedef union ProcMapsArea {
       ino_t inodenum;
       uint64_t __inodenum;
     };
+
+    uint64_t properties;
+
     char name[FILENAMESIZE];
   };
   char _padding[4096];

--- a/include/procmapsarea.h
+++ b/include/procmapsarea.h
@@ -53,6 +53,7 @@ typedef char * VA; /* VA = virtual address */
 
 typedef enum ProcMapsAreaProperties {
   DMTCP_ZERO_PAGE = 0x0001,
+  DMTCP_SKIP_WRITING_TEXT_SEGMENTS = 0x0002
 } ProcMapsAreaProperties;
 
 typedef union ProcMapsArea {

--- a/src/constants.h
+++ b/src/constants.h
@@ -90,6 +90,7 @@
 #define ENV_VAR_VIRTUAL_PID "DMTCP_VIRTUAL_PID"
 // Keep in sync with plugin/batch-queue/rm_pmi.h
 #define ENV_VAR_EXPLICIT_SRUN "DMTCP_EXPLICIT_SRUN"
+#define ENV_VAR_SKIP_WRITING_TEXT_SEGMENTS "DMTCP_SKIP_WRITING_TEXT_SEGMENTS"
 
 
 // it is not yet safe to change these; these names are hard-wired in the code
@@ -138,6 +139,7 @@
     ENV_VAR_DLSYM_OFFSET, \
     ENV_VAR_DLSYM_OFFSET_M32, \
     ENV_VAR_VIRTUAL_PID, \
+    ENV_VAR_SKIP_WRITING_TEXT_SEGMENTS, \
     ENV_DELTACOMPRESSION
 
 #define DMTCP_RESTART_CMD "dmtcp_restart"

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -492,7 +492,8 @@ static void mtcp_simulateread(int fd, MtcpHeader *mtcpHdr)
   while(1) {
     mtcp_readfile(fd, &area, sizeof area);
     if (area.size == -1) break;
-    if ((area.properties & DMTCP_ZERO_PAGE) == 0) {
+    if ((area.properties & DMTCP_ZERO_PAGE) == 0 &&
+        (area.properties & DMTCP_SKIP_WRITING_TEXT_SEGMENTS) == 0) {
       void *addr = mtcp_sys_mmap(0, area.size, PROT_WRITE | PROT_READ,
                                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
       if (addr == MAP_FAILED) {
@@ -925,7 +926,7 @@ static int read_one_memory_area(int fd)
     if (try_skipping_existing_segment) {
       // This fails on teracluster.  Presumably extra symbols cause overflow.
       mtcp_skipfile(fd, area.size);
-    } else {
+    } else if ((area.properties & DMTCP_SKIP_WRITING_TEXT_SEGMENTS) == 0) {
       /* This mmapfile after prev. mmap is okay; use same args again.
        *  Posix says prev. map will be munmapped.
        */

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -492,7 +492,7 @@ static void mtcp_simulateread(int fd, MtcpHeader *mtcpHdr)
   while(1) {
     mtcp_readfile(fd, &area, sizeof area);
     if (area.size == -1) break;
-    if ((area.prot & MTCP_PROT_ZERO_PAGE) == 0) {
+    if ((area.properties & DMTCP_ZERO_PAGE) == 0) {
       void *addr = mtcp_sys_mmap(0, area.size, PROT_WRITE | PROT_READ,
                                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
       if (addr == MAP_FAILED) {
@@ -825,11 +825,11 @@ static int read_one_memory_area(int fd)
   /* Now mmap the data of the area into memory. */
 
   /* CASE MAPPED AS ZERO PAGE: */
-  if ((area.prot & MTCP_PROT_ZERO_PAGE) != 0) {
+  if ((area.properties & DMTCP_ZERO_PAGE) != 0) {
     DPRINTF("restoring non-rwx anonymous area, %p bytes at %p\n",
             area.size, area.addr);
     mmappedat = mtcp_sys_mmap (area.addr, area.size,
-                               area.prot & ~MTCP_PROT_ZERO_PAGE,
+                               area.prot,
                                area.flags | MAP_FIXED, -1, 0);
 
     if (mmappedat != area.addr) {

--- a/src/procselfmaps.cpp
+++ b/src/procselfmaps.cpp
@@ -235,5 +235,7 @@ int ProcSelfMaps::getNextArea(ProcMapsArea* area)
     area -> flags |= MAP_ANONYMOUS;
   }
 
+  area->properties = 0;
+
   return 1;
 }

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -228,7 +228,8 @@ void mtcp_writememoryareas(int fd)
       area.name[0] = '\0';
     } else if (Util::isNscdArea(area)) {
       /* Special Case Handling: nscd is enabled*/
-      area.prot = PROT_READ | PROT_WRITE | MTCP_PROT_ZERO_PAGE;
+      area.prot = PROT_READ | PROT_WRITE;
+      area.properties |= DMTCP_ZERO_PAGE;
       area.flags = MAP_PRIVATE | MAP_ANONYMOUS;
       Util::writeAll(fd, &area, sizeof(area));
       continue;
@@ -365,7 +366,7 @@ static void mtcp_write_non_rwx_and_anonymous_pages(int fd, Area *orig_area)
       mtcp_get_next_page_range(&a, &size, &is_zero);
     }
 
-    a.prot |= is_zero ? MTCP_PROT_ZERO_PAGE : 0;
+    a.properties |= is_zero ? DMTCP_ZERO_PAGE : 0;
     a.size = size;
 
     Util::writeAll(fd, &a, sizeof(a));


### PR DESCRIPTION
@gc00 @rohgarg @jiajuncao: Can you take a look at it and see if that works for you?

The optimization is enabled by setting `DMTCP_SKIP_WRITING_TEXT_AREA=1` environment variable.