### PR TITLE
Fix dlsym_default to not rely on dlsym and dlopen [duplicate of PR #347]

### DIFF
--- a/include/dlsym_default.h
+++ b/include/dlsym_default.h
@@ -32,73 +32,36 @@
 # undef __USE_GNU
 #endif
 
-/************************************************************************
- * IMPORTANT CAVEATS:
- *   DLSYM_DEFAULT() is effective when called from a library, but not when
- *     called from within the base executable.
- *   Don't use dlsym_default_internal() outside of this macro.
- *   This must be a macro because dlsym() looks one level up in the stack
- *     to decide what library the caller of dlsym() is located in.
- *   RTLD_DEFAULT does not work with this macro.
- ************************************************************************/
-
 // #define DLSYM_DEFAULT_DO_DEBUG
 
 #ifdef DLSYM_DEFAULT_DO_DEBUG
 # define DLSYM_DEFAULT_DEBUG(handle,symbol,info) \
-    JNOTE("DLSYM_DEFAULT (RTLD_NEXT==-1l)")(symbol)(handle) \
+    JNOTE("dlsym_default (RTLD_NEXT==-1l)")(symbol)(handle) \
          (info.dli_fname)(info.dli_saddr)
 #else
 # define DLSYM_DEFAULT_DEBUG(handle,symbol,info)
 #endif
-
-#define DLSYM_DEFAULT(handle,symbol)                                          \
-  ({ Dl_info info;                                                            \
-     void *handle2 = handle;                                                  \
-     if (handle == RTLD_DEFAULT || handle == RTLD_NEXT) {                     \
-       /* Hack: use dlsym()/dlopen() only to get the lib handle */            \
-       /* MUST BE MACRO:  dlsym uses stack to find curr. lib for RTLD_NEXT */ \
-       /* Logic for dlsym_fnptr is shadowing logic for dmtcp.h:NEXT_FNC() */  \
-       __typeof__(&dlsym) dlsym_fnptr;                                        \
-       dlsym_fnptr = (__typeof__(&dlsym)) dmtcp_get_libc_dlsym_addr();        \
-       void *tmp_fnc = (*dlsym_fnptr) (handle2, symbol);                      \
-       dladdr(tmp_fnc, &info);                                                \
-       DLSYM_DEFAULT_DEBUG(handle,symbol,info);                               \
-       /* Found handle of RTLD_NEXT or RTLD_DEFAULT */                        \
-       handle2 = dlopen(info.dli_fname, RTLD_NOLOAD | RTLD_LAZY);             \
-     }                                                                        \
-     /* Same signature as dlsym(): */                                         \
-     void *symbol_ptr = dlsym_default_internal(handle2, symbol);              \
-     if (handle == RTLD_DEFAULT || handle == RTLD_NEXT) {                     \
-       dlclose(handle2); /* Should verify that this returns 9. */             \
-     }                                                                        \
-     symbol_ptr; })
 
 #ifdef __cplusplus
 extern "C"
 {
 #else
 #endif
-  void *dlsym_default_internal(void *handle, const char *symbol);
+ void *dlsym_default(void *handle, const char *symbol);
 #ifdef __cplusplus
 }
 #else
 #endif
 
 #ifndef STANDALONE
-// FIXME: DLSYM_DEFAULT() and dlsym_default_internal() should probably
-//    both use dmtcp_get_libc_dlsym_addr() instead of dlsym()
-//    when used with DMTCP.
-//    Or do they need to?
-
 // This implementation mirrors dmtcp.h:NEXT_FNC() for DMTCP.
-// It uses DLSYM_DEFAULT to get default version, in case of symbol versioning
+// It uses dlsym_default to get default version, in case of symbol versioning
 # define NEXT_FNC_DEFAULT(func)                                             \
   ({                                                                        \
      static __typeof__(&func) _real_##func = (__typeof__(&func)) -1;        \
      if (_real_##func == (__typeof__(&func)) -1) {                          \
        if (dmtcp_initialize) dmtcp_initialize();                            \
-       _real_##func = (__typeof__(&func)) DLSYM_DEFAULT(RTLD_NEXT, #func);  \
+       _real_##func = (__typeof__(&func)) dlsym_default(RTLD_NEXT, #func);  \
      }                                                                      \
    _real_##func;})
 #endif
@@ -120,9 +83,9 @@ int main() {
 
   printf("================ dlsym_default ================\n");
   // NOTE: RTLD_DEFAULT would try to use this a.out, and fail to find a library
-  // fnc = DLSYM_DEFAULT(RTLD_DEFAULT, "pthread_cond_broadcast");
+  // fnc = dlsym_default(RTLD_DEFAULT, "pthread_cond_broadcast");
   // printf("pthread_cond_broadcast (via RTLD_DEFAULT): %p\n", fnc);
-  fnc = DLSYM_DEFAULT(RTLD_NEXT, "pthread_cond_broadcast");
+  fnc = dlsym_default(RTLD_NEXT, "pthread_cond_broadcast");
   printf("pthread_cond_broadcast (via RTLD_NEXT): %p\n", fnc);
 
   return 0;


### PR DESCRIPTION
The old DLSYM_DEFAULT implementation works exactly as expected
when given an actual handle for a library. However, potential
problems arose with the use of the RTLD_DEFAULT and RTLD_NEXT
pseudo-handles. In these cases, the function relied on calls
to dlopen and dlsym which could cause an infinite loop if called
before the complete initialization of libc.
This commit replaces the usage of dlopen and dlsym with dladdr1 which
simplifies the process greatly and should fix this problem.