### PR TITLE
New API get_virtual_to_physical_path

### DIFF
--- a/plugin/pathvirt/pathvirt.cpp
+++ b/plugin/pathvirt/pathvirt.cpp
@@ -311,6 +311,14 @@ get_new_path_prefix_list()
   pthread_rwlock_unlock(&listRwLock);
 }
 
+EXTERNC const char*
+get_virtual_to_physical_path(const char *virt_path)
+{
+  static dmtcp::string temp;
+  temp = VIRTUAL_TO_PHYSICAL_PATH(virt_path);
+  return temp.c_str();
+}
+
 /*
  * DMTCP Setup
  */


### PR DESCRIPTION
Assume that path virtualization is enabled and after restart, proces will
perform path virtualization. Now consider that restarted process connects
to some external process which is not running under DMTCP. On connection it
sends some path which was present in virtual->physical mapping. This would
be problem for external process as it would not perform path mapping.

This can be solved if restarted process can query for the physical mapping
and accordingly send the new path to external process.

PathVirt plugin already has same api but that is not exposed, can this API
be exposed similar to other DMTCP APIs.