### PR TITLE
Issue with PROT_NONE permissions pages being skipped to be stored in ckpt image

### DIFF
--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -204,10 +204,15 @@ void mtcp_writememoryareas(int fd)
      *
      * We suspect that libpthread is using mmap() instead of mprotect to change
      * the permission from "---p" to "rw-p".
+     *
+     * Also, on SUSE 12, if this region was part of heap, the protected region 
+     * may have the label "[heap]".  So, we also save the memory region if it 
+     * has label "[heap]", "[stack]", or  "[stack:XXX]".
      */
 
     if (!((area.prot & PROT_READ) || (area.prot & PROT_WRITE)) &&
-        (area.name[0] != '\0') && strcmp(area.name, "[heap]")) {
+        (area.name[0] != '\0') && strcmp(area.name, "[heap]") &&
+        strcmp(area.name, "[stack]") && (!Util::strStartsWith(area.name, "[stack:XXX]"))){
       continue;
     }
 
@@ -341,9 +346,9 @@ static void mtcp_get_next_page_range(Area *area, size_t *size, int *is_zero)
 static void mtcp_write_non_rwx_and_anonymous_pages(int fd, Area *orig_area)
 {
   Area area = *orig_area;
-  /* Now give read permission to the anonymous pages that do not have read
-   * permission. We should remove the permission as soon as we are done
-   * writing the area to the checkpoint image
+  /* Now give read permission to the anonymous/[heap]/[stack]/[stack:XXX] pages 
+   * that do not have read permission. We should remove the permission 
+   * as soon as we are done writing the area to the checkpoint image
    *
    * NOTE: Changing the permission here can results in two adjacent memory
    * areas to become one (merged), if they have similar permissions. This can
@@ -352,7 +357,10 @@ static void mtcp_write_non_rwx_and_anonymous_pages(int fd, Area *orig_area)
    * code and that should reset the /proc/self/maps files to its original
    * condition.
    */
-  JASSERT(orig_area->name[0] == '\0' || (strcmp(orig_area->name, "[heap]") == 0));
+
+  JASSERT(orig_area->name[0] == '\0' || (strcmp(orig_area->name, "[heap]") == 0) ||
+         (strcmp(orig_area->name, "[stack]") == 0) || 
+         (Util::strStartsWith(area.name, "[stack:XXX]")));
 
   if ((orig_area->prot & PROT_READ) == 0) {
     JASSERT(mprotect(orig_area->addr, orig_area->size,

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -207,7 +207,7 @@ void mtcp_writememoryareas(int fd)
      */
 
     if (!((area.prot & PROT_READ) || (area.prot & PROT_WRITE)) &&
-        area.name[0] != '\0') {
+        (area.name[0] != '\0') && strcmp(area.name, "[heap]")) {
       continue;
     }
 
@@ -352,7 +352,7 @@ static void mtcp_write_non_rwx_and_anonymous_pages(int fd, Area *orig_area)
    * code and that should reset the /proc/self/maps files to its original
    * condition.
    */
-  JASSERT(orig_area->name[0] == '\0');
+  JASSERT(orig_area->name[0] == '\0' || (strcmp(orig_area->name, "[heap]") == 0));
 
   if ((orig_area->prot & PROT_READ) == 0) {
     JASSERT(mprotect(orig_area->addr, orig_area->size,


### PR DESCRIPTION
Current strategy is to skip pages storing in checkpoint database
which are not anonymous and don't have any READ/WRITE permissions.
Anonymous area is identified reading /proc/<pid>/maps file with empty
string for the name. Adding only anonymous pages was necessary to checkpoint
database as user might have removed the permissions temporarily and
may later restore the permissions for later use. In case restore
of permissions happens after restart and in case we have skipped mapping
these pages to user memory then it will result in segvs if in user code.

Assumption that only anonymous areas have this property is breaking
on some kernels.

In my case if memory is allocated on heap and mprotect gives it PROT_NONE
permission then I see different behavior on SUSE12 and RHEL6 machines.

1) On Suse12(Kernel 3.0.13-0.27) after mprotect call memory area is still
marked as heap segment

2) However on RHEL6 (Kernel 2.6.32-431)  after mprotect call memory
area is marked as anonymous

1st scenario is breaking code in writeckpt.cpp which only assumes area
with non-empty string with no read/write permissions should be skipped
being stored in checkpoint image, hence causing issues in restart as
area is not mapped in process memory.