### PR TITLE
fileconnection: Fix preCkpt() for files opened using fopen-family

### DIFF
--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -212,7 +212,7 @@ void FileConnection::preCkpt()
       JASSERT(destFd != -1) (JASSERT_ERRNO) (_path) (savedFilePath);
 
       JTRACE("Saving checkpointed copy of the file") (_path) (savedFilePath);
-      if (_flags & O_WRONLY) {
+      if (_fcntlFlags & O_WRONLY) {
         // If the file is opened() in write-only mode. Open it in readonly mode
         // to create the ckpt copy.
         int tmpfd = _real_open(_path.c_str(), O_RDONLY, 0);


### PR DESCRIPTION
For files opened using the fopen* family of functions, the `_flags` field
of the `FileConnection` object is initialized to -1. The field is initialized
when the object is created at the time  of opening the file and is never
set to the correct value.

This patch fixes an issue caused because the `preCkpt()` method
incorrectly referred to the `_flags` field to determine how to save a
copy of an opened file (when using the `--checkpoint-open-files` option).

This fix is to use the `_fcntlFlags` field instead of the `_flags` field
in the `preCkpt()` method. The `_fnctlFlags` field is set to the value
returned by `fcntl(F_GETFL)` in the `drain()` method, which gets called
before `preCkpt()`.