### PR TITLE
pid-plugin: Use pre-allocated buffer for mutex map

### DIFF
--- a/src/plugin/pid/pid.cpp
+++ b/src/plugin/pid/pid.cpp
@@ -36,11 +36,12 @@ using namespace dmtcp;
 extern "C" pid_t dmtcp_update_ppid();
 
 static string pidMapFile;
-map<pthread_mutex_t*, pid_t>& mapMutexVirtTid()
+dmtcp::map<pthread_mutex_t*, pid_t>& mapMutexVirtTid()
 {
-  static map<pthread_mutex_t*, pid_t> *instance = NULL;
+  static dmtcp::map<pthread_mutex_t*, pid_t> *instance = NULL;
   if (instance == NULL) {
-    instance = new map<pthread_mutex_t*, pid_t>();
+    void *buffer = JALLOC_MALLOC(1024*1024);
+    instance = new (buffer) dmtcp::map<pthread_mutex_t*, pid_t>();
   }
   return *instance;
 }


### PR DESCRIPTION
The pid plugin uses the `mapMutexVirtTid` STL map to track mutexes used
by an application. This is required to patch the libc internal mutex
structs on restart. The problem with the current approach is that calls
to allocate and initiate the map (using the new operator) can lead to
a deadlock when an application defines uses a custom memory allocator
library that ends up calling other wrappers. The fix is to force the
allocation of the map from the DMTCP alloc arena.

Here's an excerpt from a stacktrace demonstrating the bug:

    #15 pthread_mutex_lock ()
    #16 dmtcp::ConnectionList::_lock_tbl ()
    #17 dmtcp::ConnectionList::add ()
    #18 dmtcp::FileConnList::processFileConnection ()
    #19 _open_open64_work ()
    #20 open (path=0x5809fc "/dev/zero", flags=<optimized out>)
    ...
    #23 operator new (req=48)
    #24 mapMutexVirtTid ()
    #25 pthread_mutex_lock ()
    #26 lock_threads ()
    #27 dmtcp::ThreadList::getNewThread ()
    #28 dmtcp::ThreadList::init ()
    #29 dmtcp_initialize ()

Although, this patch fixes the problem for now, a proper fix would be
to change the DMTCP internal locks to use custom locking primitives.