### PR TITLE
pid-plugin: Fix restart callback to use _real_* functions

### DIFF
--- a/src/plugin/pid/pid.cpp
+++ b/src/plugin/pid/pid.cpp
@@ -147,9 +147,9 @@ static void openOriginalToCurrentMappingFiles()
   if (!Util::isValidFd(PROTECTED_PIDMAP_FD)) {
     fd = openSharedFile(pidMapFile, O_RDWR);
     JASSERT (fd != -1);
-    JASSERT (dup2 (fd, PROTECTED_PIDMAP_FD) == PROTECTED_PIDMAP_FD)
+    JASSERT (_real_dup2 (fd, PROTECTED_PIDMAP_FD) == PROTECTED_PIDMAP_FD)
       (pidMapFile);
-    close (fd);
+    _real_close (fd);
   }
 }
 

--- a/src/plugin/pid/pid_syscallsreal.c
+++ b/src/plugin/pid/pid_syscallsreal.c
@@ -385,6 +385,18 @@ int _real_open64(const char *path, int flags, ...) {
   REAL_FUNC_PASSTHROUGH(open64) (path, flags, mode);
 }
 
+LIB_PRIVATE
+int _real_close(int fd)
+{
+  REAL_FUNC_PASSTHROUGH(close) (fd);
+}
+
+LIB_PRIVATE
+int _real_dup2(int fd1, int fd2)
+{
+  REAL_FUNC_PASSTHROUGH(dup2) (fd1, fd2);
+}
+
 FILE* _real_fopen(const char *path, const char *mode) {
   REAL_FUNC_PASSTHROUGH_TYPED(FILE*, fopen) (path, mode);
 }

--- a/src/plugin/pid/pidwrappers.h
+++ b/src/plugin/pid/pidwrappers.h
@@ -146,6 +146,8 @@ extern "C"
   MACRO(fcntl)              \
   MACRO(open)               \
   MACRO(open64)             \
+  MACRO(close)              \
+  MACRO(dup2)               \
   MACRO(fopen64)            \
   MACRO(__xstat)            \
   MACRO(__xstat64)          \
@@ -254,6 +256,8 @@ extern "C"
 
   int _real_open(const char *pathname, int flags, ...);
   int _real_open64(const char *pathname, int flags, ...);
+  int _real_close(int fd);
+  int _real_dup2(int fd1, int fd2);
   FILE* _real_fopen(const char *path, const char *mode);
   FILE* _real_fopen64(const char *path, const char *mode);
   int _real_fclose(FILE *fp);


### PR DESCRIPTION
This appears to be an old bug. Usage of close()/dup2() can lead
to unexpected consequences where a fd associated with a different
plugin (socket, etc.) may be closed affecting their behavior on
restart.

I noticed this issue when a raw socket associated with the IPC plugin
was being closed unintentionally as a result of calling close() in the
pid plugin's restart callback. The temporary PIDMAP fd opened in the
restart callback happened to be the same as the socket fd that the raw
socket was associated with prior to checkpointing.