### PR TITLE
Plugins for DMTCP 3.0 don't require config.h now

### DIFF
--- a/configure
+++ b/configure
@@ -4930,7 +4930,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 ac_config_headers="$ac_config_headers include/config.h"
 
-ac_config_files="$ac_config_files Makefile contrib/Makefile contrib/ckptfile/Makefile contrib/infiniband/Makefile plugin/Makefile src/Makefile src/mtcp/Makefile src/plugin/Makefile test/Makefile test/autotest_config.py test/plugin/Makefile"
+ac_config_files="$ac_config_files Makefile contrib/Makefile contrib/ckptfile/Makefile contrib/infiniband/Makefile plugin/Makefile src/Makefile src/mtcp/Makefile src/plugin/Makefile include/dmtcp.h test/Makefile test/autotest_config.py test/plugin/Makefile"
 
 #AC_CONFIG_FILES([test/credentials/Makefile])
 
@@ -8118,6 +8118,7 @@ do
     "src/Makefile") CONFIG_FILES="$CONFIG_FILES src/Makefile" ;;
     "src/mtcp/Makefile") CONFIG_FILES="$CONFIG_FILES src/mtcp/Makefile" ;;
     "src/plugin/Makefile") CONFIG_FILES="$CONFIG_FILES src/plugin/Makefile" ;;
+    "include/dmtcp.h") CONFIG_FILES="$CONFIG_FILES include/dmtcp.h" ;;
     "test/Makefile") CONFIG_FILES="$CONFIG_FILES test/Makefile" ;;
     "test/autotest_config.py") CONFIG_FILES="$CONFIG_FILES test/autotest_config.py" ;;
     "test/plugin/Makefile") CONFIG_FILES="$CONFIG_FILES test/plugin/Makefile" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,7 @@ AC_CONFIG_FILES([Makefile \
                  src/Makefile \
                  src/mtcp/Makefile \
                  src/plugin/Makefile \
+                 include/dmtcp.h \
                  test/Makefile \
                  test/autotest_config.py \
                  test/plugin/Makefile])

--- a/include/dmtcp.h.in
+++ b/include/dmtcp.h.in
@@ -38,6 +38,10 @@
 # endif // ifdef __cplusplus
 #endif // ifndef EXTERNC
 
+/* Define to the version of this package. */
+#define DMTCP_PACKAGE_VERSION "@PACKAGE_VERSION@"
+#define DMTCP_PLUGIN_API_VERSION "3"
+
 // C++ takes null arg, while C takes void arg.
 #ifdef __cplusplus
 # define DMTCP_VOID
@@ -46,8 +50,6 @@
 #endif // ifdef __cplusplus
 
 #define LIB_PRIVATE              __attribute__((visibility("hidden")))
-
-#define DMTCP_PLUGIN_API_VERSION "3"
 
 typedef enum eDmtcpEvent {
   DMTCP_EVENT_INIT,

--- a/test/plugin/applic-delayed-ckpt/applic.c
+++ b/test/plugin/applic-delayed-ckpt/applic.c
@@ -23,7 +23,7 @@
 #include <unistd.h>
 
 #include "dmtcp.h"
-;
+
 int
 main()
 {

--- a/test/plugin/applic-delayed-ckpt/plugin-to-announce-events.c
+++ b/test/plugin/applic-delayed-ckpt/plugin-to-announce-events.c
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include "config.h"
 #include "dmtcp.h"
 
 static void
@@ -47,7 +46,7 @@ static DmtcpBarrier barriers[] = {
 
 DmtcpPluginDescriptor_t applic_delayed_ckpt_plugin = {
   DMTCP_PLUGIN_API_VERSION,
-  PACKAGE_VERSION,
+  DMTCP_PACKAGE_VERSION,
   "applic_delayed_ckpt",
   "DMTCP",
   "dmtcp@ccs.neu.edu",

--- a/test/plugin/applic-initiated-ckpt/plugin-to-announce-events.c
+++ b/test/plugin/applic-initiated-ckpt/plugin-to-announce-events.c
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include "config.h"
 #include "dmtcp.h"
 
 static void
@@ -47,7 +46,7 @@ static DmtcpBarrier barriers[] = {
 
 DmtcpPluginDescriptor_t applic_initiated_ckpt_plugin = {
   DMTCP_PLUGIN_API_VERSION,
-  PACKAGE_VERSION,
+  DMTCP_PACKAGE_VERSION,
   "applic_initiated_ckpt",
   "DMTCP",
   "dmtcp@ccs.neu.edu",

--- a/test/plugin/example-db/example-db.c
+++ b/test/plugin/example-db/example-db.c
@@ -1,3 +1,5 @@
+// This code illustrates the publish/subscribe feature of DMTCP.
+
 /* NOTE:  This code assumes that two environment variables have
  *  been set:  EXAMPLE_DB_KEY and EXAMPLE_DB_KEY_OTHER (for the other process).
  *  We will announce our (EXAMPLE_DB_KEY, <pid>) to the coordinator, and then
@@ -9,7 +11,6 @@
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include "config.h"
 #include "dmtcp.h"
 
 struct keyPid {
@@ -105,7 +106,7 @@ static DmtcpBarrier barriers[] = {
 
 DmtcpPluginDescriptor_t example_db_plugin = {
   DMTCP_PLUGIN_API_VERSION,
-  PACKAGE_VERSION,
+  DMTCP_PACKAGE_VERSION,
   "example_db",
   "DMTCP",
   "dmtcp@ccs.neu.edu",

--- a/test/plugin/example/example.c
+++ b/test/plugin/example/example.c
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include "config.h"
 #include "dmtcp.h"
 
 
@@ -45,7 +44,7 @@ static DmtcpBarrier barriers[] = {
 
 DmtcpPluginDescriptor_t example_plugin = {
   DMTCP_PLUGIN_API_VERSION,
-  PACKAGE_VERSION,
+  DMTCP_PACKAGE_VERSION,
   "example",
   "DMTCP",
   "dmtcp@ccs.neu.edu",

--- a/test/plugin/sleep1/sleep1.c
+++ b/test/plugin/sleep1/sleep1.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <sys/time.h>
-#include "config.h"
 #include "dmtcp.h"
 
 void
@@ -42,7 +41,7 @@ static DmtcpBarrier barriers[] = {
 
 DmtcpPluginDescriptor_t sleep1_plugin = {
   DMTCP_PLUGIN_API_VERSION,
-  PACKAGE_VERSION,
+  DMTCP_PACKAGE_VERSION,
   "sleep1",
   "DMTCP",
   "dmtcp@ccs.neu.edu",

--- a/test/plugin/sleep2/sleep2.c
+++ b/test/plugin/sleep2/sleep2.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <sys/time.h>
-#include "config.h"
 #include "dmtcp.h"
 
 void
@@ -60,7 +59,7 @@ static DmtcpBarrier barriers[] = {
 
 DmtcpPluginDescriptor_t sleep2_plugin = {
   DMTCP_PLUGIN_API_VERSION,
-  PACKAGE_VERSION,
+  DMTCP_PACKAGE_VERSION,
   "sleep2",
   "DMTCP",
   "dmtcp@ccs.neu.edu",


### PR DESCRIPTION
User plugins in version 3.0 required `#include config.h`.  This was a problem for two reasons:
1.  It would seem weird to the user.  The reason is that the new interface was using PACKAGE_VERSION, a configure variable from autoconf.
2.  `config.h` was defining lots of macros like PACKAGE_VERSION in the user's namespace.  This is bad, since the user might have defined their own macro, PACKAGE_VERSION.

The solution was to rename `include/dmtcp.h` to `include/dmtcp.h.in`, to add to it
`#define DMTCP_PACKAGE_VERSION "@PACKAGE_VERSION@"`
and then modify `configure` and `configure.ac` to auto-generate `include/dmtcp.h`.

I tested this on 3.0.  I assume we don't need this for 2.5, since 2.5 doesn't use PACKAGE_VERSION or `config.h` for plugins.
