### PR TITLE
Add support for logging coordinator messages when running in daemon mode

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -92,6 +92,7 @@
 #define ENV_VAR_EXPLICIT_SRUN "DMTCP_EXPLICIT_SRUN"
 #define ENV_VAR_SKIP_WRITING_TEXT_SEGMENTS "DMTCP_SKIP_WRITING_TEXT_SEGMENTS"
 
+#define ENV_VAR_COORD_LOGFILE "DMTCP_COORD_LOG_FILENAME"
 
 // it is not yet safe to change these; these names are hard-wired in the code
 #define ENV_VAR_STDERR_PATH "JALIB_STDERR_PATH"

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -128,6 +128,8 @@ static const char* theUsage =
   "               different tmpdirs.)\n"
   "  -q, --quiet (or set environment variable DMTCP_QUIET = 0, 1, or 2)\n"
   "              Skip NOTE messages; if given twice, also skip WARNINGs\n"
+  "  --coord-logfile PATH (environment variable DMTCP_COORD_LOG_FILENAME\n"
+  "              Coordinator will dump its logs to the given file\n"
   "  --help\n"
   "              Print this message and exit.\n"
   "  --version\n"
@@ -257,6 +259,9 @@ static void processArgs(int *orig_argc, char ***orig_argv,
       shift;
     } else if (s == "-i" || s == "--interval") {
       setenv(ENV_VAR_CKPT_INTR, argv[1], 1);
+      shift; shift;
+    } else if (s == "--coord-logfile") {
+      setenv(ENV_VAR_COORD_LOGFILE, argv[1], 1);
       shift; shift;
     } else if (argv[0][0] == '-' && argv[0][1] == 'i' &&
                isdigit(argv[0][2])) { // else if -i5, for example

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -98,6 +98,8 @@ static const char* theUsage =
   "              Directory to store temporary files (default: $TMDPIR or /tmp)\n"
   "  -q, --quiet (or set environment variable DMTCP_QUIET = 0, 1, or 2)\n"
   "              Skip NOTE messages; if given twice, also skip WARNINGs\n"
+  "  --coord-logfile PATH (environment variable DMTCP_COORD_LOG_FILENAME\n"
+  "              Coordinator will dump its logs to the given file\n"
   "  --help\n"
   "              Print this message and exit.\n"
   "  --version\n"
@@ -670,6 +672,9 @@ int main(int argc, char** argv)
       shift;
     } else if (s == "-i" || s == "--interval") {
       setenv(ENV_VAR_CKPT_INTR, argv[1], 1);
+      shift; shift;
+    } else if (s == "--coord-logfile") {
+      setenv(ENV_VAR_COORD_LOGFILE, argv[1], 1);
       shift; shift;
     } else if (argv[0][0] == '-' && argv[0][1] == 'i' &&
                isdigit(argv[0][2])) { // else if -i5, for example

--- a/src/restartscript.cpp
+++ b/src/restartscript.cpp
@@ -137,6 +137,8 @@ static const char* usage =
   "  --interval, -i, (environment variable DMTCP_CHECKPOINT_INTERVAL):\n"
   "      Time in seconds between automatic checkpoints\n"
   "      (Default: Use pre-checkpoint value)\n"
+  "  --coord-logfile PATH (environment variable DMTCP_COORD_LOG_FILENAME\n"
+  "              Coordinator will dump its logs to the given file\n"
   "  --help:\n"
   "      Print this message and exit.\'\n"
   "\n\n"
@@ -156,6 +158,9 @@ static const char* cmdlineArgHandler =
   "          shift; shift;;\n"
   "        --coord-port|--port|-p)\n"
   "          coord_port=\"$2\"\n"
+  "          shift; shift;;\n"
+  "        --coord-logfile)\n"
+  "          coord_logfile=\"$2\"\n"
   "          shift; shift;;\n"
   "        --hostfile)\n"
   "          hostfile=\"$2\"\n"
@@ -207,7 +212,7 @@ static const char* singleHostProcessing =
   "  ckpt_files=$given_ckpt_files\n"
   "fi\n\n"
 
-  "coordinator_info=\"--coord-host $coord_host --coord-port $coord_port\"\n"
+  "coordinator_info=\"--coord-host $coord_host --coord-port $coord_port --coord-logfile $coord_logfile\"\n"
 
   "tmpdir=\n"
   "if [ ! -z \"$DMTCP_TMPDIR\" ]; then\n"
@@ -292,7 +297,7 @@ static const char* multiHostProcessing =
   "  if [ -z $maybebg ]; then\n"
   "    $maybexterm /usr/bin/ssh -t \"$worker_host\" \\\n"
   "      $dmt_rstr_cmd --coord-host \"$coord_host\""
-                                             " --cord-port \"$coord_port\"\\\n"
+                                             " --cord-port \"$coord_port\" --coord-logfile \"$coord_logfile\"\\\n"
   "      $ckpt_dir --join --interval \"$checkpoint_interval\" $tmpdir \\\n"
   "      $new_ckpt_files_group\n"
   "  else\n"
@@ -300,14 +305,14 @@ static const char* multiHostProcessing =
   // In Open MPI 1.4, without this (sh -c ...), orterun hangs at the
   // end of the computation until user presses enter key.
   "      \"/bin/sh -c \'$dmt_rstr_cmd --coord-host $coord_host"
-                                                " --coord-port $coord_port\\\n"
+                                                " --coord-port $coord_port --coord-logfile $coord_logfile\\\n"
   "      $ckpt_dir --join --interval \"$checkpoint_interval\" $tmpdir \\\n"
   "      $new_ckpt_files_group\'\" &\n"
   "  fi\n\n"
   "done\n\n"
   "if [ -n \"$localhost_ckpt_files_group\" ]; then\n"
   "exec $dmt_rstr_cmd --coord-host \"$coord_host\""
-                                           " --coord-port \"$coord_port\" \\\n"
+                                           " --coord-port \"$coord_port\" --coord-logfile \"$coord_logfile\" \\\n"
   "  $ckpt_dir $maybejoin --interval \"$checkpoint_interval\" $tmpdir $noStrictChecking $localhost_ckpt_files_group\n"
   "fi\n\n"
 


### PR DESCRIPTION
This patch adds a `--coord-logfile <filename>` option to dmtcp_coordinator,
dmtcp_launch, dmtcp_restart, and the restart script. This option can be
used to specify a file where the coordinator can dump its log messages
when running in daemon mode. This is useful for debugging.