### PR TITLE
socket-plugin: Replace call to select() in drain() with poll()

### DIFF
--- a/src/plugin/ipc/socket/socketwrappers.h
+++ b/src/plugin/ipc/socket/socketwrappers.h
@@ -39,5 +39,6 @@
 #define _real_getnameinfo NEXT_FNC(getnameinfo)
 #define _real_gethostbyname NEXT_FNC(gethostbyname)
 #define _real_gethostbyaddr NEXT_FNC(gethostbyaddr)
+#define _real_poll NEXT_FNC(poll)
 
 #endif // SOCKET_WRAPPERS_H


### PR DESCRIPTION
The select() call is only capable of handling 1024 fds. Usage of select()
with more than 1024 fds can lead to undefined behavior because of the
way it's implemented in libc. This patch replaces a call to select()
with poll() in the drain() method of the TcpConnection class.