### PR TITLE
ipc-plugin: Replace calls to select() with drain()

### DIFF
--- a/src/plugin/ipc/file/ptyconnection.cpp
+++ b/src/plugin/ipc/file/ptyconnection.cpp
@@ -45,8 +45,7 @@ static bool ptmxTestPacketMode(int masterFd)
 {
   char tmp_buf[100];
   int slave_fd, ioctlArg, rc;
-  fd_set read_fds;
-  struct timeval zeroTimeout = {0, 0}; /* Zero: will use to poll, not wait.*/
+  struct pollfd pollFd = {0};
 
   _real_ptsname_r(masterFd, tmp_buf, 100);
   /* permissions not used, but _real_open requires third arg */
@@ -70,10 +69,10 @@ static bool ptmxTestPacketMode(int masterFd)
   ioctlArg = 1;
   ioctl(masterFd, TIOCINQ, &ioctlArg);
   /* Now check if there's a command byte still to read. */
-  FD_ZERO(&read_fds);
-  FD_SET(masterFd, &read_fds);
-  select(masterFd + 1, &read_fds, NULL, NULL, &zeroTimeout);
-  if (FD_ISSET(masterFd, &read_fds)) {
+  pollFd.fd = masterFd;
+  pollFd.events = POLLIN;
+  _real_poll(&pollFd, 1, 0); /* Zero: will use to poll, not wait.*/
+  if (pollFd.revents & POLLIN) {
     // Clean up someone else's command byte from packet mode.
     // FIXME:  We should restore this on resume/restart.
     rc = read(masterFd, tmp_buf, 100);
@@ -98,12 +97,11 @@ static bool ptmxTestPacketMode(int masterFd)
 // Also record the count read on each iteration, in case it's packet mode
 static bool readyToRead(int fd)
 {
-  fd_set read_fds;
-  struct timeval zeroTimeout = {0, 0}; /* Zero: will use to poll, not wait.*/
-  FD_ZERO(&read_fds);
-  FD_SET(fd, &read_fds);
-  select(fd + 1, &read_fds, NULL, NULL, &zeroTimeout);
-  return FD_ISSET(fd, &read_fds);
+  struct pollfd pollFd = {0};
+  pollFd.fd = fd;
+  pollFd.events = POLLIN;
+  _real_poll(&pollFd, 1, 0); /* Zero: will use to poll, not wait.*/
+  return (pollFd.revents & POLLIN);
 }
 
 // returns 0 if not ready to read; else returns -1, or size read incl. header

--- a/src/plugin/ipc/ipc.h
+++ b/src/plugin/ipc/ipc.h
@@ -26,6 +26,8 @@
 #include <dirent.h>
 #include <sys/types.h>
 #include <linux/version.h>
+#include <signal.h>
+#include <poll.h>
 #include "dmtcp.h"
 
 #define CONNECTION_ID_START 99000
@@ -49,6 +51,7 @@
 
 #define _real_fcntl NEXT_FNC(fcntl)
 #define _real_select NEXT_FNC(select)
+#define _real_poll NEXT_FNC(poll)
 #define _real_pthread_mutex_lock NEXT_FNC(pthread_mutex_lock)
 #define _real_pthread_mutex_unlock NEXT_FNC(pthread_mutex_unlock)
 


### PR DESCRIPTION
This patch is a follow-up to commit: 907003c. As mentioned before, the
select() call is only capable of handling 1024 fds. Usage of select()
with more than 1024 fds can lead to undefined behavior because of the
way it's implemented in libc. This patch replaces calls to select()
with poll() in four different places in the IPC plugin.