### PR TITLE
fileconnection: Fix checkpointing of unlinked files opened with O_WRONLY

### DIFF
--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -264,7 +264,7 @@ void FileConnection::refill(bool isRestart)
 
   if (!_ckpted_file) {
     int tempfd;
-    if (_type == FILE_DELETED && (_flags & (O_WRONLY | O_RDWR))) {
+    if (_type == FILE_DELETED && ((_flags & O_WRONLY) || (_flags & O_RDWR))) {
       tempfd = _real_open(_path.c_str(), _fcntlFlags | O_CREAT, 0600);
       JASSERT(tempfd != -1) (_path) (JASSERT_ERRNO) .Text("open() failed");
       JASSERT(truncate(_path.c_str(), _st_size) ==  0)
@@ -306,7 +306,7 @@ void FileConnection::refill(bool isRestart)
 
 void FileConnection::resume(bool isRestart)
 {
-  if (_ckpted_file && isRestart && _type == FILE_DELETED) {
+  if (isRestart && _type == FILE_DELETED) {
     /* Here we want to unlink the file. We want to do it only at the time of
      * restart, but there is no way of finding out if we are restarting or not.
      * That is why we look for the file on disk and if it is present(it was


### PR DESCRIPTION
This patch fixes an issue where DMTCP would incorrectly restore
files that were unlinked after opening with O_WRONLY.

The policy for checkpoint-restore of such files was first defined
in the commit 5c3dd0a as follows:

 a) DMTCP should not checkpoint such files, regardless of the
    --checkpoint-open-files flags; and
 b) On restart, DMTCP should open such files with (O_WRONLY|O_CREAT)
    and unlink them.

However, the implementaiton never achieved these goals. We did end up
doing the first part correctly, but never really got the second path right.

With the above commit, files would be opened with (O_WRONLY|O_CREAT)
on restart but were never unlinked because the commit overlooked an
if-clause in the `FileConnection::resume()` method. The if-clause would
call unlink() only if a file had the `_ckpted_file` flag set to true.

Later, the commit: 8514737 worsened the situation. It introduced a bug
in the `FileConnection::refill()` method that would prevent us from even
opening write-only, unlinked files on restart.