### PR TITLE
socket-plugin: Add basic support for raw (netlink) sockets

### DIFF
--- a/jalib/jbuffer.cpp
+++ b/jalib/jbuffer.cpp
@@ -38,6 +38,14 @@ jalib::JBuffer::JBuffer ( const char* src, int size )
   memcpy ( _buffer, src, _size );
 }
 
+jalib::JBuffer::JBuffer ( const void* src, int size )
+    :_size ( size )
+{
+  _buffer = (char*)JALLOC_HELPER_MALLOC(size);
+  JASSERT ( size >= 0 ) ( size );
+  memcpy ( _buffer, src, _size );
+}
+
 
 jalib::JBuffer::~JBuffer()
 {

--- a/jalib/jbuffer.h
+++ b/jalib/jbuffer.h
@@ -39,6 +39,7 @@ namespace jalib
 #endif
       JBuffer ( int size = 0 );
       JBuffer ( const char* source, int size );
+      JBuffer ( const void* source, int size );
       JBuffer ( const JBuffer& that );
       ~JBuffer();
       jalib::JBuffer& operator= ( const JBuffer& that );


### PR DESCRIPTION
This patch adds some basic support for raw (netlink) sockets with some
reorganization and clean-up of the code in the socket plugin.

Future patches will make the support more robust.