### PR TITLE
Fix dlsym_default to not rely on dlsym and dlopen

### DIFF
--- a/include/dlsym_default.h
+++ b/include/dlsym_default.h
@@ -32,73 +32,36 @@
 # undef __USE_GNU
 #endif
 
-/************************************************************************
- * IMPORTANT CAVEATS:
- *   DLSYM_DEFAULT() is effective when called from a library, but not when
- *     called from within the base executable.
- *   Don't use dlsym_default_internal() outside of this macro.
- *   This must be a macro because dlsym() looks one level up in the stack
- *     to decide what library the caller of dlsym() is located in.
- *   RTLD_DEFAULT does not work with this macro.
- ************************************************************************/
-
 // #define DLSYM_DEFAULT_DO_DEBUG
 
 #ifdef DLSYM_DEFAULT_DO_DEBUG
 # define DLSYM_DEFAULT_DEBUG(handle,symbol,info) \
-    JNOTE("DLSYM_DEFAULT (RTLD_NEXT==-1l)")(symbol)(handle) \
+    JNOTE("dlsym_default (RTLD_NEXT==-1l)")(symbol)(handle) \
          (info.dli_fname)(info.dli_saddr)
 #else
 # define DLSYM_DEFAULT_DEBUG(handle,symbol,info)
 #endif
-
-#define DLSYM_DEFAULT(handle,symbol)                                          \
-  ({ Dl_info info;                                                            \
-     void *handle2 = handle;                                                  \
-     if (handle == RTLD_DEFAULT || handle == RTLD_NEXT) {                     \
-       /* Hack: use dlsym()/dlopen() only to get the lib handle */            \
-       /* MUST BE MACRO:  dlsym uses stack to find curr. lib for RTLD_NEXT */ \
-       /* Logic for dlsym_fnptr is shadowing logic for dmtcp.h:NEXT_FNC() */  \
-       __typeof__(&dlsym) dlsym_fnptr;                                        \
-       dlsym_fnptr = (__typeof__(&dlsym)) dmtcp_get_libc_dlsym_addr();        \
-       void *tmp_fnc = (*dlsym_fnptr) (handle2, symbol);                      \
-       dladdr(tmp_fnc, &info);                                                \
-       DLSYM_DEFAULT_DEBUG(handle,symbol,info);                               \
-       /* Found handle of RTLD_NEXT or RTLD_DEFAULT */                        \
-       handle2 = dlopen(info.dli_fname, RTLD_NOLOAD | RTLD_LAZY);             \
-     }                                                                        \
-     /* Same signature as dlsym(): */                                         \
-     void *symbol_ptr = dlsym_default_internal(handle2, symbol);              \
-     if (handle == RTLD_DEFAULT || handle == RTLD_NEXT) {                     \
-       dlclose(handle2); /* Should verify that this returns 9. */             \
-     }                                                                        \
-     symbol_ptr; })
 
 #ifdef __cplusplus
 extern "C"
 {
 #else
 #endif
-  void *dlsym_default_internal(void *handle, const char *symbol);
+void *dlsym_default(void *handle, const char *symbol);
 #ifdef __cplusplus
 }
 #else
 #endif
 
 #ifndef STANDALONE
-// FIXME: DLSYM_DEFAULT() and dlsym_default_internal() should probably
-//    both use dmtcp_get_libc_dlsym_addr() instead of dlsym()
-//    when used with DMTCP.
-//    Or do they need to?
-
 // This implementation mirrors dmtcp.h:NEXT_FNC() for DMTCP.
-// It uses DLSYM_DEFAULT to get default version, in case of symbol versioning
+// It uses dlsym_default to get default version, in case of symbol versioning
 # define NEXT_FNC_DEFAULT(func)                                             \
   ({                                                                        \
      static __typeof__(&func) _real_##func = (__typeof__(&func)) -1;        \
      if (_real_##func == (__typeof__(&func)) -1) {                          \
        if (dmtcp_initialize) dmtcp_initialize();                            \
-       _real_##func = (__typeof__(&func)) DLSYM_DEFAULT(RTLD_NEXT, #func);  \
+       _real_##func = (__typeof__(&func)) dlsym_default(RTLD_NEXT, #func);  \
      }                                                                      \
    _real_##func;})
 #endif
@@ -120,9 +83,9 @@ int main() {
 
   printf("================ dlsym_default ================\n");
   // NOTE: RTLD_DEFAULT would try to use this a.out, and fail to find a library
-  // fnc = DLSYM_DEFAULT(RTLD_DEFAULT, "pthread_cond_broadcast");
+  // fnc = dlsym_default(RTLD_DEFAULT, "pthread_cond_broadcast");
   // printf("pthread_cond_broadcast (via RTLD_DEFAULT): %p\n", fnc);
-  fnc = DLSYM_DEFAULT(RTLD_NEXT, "pthread_cond_broadcast");
+  fnc = dlsym_default(RTLD_NEXT, "pthread_cond_broadcast");
   printf("pthread_cond_broadcast (via RTLD_NEXT): %p\n", fnc);
 
   return 0;

--- a/src/dlsym_default.c
+++ b/src/dlsym_default.c
@@ -21,9 +21,7 @@
 
 /* USAGE:
  * #include "dlsym_default.h"
- * ... DLSYM_DEFAULT(RTLD_NEXT, ...) ...
- * WARNING:  DLSYM_DEFAULT works within a library, but not in base executable
- * WARNING:  RTLD_DEFAULT will not work with DLSYM_DEFAULT()
+ * ... dlsym_default(RTLD_NEXT, ...) ...
  */
 
 /* THEORY:  A versioned symbol consists of multiple symbols, one for
@@ -43,7 +41,7 @@
  * then hopes for a unique versioned symbol.  (It seems that in all of
  * the above, the linker will always ignore a hidden symbol for these
  * purposes.  Unfortunately, dlsym doesn't follow the same policy as the
- * static or dynamic linker.  Hence, dlsym_default_internal tries to replicate
+ * static or dynamic linker.  Hence, dlsym_default tries to replicate
  * that policy of preferring non-hidden symbols always.)
  *     The symbol pthread_cond_broadcast is a good test case.  It seems to
  * have its base version referenced as a hidden symbol, and only a non-base
@@ -265,49 +263,15 @@ static void get_dt_tags(void *handle, dt_tag *tags) {
     }
 }
 
-//  Don't use dlsym_default_internal(); use dlsym_default.h:DLSYM_DEFAULT()
-void *dlsym_default_internal(void *handle, const char*symbol) {
+// Given a handle for a library (not RTLD_DEFAULT or RTLD_NEXT), retrieves the
+// default symbol for the given symbol if it exists in that library.
+// Also sets the tags and default_symbol_index for usage later
+void *dlsym_default_internal_library_handler(void *handle, const char*symbol,
+      dt_tag *tags_p, Elf32_Word *default_symbol_index_p)
+{
   dt_tag tags;
   Elf32_Word default_symbol_index = 0;
   Elf32_Word i;
-
-#ifdef __USE_GNU
-  if (handle == RTLD_NEXT || handle == RTLD_DEFAULT) {
-    Dl_info info;
-    void *tmp_fnc = dlsym(handle, symbol);  // Hack: get symbol w/ any version
-    // printf("tmp_fnc: %p\n", tmp_fnc);
-    dladdr(tmp_fnc, &info);
-    // ... and find what library the symbol is in
-   printf("info.dli_fname: %s\n", info.dli_fname);
-#if 0
-char *tmp = info.dli_fname;
-char *basename = tmp;
-for ( ; *tmp != '\0'; tmp++ ) {
-  if (*tmp == '/')
-    basename = tmp+1;
-}
-#endif
-    // Found handle of RTLD_NEXT or RTLD_DEFAULT
-    handle = dlopen(info.dli_fname, RTLD_NOLOAD | RTLD_LAZY);
-    // symbol name is:  info.dli_sname;  Could add assert as double-check.
-    if (handle == NULL)
-      printf("ERROR:  RTLD_DEFAULT or RTLD_NEXT called; no library found.\n");
-    // Could try:  dlopen(info.dli_fname, RTLD_LOCAL|RTLD_LAZY); to get handle
-    // But if library wasn't loaded before, we shouldn't load it now.
-  }
-  // An alternative to the above code is to use dl_iterate_phdr() to walk the
-  //   list of loaded libraries, and for each one, hash on the symbol name
-  //   to see if it's contained in that one.  But dl_iterate_phdr gives you
-  //   the base address of the shared object.
-  // dlopen(NULL); provides a handle for main program.  dlinfo can then get
-  //   dynamic section (see get_dt_tags()), and also the link_map.
-  //   When we find a shared object with our symbol in it, the link_map
-  //   will give us the name, and dlopen (w/ NOLOAD?) on it gives us a handle.
-  // A better way might be to start with any library handle at all: dlopen
-  //   Then call dlinfo(handle, RTLD_DI_LINKMAP, &link_map);
-  //   for: 'struct link_map &link_map;'  and follow get_dt_tags() for find
-  //   info from dynamic section.
-#endif
 
   get_dt_tags(handle, &tags);
   assert(tags.hash != NULL || tags.gnu_hash != NULL);
@@ -335,6 +299,99 @@ if (default_symbol_index) {
       }
     }
   }
+  *tags_p = tags;
+  *default_symbol_index_p = default_symbol_index;
+  
+  if (default_symbol_index)
+    return tags.base_addr + tags.symtab[default_symbol_index].st_value;
+  else
+    return NULL;
+}
+
+// Given a pseudo-handle, symbol name, and addr, returns the address of the symbol
+// with the given name of a default version found by the search order of the given
+// handle which is either RTLD_DEFAULT or RTLD_NEXT.
+void *dlsym_default_internal_flag_handler(void* handle, const char* symbol, void* addr,
+      dt_tag *tags_p, Elf32_Word *default_symbol_index_p)
+{
+  Dl_info info;
+  void* extra_info;
+  void* result;
+
+  // Retrieve the link_map for the library given by addr
+  int ret = dladdr1(addr, &info, &extra_info, RTLD_DL_LINKMAP);
+  if (!ret) {
+    printf("dladdr1 could not find shared object for address\n");
+    return NULL;
+  }
+
+  struct link_map* map = (struct link_map*) extra_info;
+
+  // Handle RTLD_DEFAULT starts search at first loaded object
+  if (handle == RTLD_DEFAULT) {
+    while (map->l_prev) {
+      // Rewinding to search by load order
+      map = map->l_prev;
+    }
+  }	
+
+  // Handle RTLD_NEXT starts search after current library
+  if (handle == RTLD_NEXT) {
+    // Skip current library
+    if (!map->l_next) {
+      printf("There are no libraries after the current library.\n");
+      return NULL;
+    }
+    map = map->l_next;
+  }
+
+  // Search through libraries until end of list is reached or symbol is found.
+  while (1) {
+    // printf("l_name: %s\n", map->l_name);
+    // Running dlsym_default_internal on the linux-vdso library will
+    // cause a segfault. Because it may have different versions on
+    // different systems, we check this way rather than a strcmp.
+    // If the library is vdso, we simply move to the next loaded,
+    // library if it exists.
+    if (map->l_name[0] == 'l' &&
+      map->l_name[1] == 'i' &&
+      map->l_name[2] == 'n' &&
+      map->l_name[3] == 'u' &&
+      map->l_name[4] == 'x' &&
+      map->l_name[5] == '-' &&
+      map->l_name[6] == 'v' &&
+      map->l_name[7] == 'd' &&
+      map->l_name[8] == 's' &&
+      map->l_name[9] == 'o') {
+			if (!map->l_next) {
+        printf("No more libraries to search.\n");
+        return NULL;
+      }	
+      // Change link map to next library
+      map = map->l_next;
+      continue;	
+    }
+
+    // Search current library
+    result = dlsym_default_internal_library_handler((void*) map, symbol, tags_p, default_symbol_index_p);
+    if (result) {
+      return result;
+    }
+
+    // Check if next library exists
+    if (!map->l_next) {
+      //printf("No more libraries to search.\n");
+      return NULL;
+    }
+    // Change link map to next library
+    map = map->l_next;
+  }
+}
+
+// Produces an error message and hard fails if no default_symbol was found.
+void print_debug_messages(dt_tag tags, Elf32_Word default_symbol_index,
+                      const char *symbol)
+{
 #ifdef VERBOSE
   if (default_symbol_index) {
     printf("** st_value: %p\n",
@@ -347,9 +404,28 @@ if (default_symbol_index) {
     printf("ERROR:  No default symbol version found for %s.\n"
            "        Extend code to look for hidden symbols?\n", symbol);
   }
-  if (default_symbol_index)
-    return tags.base_addr + tags.symtab[default_symbol_index].st_value;
-  else
-    assert(0);
-    return NULL;
+}
+
+// Like dlsym but finds the 'default' symbol of a library (the symbol that the
+// dynamic executable automatically links to) rather than the oldest version
+// which is what dlsym finds
+void *dlsym_default(void *handle, const char*symbol) {
+  dt_tag tags;
+  Elf32_Word default_symbol_index = 0;
+
+#ifdef __USE_GNU
+  if (handle == RTLD_NEXT || handle == RTLD_DEFAULT) {
+  // Determine where this function will return
+  void* return_address = __builtin_return_address(0);
+  // Search for symbol using given pseudo-handle order
+  void *result = dlsym_default_internal_flag_handler(handle, symbol, return_address,
+                                                      &tags, &default_symbol_index);
+  print_debug_messages(tags, default_symbol_index, symbol);
+  return result;
+  }
+#endif
+
+  void *result = dlsym_default_internal_library_handler(handle, symbol, &tags, &default_symbol_index);
+  print_debug_messages(tags, default_symbol_index, symbol);
+  return result;
 }


### PR DESCRIPTION
The old DLSYM_DEFAULT implementation works exactly as expected
when given an actual handle for a library. However, potential
problems arose with the use of the RTLD_DEFAULT and RTLD_NEXT
pseudo-handles. In these cases, the function relied on calls
to dlopen and dlsym which could cause an infinite loop if called
before the complete initialization of libc.
This commit replaces the usage of dlopen and dlsym with dladdr1 which
simplifies the process greatly and should fix this problem.

Please let me know if there is anything I should change before this is merged.
