### PR TITLE
Expose file-contents-differ error msg to user when using ckpt-open-files

### DIFF
--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -471,7 +471,7 @@ static bool areFilesEqual(int fd, int savedFd, size_t size)
     readBytes = Util::readAll(savedFd, buf1, MIN(bufSize, size));
     JASSERT(readBytes != -1) (JASSERT_ERRNO) .Text("Read Failed");
     if (readBytes == 0) break;
-    JASSERT(Util::readAll(fd, buf2, readBytes) == readBytes);
+    if (Util::readAll(fd, buf2, readBytes) != readBytes) break;
     if (memcmp(buf1, buf2, readBytes) != 0) {
       break;
     }


### PR DESCRIPTION
When using the `--checkpoint-open-files` flag, on restart, the contents
of the saved version of a file are compared with its existing copy (if
any), and if the contents differ, DMTCP's policy is to throw an error to
the user. This is done to ensure that a user's file is not accidentally
overwritten. However, the existing implementation of the file comparison
function, `areFilesEqual()`, would assert out with a misleading error
message leaving the user confused when the file contents differed. This
patch forces the comparison function to return a comparison failed
(false) result to its caller to allow the caller to assert out with a
more meaningful error message.