### PR TITLE
fileconnection: Fix ckpt-ing of deleted files

### DIFF
--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -160,14 +160,15 @@ void FileConnection::drain()
     return;
   }
 
+  if (_type == FILE_DELETED && (_flags & O_WRONLY)) {
+    return;
+  }
+
   if (dmtcp_must_ckpt_file && dmtcp_must_ckpt_file(_path.c_str())) {
     _ckpted_file = true;
     return;
   }
 
-  if (_type == FILE_DELETED && (_flags & O_WRONLY)) {
-    return;
-  }
   if (_isBlacklistedFile(_path)) {
     return;
   }


### PR DESCRIPTION
This patch fixes an issue with ckpt-ing of deleted files caused when a plugin
uses the `dmtcp_must_ckpt_file()` API to force checkpointing of a
file that might have been deleted. The fix is to return early from the
`FileConnection::drain()` method in case of a deleted file, i.e., return
without checking for the return value of the `dmtcp_must_ckpt_file()` API.