### PR TITLE
dmtcp_coordinator: Fix restart timing

### DIFF
--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -422,7 +422,8 @@ void DmtcpCoordinator::updateMinimumState()
         (restartBarriers[nextRestartBarrier]);
       releaseBarrier(restartBarriers[nextRestartBarrier]);
       nextRestartBarrier++;
-    } else {
+    }
+    if (nextRestartBarrier == restartBarriers.size()) {
       JTIMER_STOP(restart);
       JNOTE("Resuming all nodes after restart");
     }


### PR DESCRIPTION
This patch fixes an issue with the coordinator where
it would fail to record the restart timing information when
configured with --enable-timing.

The issue was due to recent changes in the barrier API. The
new implementation would first check if the coordinator had
released all the requested global barriers, and if not, it would
execute a barrier and increment a counter that keeps track of
the number of executed barriers. However, the implementation
failed to stop and record the restart timer when the global
counter (or the number of executed barriers) became equal to
the number of requested global barriers.