### PR TITLE
socketwrappers: Fix masking of real errno

### DIFF
--- a/src/plugin/ipc/socket/socketwrappers.cpp
+++ b/src/plugin/ipc/socket/socketwrappers.cpp
@@ -76,6 +76,7 @@ extern "C" int connect(int sockfd, const struct sockaddr *serv_addr,
   DMTCP_PLUGIN_DISABLE_CKPT(); // The lock is released inside the macro.
 
   int ret = _real_connect(sockfd,serv_addr,addrlen);
+  int savedErrno = errno; // Save errno to prevent modifications by the following code
   if ((ret != -1 || errno == EINPROGRESS) &&
       dmtcp_is_running_state() &&
       !_doNotProcessSockets) {
@@ -89,6 +90,7 @@ extern "C" int connect(int sockfd, const struct sockaddr *serv_addr,
     }
   }
 
+  errno = savedErrno;
   DMTCP_PLUGIN_ENABLE_CKPT();
   return ret;
 }


### PR DESCRIPTION
This patch is an attempt to fix the issue of masking of the _real_
errno by DMTCP's socket wrappers.

The problem is that the code in a wrapper between the call to the real
function and the return statement, for example, JTRACE's, etc., can have
a side-effect of modifying the errno. As a result, the wrapper can end
up returning an incorrect errno to the user. The solution is to save
the errno once a real call returns and restore it just before returning.

Although this patch only addresses the issue for socketwrappers, the
problem is more widespread (see issue #365); I'm putting this out for
early feedback.