### PR TITLE
Replaced CoordinatorAPI class with namespace.

### DIFF
--- a/src/dmtcp_command.cpp
+++ b/src/dmtcp_command.cpp
@@ -141,7 +141,6 @@ main(int argc, char **argv)
   int isRunning;
   int ckptInterval;
   char *workerList = NULL;
-  CoordinatorAPI coordinatorAPI;
   char *cmd = (char *)request.c_str();
   switch (*cmd) {
   case 'h':
@@ -150,34 +149,34 @@ main(int argc, char **argv)
 
   case 'i':
     setenv(ENV_VAR_CKPT_INTR, interval.c_str(), 1);
-    coordinatorAPI.connectAndSendUserCommand(*cmd, &coordCmdStatus);
+    CoordinatorAPI::connectAndSendUserCommand(*cmd, &coordCmdStatus);
     printf("Interval changed to %s\n", interval.c_str());
     break;
   case 'b':
   case 'x':
 
     // blocking prefix
-    coordinatorAPI.connectAndSendUserCommand(*cmd, &coordCmdStatus);
+    CoordinatorAPI::connectAndSendUserCommand(*cmd, &coordCmdStatus);
 
     // actual command
-    coordinatorAPI.connectAndSendUserCommand(*(cmd + 1), &coordCmdStatus);
+    CoordinatorAPI::connectAndSendUserCommand(*(cmd + 1), &coordCmdStatus);
     break;
   case 's':
-    coordinatorAPI.connectAndSendUserCommand(*cmd,
-                                             &coordCmdStatus,
-                                             &numPeers,
-                                             &isRunning,
-                                             &ckptInterval);
+    CoordinatorAPI::connectAndSendUserCommand(*cmd,
+                                              &coordCmdStatus,
+                                              &numPeers,
+                                              &isRunning,
+                                              &ckptInterval);
     break;
   case 'l':
     workerList =
-      coordinatorAPI.connectAndSendUserCommand(*cmd, &coordCmdStatus);
+      CoordinatorAPI::connectAndSendUserCommand(*cmd, &coordCmdStatus);
     break;
   case 'c':
   case 'k':
   case 'q':
     workerList =
-      coordinatorAPI.connectAndSendUserCommand(*cmd, &coordCmdStatus);
+      CoordinatorAPI::connectAndSendUserCommand(*cmd, &coordCmdStatus);
     break;
   default:
     fprintf(stderr, theUsage, "");

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -576,9 +576,9 @@ main(int argc, char **argv)
 
   // Initialize host and port now.  Will be used in low-level functions.
   CoordinatorAPI::getCoordHostAndPort(allowedModes, host, &port);
-  CoordinatorAPI::instance().connectToCoordOnStartup(allowedModes, argv[0],
-                                                     &compId, &coordInfo,
-                                                     &localIPAddr);
+  CoordinatorAPI::connectToCoordOnStartup(allowedModes, argv[0],
+                                          &compId, &coordInfo,
+                                          &localIPAddr);
 
   // If port was 0, we'll get new random port when coordinator starts up.
   CoordinatorAPI::getCoordHostAndPort(allowedModes, host, &port);

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -251,14 +251,14 @@ class RestoreTarget
 
         // FIXME:  We will use the new HOST and PORT here, but after restart,,
         // we will use the old HOST and PORT from the ckpt image.
-        CoordinatorAPI::instance().connectToCoordOnRestart(allowedModes,
-                                                           _pInfo.procname(),
-                                                           _pInfo.compGroup(),
-                                                           _pInfo.numPeers(),
-                                                           &coordInfo,
-                                                           host.c_str(),
-                                                           port,
-                                                           &localIPAddr);
+        CoordinatorAPI::connectToCoordOnRestart(allowedModes,
+                                                _pInfo.procname(),
+                                                _pInfo.compGroup(),
+                                                _pInfo.numPeers(),
+                                                &coordInfo,
+                                                host.c_str(),
+                                                port,
+                                                &localIPAddr);
 
         // If port was 0, we'll get new random port when coordinator starts up.
         CoordinatorAPI::getCoordHostAndPort(allowedModes, host, &port);
@@ -368,14 +368,14 @@ class RestoreTarget
         int port = UNINITIALIZED_PORT;
         int *port_p = &port;
         CoordinatorAPI::getCoordHostAndPort(allowedModes, host, port_p);
-        CoordinatorAPI::instance().connectToCoordOnRestart(allowedModes,
-                                                           _pInfo.procname(),
-                                                           _pInfo.compGroup(),
-                                                           _pInfo.numPeers(),
-                                                           NULL,
-                                                           host.c_str(),
-                                                           port,
-                                                           NULL);
+        CoordinatorAPI::connectToCoordOnRestart(allowedModes,
+                                                _pInfo.procname(),
+                                                _pInfo.compGroup(),
+                                                _pInfo.numPeers(),
+                                                NULL,
+                                                host.c_str(),
+                                                port,
+                                                NULL);
       }
 
       setEnvironFd();

--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -76,9 +76,8 @@ dmtcp_checkpoint()
   while (1) {
     WRAPPER_EXECUTION_GET_EXCL_LOCK();
 
-    CoordinatorAPI coordinatorAPI;
     int status;
-    coordinatorAPI.connectAndSendUserCommand('c', &status);
+    CoordinatorAPI::connectAndSendUserCommand('c', &status);
 
     if (status != CoordCmdStatus::ERROR_NOT_RUNNING_STATE) {
       oldNumRestarts = ProcessInfo::instance().numRestarts();
@@ -112,8 +111,7 @@ dmtcp_get_coordinator_status(int *numPeers, int *isRunning)
   WRAPPER_EXECUTION_GET_EXCL_LOCK();
 
   int status;
-  CoordinatorAPI coordinatorAPI;
-  coordinatorAPI.connectAndSendUserCommand('s', &status, numPeers, isRunning);
+  CoordinatorAPI::connectAndSendUserCommand('s', &status, numPeers, isRunning);
 
   WRAPPER_EXECUTION_RELEASE_EXCL_LOCK();
   return DMTCP_IS_PRESENT;
@@ -188,9 +186,7 @@ dmtcp_set_ckpt_dir(const char *dir)
 EXTERNC const char *
 dmtcp_get_coord_ckpt_dir(void)
 {
-  static string dir;
-
-  dir = CoordinatorAPI::instance().getCoordCkptDir();
+  static string dir = CoordinatorAPI::getCoordCkptDir();
   return dir.c_str();
 }
 
@@ -198,7 +194,7 @@ EXTERNC int
 dmtcp_set_coord_ckpt_dir(const char *dir)
 {
   if (dir != NULL) {
-    CoordinatorAPI::instance().updateCoordCkptDir(dir);
+    CoordinatorAPI::updateCoordCkptDir(dir);
   }
   return DMTCP_IS_PRESENT;
 }
@@ -509,11 +505,11 @@ dmtcp_send_key_val_pair_to_coordinator(const char *id,
                                        const void *val,
                                        uint32_t val_len)
 {
-  return CoordinatorAPI::instance().sendKeyValPairToCoordinator(id,
-                                                                key,
-                                                                key_len,
-                                                                val,
-                                                                val_len);
+  return CoordinatorAPI::sendKeyValPairToCoordinator(id,
+                                                     key,
+                                                     key_len,
+                                                     val,
+                                                     val_len);
 }
 
 // On input, val points to a buffer in user memory and *val_len is the maximum
@@ -527,8 +523,7 @@ dmtcp_send_query_to_coordinator(const char *id,
                                 void *val,
                                 uint32_t *val_len)
 {
-  return CoordinatorAPI::instance().sendQueryToCoordinator(id, key, key_len,
-                                                           val, val_len);
+  return CoordinatorAPI::sendQueryToCoordinator(id, key, key_len, val, val_len);
 }
 
 EXTERNC void

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -426,7 +426,7 @@ DmtcpWorker::waitForSuspendMessage()
     string shmFile = jalib::Filesystem::GetDeviceName(PROTECTED_SHM_FD);
     JASSERT(!shmFile.empty());
     unlink(shmFile.c_str());
-    CoordinatorAPI::instance().waitForCheckpointCommand();
+    CoordinatorAPI::waitForCheckpointCommand();
     ProcessInfo::instance().numPeers(1);
     ProcessInfo::instance().compGroup(SharedData::getCompId());
     return;
@@ -445,7 +445,7 @@ DmtcpWorker::waitForSuspendMessage()
   JTRACE("waiting for SUSPEND message");
 
   DmtcpMessage msg;
-  CoordinatorAPI::instance().recvMsgFromCoordinator(&msg);
+  CoordinatorAPI::recvMsgFromCoordinator(&msg);
 
   if (exitInProgress()) {
     ThreadSync::destroyDmtcpWorkerLockUnlock();
@@ -477,10 +477,10 @@ DmtcpWorker::acknowledgeSuspendMsg()
   }
 
   JTRACE("Waiting for DMT_DO_CHECKPOINT message");
-  CoordinatorAPI::instance().sendMsgToCoordinator(DmtcpMessage(DMT_OK));
+  CoordinatorAPI::sendMsgToCoordinator(DmtcpMessage(DMT_OK));
 
   DmtcpMessage msg;
-  CoordinatorAPI::instance().recvMsgFromCoordinator(&msg);
+  CoordinatorAPI::recvMsgFromCoordinator(&msg);
   msg.assertValid();
   if (msg.type == DMT_KILL_PEER) {
     JTRACE("Received KILL message from coordinator, exiting");
@@ -541,7 +541,7 @@ void
 DmtcpWorker::postCheckpoint()
 {
   WorkerState::setCurrentState(WorkerState::CHECKPOINTED);
-  CoordinatorAPI::instance().sendCkptFilename();
+  CoordinatorAPI::sendCkptFilename();
 
   if (_exitAfterCkpt) {
     JTRACE("Asked to exit after checkpoint. Exiting!");
@@ -555,7 +555,7 @@ DmtcpWorker::postCheckpoint()
 
   // Inform Coordinator of RUNNING state.
   WorkerState::setCurrentState(WorkerState::RUNNING);
-  CoordinatorAPI::instance().sendMsgToCoordinator(DmtcpMessage(DMT_OK));
+  CoordinatorAPI::sendMsgToCoordinator(DmtcpMessage(DMT_OK));
 }
 
 void
@@ -572,5 +572,5 @@ DmtcpWorker::postRestart(double ckptReadTime)
 
   // Inform Coordinator of RUNNING state.
   WorkerState::setCurrentState(WorkerState::RUNNING);
-  CoordinatorAPI::instance().sendMsgToCoordinator(DmtcpMessage(DMT_OK));
+  CoordinatorAPI::sendMsgToCoordinator(DmtcpMessage(DMT_OK));
 }

--- a/src/plugininfo.cpp
+++ b/src/plugininfo.cpp
@@ -121,7 +121,7 @@ PluginInfo::processBarrier(BarrierInfo *barrier)
     // Do nothing.
   } else if (barrier->isGlobal()) {
     JTRACE("Waiting for global barrier") (barrier->toString());
-    CoordinatorAPI::instance().waitForBarrier(barrier->toString());
+    CoordinatorAPI::waitForBarrier(barrier->toString());
   } else if (barrier->isLocal()) {
     JTRACE("Waiting for local barrier") (barrier->toString());
     SharedData::waitForBarrier(barrier->toString());

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -25,12 +25,10 @@ dmtcp_register_plugin(DmtcpPluginDescriptor_t descr)
 
 namespace dmtcp
 {
-DmtcpPluginDescriptor_t dmtcp_CoordinatorAPI_PluginDescr();
 DmtcpPluginDescriptor_t dmtcp_ProcessInfo_PluginDescr();
 DmtcpPluginDescriptor_t dmtcp_Syslog_PluginDescr();
 DmtcpPluginDescriptor_t dmtcp_Alarm_PluginDescr();
 DmtcpPluginDescriptor_t dmtcp_Terminal_PluginDescr();
-DmtcpPluginDescriptor_t dmtcp_CoordinatorAPI_PluginDescr();
 
 void
 PluginManager::initialize()
@@ -68,7 +66,7 @@ dmtcp_initialize_plugin()
   dmtcp_register_plugin(dmtcp_Syslog_PluginDescr());
   dmtcp_register_plugin(dmtcp_Alarm_PluginDescr());
   dmtcp_register_plugin(dmtcp_Terminal_PluginDescr());
-  dmtcp_register_plugin(dmtcp_CoordinatorAPI_PluginDescr());
+  dmtcp_register_plugin(CoordinatorAPI::pluginDescr());
   dmtcp_register_plugin(dmtcp_ProcessInfo_PluginDescr());
 
   void (*fn)() = NEXT_FNC(dmtcp_initialize_plugin);
@@ -119,13 +117,8 @@ PluginManager::registerBarriersWithCoordinator()
     Util::joinStrings(ckptBarriers, ",") + ";" +
     Util::joinStrings(restartBarriers, ",");
 
-  DmtcpMessage msg;
-  msg.type = DMT_BARRIER_LIST;
-  msg.state = WorkerState::currentState();
-  msg.extraBytes = barrierList.length() + 1;
-  CoordinatorAPI::instance().sendMsgToCoordinator(msg,
-                                                  barrierList.c_str(),
-                                                  msg.extraBytes);
+  DmtcpMessage msg(DMT_BARRIER_LIST);
+  CoordinatorAPI::sendMsgToCoordinator(msg, barrierList);
 }
 
 void
@@ -211,7 +204,7 @@ PluginManager::processRestartBarriers()
 
   Util::allowGdbDebug(DEBUG_PLUGIN_MANAGER);
 
-  CoordinatorAPI::instance().waitForBarrier(firstRestartBarrier);
+  CoordinatorAPI::waitForBarrier(firstRestartBarrier);
 
   for (int i = pluginManager->pluginInfos.size() - 1; i >= 0; i--) {
     pluginManager->pluginInfos[i]->processBarriers();


### PR DESCRIPTION
Instead of using a singleton class, we use the namespace with a couple of file-global variables (coordinatorSocket and nsSocket).

This PR is motivated by the interactions around instantiation of CoordinatorAPI singleton class during startup. Often, this has caused some weird code paths where the object instantiation calls malloc which in turn calls other functions/wrappers and so on.
