### PR TITLE
Enhancing Ckptfile plugin with overwrite functionality for ckpt-files

### DIFF
--- a/contrib/ckptfile/README
+++ b/contrib/ckptfile/README
@@ -8,25 +8,35 @@
 
 This plugin allows you to:
 
- a) specify a file that DMTCP should checkpoint; and
+ a) specify a file that DMTCP should checkpoint; 
+ b) specify a file that DMTCP should checkpoint and overwrite 
+    the existing version of file on restart with the checkpointed version
  b) specify the path on restart of a file if it wasn't checkpointed.
 
 The plugin reads a user-specified database at checkpoint time. The
 database is a simple text file that specifies the files that should
-be checkpointed, and the restart paths of files that shouldn't be
+be checkpointed, checkpointed with overwrite of existing file at restart 
+with checkpointed copy, and the restart paths of files that shouldn't be 
 checkpointed.
 
 The database file's format is described below.
 
-   FILE:SAVE_AND_RESTORE={1|0};RESTART_PATH=NEW_FILE
-   FILE_PATTERN:SAVE_AND_RESTORE={1|0};RESTART_PATH=NEW_FILE_PATTERN
+   FILE:SAVE_AND_RESTORE={1|2|0};RESTART_PATH=NEW_FILE
+   FILE_PATTERN:SAVE_AND_RESTORE={1|2|0};RESTART_PATH=NEW_FILE_PATTERN
+
+SAVE_AND_RESTORE = 1 means file will be checkpointed and in case of any 
+pre-existing file at restart, file will not be replaced with checkpointed
+copy, however error checks will come into picture for equality of file. 
+
+SAVE_AND_RESTORE = 2 means file will be checkpointed and any pre-exisitng
+file at restart will be overwritten with the checkpointed copy
 
 Here, FILE and NEW_FILE are pathnames, and FILE_PATTERN and
 NEW_FILE_PATTERN are shell wildcard patterns. The plugin uses the POSIX
 fnmatch() function for pattern matching.
 
 Note that for a file that's saved and then restored on restart
-(SAVE_AND_RESTORE=1), the restart path (RESTART_PATH=XXX) is ignored.
+(SAVE_AND_RESTORE=1|2), the restart path (RESTART_PATH=XXX) is ignored.
 
 Also, note that the plugin does *not* virtualize the paths for the target
 application. The plugin ensures that DMTCP will not assert and exit when

--- a/contrib/ckptfile/ckptfiles.dat
+++ b/contrib/ckptfile/ckptfiles.dat
@@ -1,3 +1,5 @@
 /home/user/hello:SAVE_AND_RESTORE=1;RESTART_PATH=/mnt/media/user/hello
 /home/user/hello2:SAVE_AND_RESTORE=0;RESTART_PATH=/mnt/media/user/hello2
 /home/user/test/*:SAVE_AND_RESTORE=1;RESTART_PATH=/mnt/media/user/test/*
+/home/user/hello1:SAVE_AND_RESTORE=2;RESTART_PATH=/mnt/media/user/hello1
+/home/user/test1/*:SAVE_AND_RESTORE=2;RESTART_PATH=/mnt/media/user/test1/*

--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -312,6 +312,13 @@ EXTERNC void dmtcp_get_new_file_path(const char *abspath, const char *cwd,
                                      char *newpath)
   __attribute((weak));
 
+/* This function gives direction to DMTCP infrastructure to overwrite
+ * exisiting file on restart with the checkpointed version of file.
+ * This function is defined only in contrib/ckptfile/ckptfile.cpp
+ */
+
+EXTERNC int dmtcp_overwrite_ckptfile_on_restart (const char *path) __attribute((weak));
+
 #define dmtcp_process_event(e,d) \
     __REPLACE_dmtcp_process_event_WITH_dmtcp_event_hook()__
 


### PR DESCRIPTION
Ckptfile plugin allows user to checkpoint its own files. Now its quite possible
that these checkpointed files have changed prior to restart. Currently this will
result in error saying unequal files. However this scenario cannot be avoided
for log files which will always change.

This commit allows user to allow pre-existing files to be overwritten with the
checkpointed copy at restart rather than resulting in error.  Simple text
file used as database has been enhanced to point which files are allowed
to be overwritten. User can provide SAVE_AND_RESTORE=2 to point file will
be checkpointed and allowed to be overwritten at restart time.

This also targets   ckptfile-plugin: make it useful #9 