### PR TITLE
Fix commit 2590376dc (restoring ARM_HOST)

### DIFF
--- a/configure
+++ b/configure
@@ -664,6 +664,9 @@ HAS_CMA
 AARCH64_HOST
 AARCH64_HOST_FALSE
 AARCH64_HOST_TRUE
+ARM_HOST
+ARM_HOST_FALSE
+ARM_HOST_TRUE
 HAS_READLINE
 M32
 CONFIG_M32_FALSE
@@ -5681,6 +5684,23 @@ case "$host_cpu" in
   aarch64*) is_aarch64_host=yes ;;
   i?86) is_i486_host=yes ;;
 esac
+
+ if test "$is_arm_host" == "yes"; then
+  ARM_HOST_TRUE=
+  ARM_HOST_FALSE='#'
+else
+  ARM_HOST_TRUE='#'
+  ARM_HOST_FALSE=
+fi
+
+if test "$is_arm_host" == "yes"; then
+  ARM_HOST=yes
+
+else
+  ARM_HOST=no
+
+fi
+
  if test "$is_aarch64_host" == "yes"; then
   AARCH64_HOST_TRUE=
   AARCH64_HOST_FALSE='#'
@@ -7436,6 +7456,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${CONFIG_M32_TRUE}" && test -z "${CONFIG_M32_FALSE}"; then
   as_fn_error $? "conditional \"CONFIG_M32\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${ARM_HOST_TRUE}" && test -z "${ARM_HOST_FALSE}"; then
+  as_fn_error $? "conditional \"ARM_HOST\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${AARCH64_HOST_TRUE}" && test -z "${AARCH64_HOST_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -347,6 +347,14 @@ case "$host_cpu" in
   aarch64*) is_aarch64_host=yes ;;
   i?86) is_i486_host=yes ;;
 esac
+
+AM_CONDITIONAL(ARM_HOST, [test "$is_arm_host" == "yes"])
+if test "$is_arm_host" == "yes"; then
+  AC_SUBST([ARM_HOST], [yes])
+else
+  AC_SUBST([ARM_HOST], [no])
+fi
+
 AM_CONDITIONAL(AARCH64_HOST, [test "$is_aarch64_host" == "yes"])
 if test "$is_aarch64_host" == "yes"; then
   AC_SUBST([AARCH64_HOST], [yes])


### PR DESCRIPTION
In commit 2590376dc (Sep. 16, 2015), I accidentally removed ARM (32-bit) support while trying to add AARCH64 support.  I've tested this restoration on a BeagleBoard (ARM Cortex A8), and it seems to be working there.

The only real change is in configure.ac.  You can see what I did by looking at my buggy commit:
`git diff 2590376dc^ 2590376dc -- configure.ac`
and comparing that old commit with the diff for configure.ac in this commit request.

I'm hoping for a fast review.  :-)  This should go into all of 3.0, 2.5, and 2.4.5.