### PR TITLE
monitorSockets: Re-implement using poll()

### DIFF
--- a/jalib/jalib.cpp
+++ b/jalib/jalib.cpp
@@ -166,6 +166,10 @@ namespace jalib {
                                         timeout);
   }
 
+  int poll(struct pollfd fds[], nfds_t nfds, int timeout) {
+    REAL_FUNC_PASSTHROUGH(int, poll) (fds, nfds, timeout);
+  }
+
   int socket(int domain, int type, int protocol) {
     REAL_FUNC_PASSTHROUGH(int, socket) (domain, type, protocol);
   }

--- a/jalib/jalib.h
+++ b/jalib/jalib.h
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <poll.h>
 
 #include <fstream>
 
@@ -49,6 +50,7 @@ namespace jalib {
     ssize_t (*write)(int fd, const void *buf, size_t count);
     int   (*select)(int nfds, fd_set *readfds, fd_set *writefds,
                     fd_set *exceptfds, struct timeval *timeout);
+    int   (*poll)(struct pollfd fds[], nfds_t nfds, int timeout);
 
     int   (*socket)(int domain, int type, int protocol);
     int   (*connect)(int sockfd, const struct sockaddr *saddr, socklen_t addrlen);
@@ -86,6 +88,7 @@ namespace jalib {
   ssize_t write(int fd, const void *buf, size_t count);
   int select(int nfds, fd_set *readfds, fd_set *writefds,
              fd_set *exceptfds, struct timeval *timeout);
+  int poll(struct pollfd fds[], nfds_t nfds, int timeout);
 
   int socket(int domain, int type, int protocol);
   int connect(int sockfd, const struct sockaddr *serv_addr, socklen_t addrlen);

--- a/src/jalibinterface.cpp
+++ b/src/jalibinterface.cpp
@@ -51,6 +51,7 @@ extern "C" void initializeJalib()
   INIT_JALIB_FPTR(read);
   INIT_JALIB_FPTR(write);
   INIT_JALIB_FPTR(select);
+  INIT_JALIB_FPTR(poll);
 
   INIT_JALIB_FPTR(socket);
   INIT_JALIB_FPTR(connect);


### PR DESCRIPTION
This patch fixes an issue (#389) with the `monitorsockets()` function that
would result in a buffer overflow at checkpoint time for applications
that open many file descriptors (> 1024). The issue arises due to
the use of `select()` call.  The root cause for the buffer overflows
is the implementation of `FD_{SET|CLR|ISSET}` macros in glibc. However,
according to the man page, it's the application's responsibility to ensure
that these macros are not called for a file-descriptor that is larger than
FD_SETSIZE, which is typically 1024 in most implementations.

The fix here is to re-implement the function using `poll()`, which scales
better than `select()`.