### PR TITLE
This patch will enable pathvirt on process lauched via ssh/rsh.

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -74,6 +74,7 @@ EXTERNC int dmtcp_batch_queue_enabled(void) __attribute__((weak));
 EXTERNC int dmtcp_modify_env_enabled(void) __attribute__((weak));
 EXTERNC int dmtcp_ptrace_enabled(void) __attribute__((weak));
 EXTERNC int dmtcp_unique_ckpt_enabled(void) __attribute__((weak));
+EXTERNC int dmtcp_pathvirt_enabled(void) __attribute__((weak));
 
 
 /*

--- a/plugin/pathvirt/pathvirt.cpp
+++ b/plugin/pathvirt/pathvirt.cpp
@@ -69,6 +69,8 @@ static char newPathPrefixList[MAX_ENV_VAR_SIZE];
 static bool tmpBufferModified = false;
 static pthread_rwlock_t  listRwLock;
 
+EXTERNC int dmtcp_pathvirt_enabled() { return 1; }
+
 /*
  * Helper Functions
  */
@@ -362,6 +364,25 @@ dmtcp_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
            shouldSwap = *oldPathPrefixList && *newPathPrefixList;
        }
        break;
+    }
+    case DMTCP_EVENT_RESTART:
+    {
+      char tmp[MAX_ENV_VAR_SIZE] = {0};
+
+      int ret = dmtcp_get_restart_env(ENV_ORIG_DPP, tmp, sizeof(tmp) - 1);
+      errCheckGetRestartEnv(ret);
+ 
+      if (ret == RESTART_ENV_SUCCESS) {
+        setenv(ENV_ORIG_DPP, tmp, 1);
+      }
+
+      ret = dmtcp_get_restart_env(ENV_NEW_DPP, tmp, sizeof(tmp) - 1);
+      errCheckGetRestartEnv(ret);
+ 
+      if (ret == RESTART_ENV_SUCCESS) {
+        setenv(ENV_NEW_DPP, tmp, 1);
+      }
+      break;
     }
     default:
     ;

--- a/plugin/pathvirt/pathvirt.cpp
+++ b/plugin/pathvirt/pathvirt.cpp
@@ -199,6 +199,9 @@ pathvirtInitialize()
     int ret = dmtcp_get_restart_env(ENV_NEW_DPP, newPathPrefixList,
                                     sizeof(newPathPrefixList) - 1);
     errCheckGetRestartEnv(ret);
+    if (ret == RESTART_ENV_SUCCESS) {
+      setenv(ENV_NEW_DPP, newPathPrefixList, 1);
+    }
 
     /* If the user had modified the original buffer prior to checkpointing,
      * we use it now.
@@ -217,6 +220,7 @@ pathvirtInitialize()
     if (ret == RESTART_ENV_SUCCESS) {
         memset(oldPathPrefixList, 0, sizeof(oldPathPrefixList));
         snprintf(oldPathPrefixList, sizeof(oldPathPrefixList), "%s", tmp);
+        setenv(ENV_ORIG_DPP, tmp, 1);
     }
 
     /* we should only swap if oldPathPrefixList contains something,
@@ -364,25 +368,6 @@ dmtcp_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
            shouldSwap = *oldPathPrefixList && *newPathPrefixList;
        }
        break;
-    }
-    case DMTCP_EVENT_RESTART:
-    {
-      char tmp[MAX_ENV_VAR_SIZE] = {0};
-
-      int ret = dmtcp_get_restart_env(ENV_ORIG_DPP, tmp, sizeof(tmp) - 1);
-      errCheckGetRestartEnv(ret);
- 
-      if (ret == RESTART_ENV_SUCCESS) {
-        setenv(ENV_ORIG_DPP, tmp, 1);
-      }
-
-      ret = dmtcp_get_restart_env(ENV_NEW_DPP, tmp, sizeof(tmp) - 1);
-      errCheckGetRestartEnv(ret);
- 
-      if (ret == RESTART_ENV_SUCCESS) {
-        setenv(ENV_NEW_DPP, tmp, 1);
-      }
-      break;
     }
     default:
     ;

--- a/src/plugin/ipc/ssh/ssh.cpp
+++ b/src/plugin/ipc/ssh/ssh.cpp
@@ -16,6 +16,8 @@
 using namespace dmtcp;
 
 #define SSHD_PIPE_FD -1
+#define ENV_ORIG_DPP       "DMTCP_ORIGINAL_PATH_PREFIX"
+#define ENV_NEW_DPP        "DMTCP_NEW_PATH_PREFIX"
 
 static string cmd;
 static string prefix;
@@ -335,6 +337,23 @@ static void prepareForExec(char *const argv[], char ***newArgv)
     prefix += " --rsh-slave ";
   } else {
     prefix += " --ssh-slave ";
+  }
+
+  if(dmtcp_pathvirt_enabled && dmtcp_pathvirt_enabled()) {
+    if(getenv(ENV_NEW_DPP)) {
+      prefix += "/usr/bin/env ";
+      prefix += ENV_NEW_DPP;
+      prefix += "=";
+      prefix += getenv(ENV_NEW_DPP);
+      prefix += " ";
+    }
+    if(getenv(ENV_ORIG_DPP)) {
+      prefix += "/usr/bin/env ";
+      prefix += ENV_ORIG_DPP;
+      prefix += "=";
+      prefix += getenv(ENV_ORIG_DPP);
+      prefix += " ";
+    }
   }
 
   JTRACE("Prefix")(prefix);

--- a/src/util_exec.cpp
+++ b/src/util_exec.cpp
@@ -689,6 +689,10 @@ void Util::getDmtcpArgs(vector<string> &dmtcp_args)
     dmtcp_args.push_back("--batch-queue");
   }
 
+  if (dmtcp_pathvirt_enabled != NULL && dmtcp_pathvirt_enabled()) {
+    dmtcp_args.push_back("--pathvirt");
+  }
+
 #ifdef HBICT_DELTACOMP
   if (deltacompression != NULL) {
     if (strcmp(deltacompression, "0") == 0)


### PR DESCRIPTION
Currently pathvirt is not enabled on processes launched on remote
machine via rsh/ssh. Also the corresponding environment variables
DMTCP_ORIGINAL_PATH_PREFIX/DMTCP_NEW_PATH_PREFIX are not propagated
on restarted process. So setting these environments in restart
within partvirt plugin. Also passing additional arguments to
processes launched on remote machine in ssh plugin.