### PR TITLE
Uniquepid: Generate comp. id using higher resoulution timer

### DIFF
--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -123,6 +123,14 @@ void SharedData::initialize(const char *tmpDir = NULL,
 
     int fd = _real_open(o.str().c_str(), O_RDWR | O_CREAT | O_EXCL, 0600);
     if (fd == -1 && errno == EEXIST) {
+      /* If the shared data area already exists, it's probably a conflict
+       * and two independent computations might have been launched at the
+       * same time.
+       * FIXME: We're unlikely to hit this bug since we are using a higher
+       *        resolution timer, clock_gettime() (1 nanosecond).
+       */
+      JWARNING(false)
+              ("Internal error detected! Shared data area already exists.");
       fd = _real_open(o.str().c_str(), O_RDWR, 0600);
     } else {
       needToInitialize = true;

--- a/src/uniquepid.cpp
+++ b/src/uniquepid.cpp
@@ -20,6 +20,7 @@
  ****************************************************************************/
 
 #include <stdlib.h>
+#include <time.h>
 #include "uniquepid.h"
 #include "constants.h"
 #include "../jalib/jconvert.h"
@@ -74,11 +75,15 @@ static UniquePid& parentProcess()
 // So, it can't return a const UniquePid
 UniquePid& UniquePid::ThisProcess(bool disableJTrace /*=false*/)
 {
+  struct timespec value;
+  uint64_t nsecs = 0;
   if ( theProcess() == nullProcess() )
   {
+    JASSERT(clock_gettime(CLOCK_MONOTONIC, &value) == 0);
+    nsecs = value.tv_sec*100000000L + value.tv_nsec;
     theProcess() = UniquePid ( theUniqueHostId() ,
-                                      ::getpid(),
-                                      ::time(NULL) );
+                               ::getpid(),
+                               nsecs );
     if (disableJTrace == false) {
       JTRACE ( "recalculated process UniquePid..." ) ( theProcess() );
     }


### PR DESCRIPTION
The current implementation for generating a unique computation
identifier relies on a low resolution timer function,
`time()`, with a min. resolution of 1 second. This can result in
conflicts in the computation id space when running independent
computations in parallel on the same host.

I first encountered this problem when launching independent
programs under DMTCP in parallel using `make -j`. I noticed
that a program would end up reading the coordinator info
from the shared data area of a different program because
of matching computation id values. The program would then
try to send messages to the wrong coordinator and result in
undefined behavior.

The fix is to use a higher resolution timer API, `clock_gettime()`,
with a min. resolution of 1 nanosecond.