### PR TITLE
Fixed the case where two QPs are not connected.

### DIFF
--- a/contrib/infiniband/ibv_internal.h
+++ b/contrib/infiniband/ibv_internal.h
@@ -118,8 +118,13 @@ struct internal_ibv_qp {
   struct ibv_qp user_qp;
   uint64_t magic1;
   uint64_t magic2;
-  struct ibv_qp *real_qp;
+  struct ibv_qp * real_qp;
   struct ibv_qp_init_attr init_attr; // Attributes used to construct the queue
+  /*
+   * To indicate that there is at least one successful work completion generated.
+   * This field is used to handle the case where two qps are not acctually connected.
+   * */
+  bool in_use;
   ibv_qp_id_t original_id;
   ibv_qp_id_t remote_id;
   ibv_qp_id_t current_remote;


### PR DESCRIPTION
The original code assumes that for RC connections, two QPs are always connected, which is not true in certain cases (the bug was found in Manuel's cluster using Mvapich2 2.2).
