### PR TITLE
File deleted bug 

### DIFF
--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -162,7 +162,7 @@ void FileConnection::drain()
     return;
   }
 
-  if (_type == FILE_DELETED && (_flags & O_WRONLY)) {
+  if (_type == FILE_DELETED && (_fcntlFlags & O_WRONLY)) {
     return;
   }
 
@@ -316,7 +316,7 @@ void FileConnection::refill(bool isRestart)
 
   if (!_ckpted_file) {
     int tempfd;
-    if (_type == FILE_DELETED && ((_flags & O_WRONLY) || (_flags & O_RDWR))) {
+    if (_type == FILE_DELETED && ((_fcntlFlags & O_WRONLY) || (_fcntlFlags & O_RDWR))) {
       tempfd = _real_open(_path.c_str(), _fcntlFlags | O_CREAT, 0600);
       JASSERT(tempfd != -1) (_path) (JASSERT_ERRNO) .Text("open() failed");
       JASSERT(truncate(_path.c_str(), _st_size) ==  0)


### PR DESCRIPTION
Consider a scenario in which file is already opened by
parent and now child process is forked. DMTCP infrastructure
doesn't populates _flags field in FileConnection class of
child process. Now at certain time file is deleted using
unlink however file pointer was not closed. Further
child process invokes the application level checkpoint.

This has resulted in issue. Fix is to use _fcntlFlags
filed