### PR TITLE
Fix mtcp_restart for Intel C compiler

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -101,6 +101,8 @@ typedef struct RestoreInfo {
   VA vvarStart;
   VA vvarEnd;
   fnptr_t post_restart;
+  // NOTE: Update the offset when adding fields to the RestoreInfo struct
+  // See note below in the restart_fast_path() function.
   fnptr_t restorememoryareas_fptr;
 
   // void (*post_restart)();
@@ -430,7 +432,7 @@ restart_fast_path()
   void *stack_ptr = rinfo.restore_addr + rinfo.restore_size - MB;
 
 #if defined(__INTEL_COMPILER) && defined(__x86_64__)
-  memfence();
+  asm volatile ("mfence" ::: "memory"); // memfence() defined in dmtcpplugin.cpp
   asm volatile (CLEAN_FOR_64_BIT(mov %0, %%esp; )
                 CLEAN_FOR_64_BIT(xor %%ebp, %%ebp)
                   : : "g" (stack_ptr) : "memory");
@@ -438,13 +440,14 @@ restart_fast_path()
   // This is copied from gcc assembly output for:
   // rinfo.restorememoryareas_fptr(&rinfo);
   // Intel icc-13.1.3 output uses register rbp here.  It's no longer available.
-  asm volatile (
-    "movq    64+rinfo(%%rip), %%rdx;" /* rinfo.restorememoryareas_fptr */
-    "leaq    rinfo(%%rip), %%rdi;"   /* &rinfo */
-    "movl    $0, %%eax;"
-    "call    *%%rdx"
-    : :);
-
+  asm volatile(
+   // 96 = offsetof(RestoreInfo, rinfo.restorememoryareas_fptr)
+   // NOTE: Update the offset when adding fields to the RestoreInfo struct
+   "movq    96+rinfo(%%rip), %%rdx;" /* rinfo.restorememoryareas_fptr */
+   "leaq    rinfo(%%rip), %%rdi;"    /* &rinfo */
+   "movl    $0, %%eax;"
+   "call    *%%rdx"
+   : : );
   /* NOTREACHED */
 #endif /* if defined(__INTEL_COMPILER) && defined(__x86_64__) */
 


### PR DESCRIPTION
This patch fixes issue #342. I have tested this with ICC-16.0.3.
There were two issues:
- Missing definition for the memfence() function; and
- Incorrect offset for the restorememoryareas_fptr in the rinfo
  struct.

The second bug was introduced in the commit: dec2c26 when new fields
were added to the rinfo struct.
