### PR TITLE
Improved logging mechanism

### DIFF
--- a/include/shareddata.h
+++ b/include/shareddata.h
@@ -122,6 +122,8 @@ struct Header {
   uint32_t numIncomingConMaps;
   uint32_t numInodeConnIdMaps;
 
+  uint32_t logMask;
+
   union {
     struct BarrierInfo barrierInfo;
     char pad[128];
@@ -204,6 +206,8 @@ void getMissingConMaps(struct IncomingConMap **map, uint32_t *nmaps);
 
 void insertInodeConnIdMaps(vector<InodeConnIdMap> &maps);
 bool getCkptLeaderForFile(dev_t devnum, ino_t inode, void *id);
+uint32_t getLogMask(void);
+void setLogMask(uint32_t mask);
 }
 }
 #endif // ifndef SHARED_DATA_H

--- a/include/util.h
+++ b/include/util.h
@@ -185,6 +185,7 @@ char *findExecutable(char *executable, const char *path_env, char *exec_path);
 string getPath(string cmd, bool is32bit = false);
 void getDmtcpArgs(vector<string> &dmtcp_args);
 void allowGdbDebug(int currentDebugLevel);
+uint32_t processDebugLogsArg(char *logString);
 }
 }
 #endif // ifdef __cplusplus

--- a/jalib/jalib.cpp
+++ b/jalib/jalib.cpp
@@ -273,6 +273,12 @@ readAll(int fd, void *buf, size_t count)
   REAL_FUNC_PASSTHROUGH(ssize_t, readAll) (fd, buf, count);
 }
 
+uint32_t
+getLogMask(void)
+{
+  REAL_FUNC_PASSTHROUGH(uint32_t, getLogMask) ();
+}
+
 bool
 strEndsWith(const char *str, const char *pattern)
 {

--- a/jalib/jalib.h
+++ b/jalib/jalib.h
@@ -24,6 +24,7 @@
 
 #include <fcntl.h>
 #include <poll.h>
+#include <stdint.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/types.h>
@@ -64,6 +65,7 @@ typedef struct JalibFuncPtrs {
 
   ssize_t (*writeAll)(int fd, const void *buf, size_t count);
   ssize_t (*readAll)(int fd, void *buf, size_t count);
+  uint32_t (*getLogMask)(void);
 } JalibFuncPtrs;
 
 namespace jalib
@@ -111,7 +113,7 @@ int pthread_mutex_unlock(pthread_mutex_t *mutex);
 
 ssize_t writeAll(int fd, const void *buf, size_t count);
 ssize_t readAll(int fd, void *buf, size_t count);
-
+uint32_t getLogMask(void);
 bool strEndsWith(const char *str, const char *pattern);
 }
 

--- a/jalib/jassert.cpp
+++ b/jalib/jassert.cpp
@@ -86,9 +86,17 @@ jassert_internal::JAssert::Text(const char *msg)
   return *this;
 }
 
+jassert_internal::JAssert::JAssert(LogSource logSrc, bool exitWhenDone)
+  : JASSERT_CONT_A(*this)
+  , JASSERT_CONT_B(*this)
+  , _logSrc(logSrc)
+  , _exitWhenDone(exitWhenDone)
+{}
+
 jassert_internal::JAssert::JAssert(bool exitWhenDone)
   : JASSERT_CONT_A(*this)
   , JASSERT_CONT_B(*this)
+  , _logSrc(UNKNOWN)
   , _exitWhenDone(exitWhenDone)
 {}
 

--- a/jalib/jassert.cpp
+++ b/jalib/jassert.cpp
@@ -96,7 +96,7 @@ jassert_internal::JAssert::JAssert(LogSource logSrc, bool exitWhenDone)
 jassert_internal::JAssert::JAssert(bool exitWhenDone)
   : JASSERT_CONT_A(*this)
   , JASSERT_CONT_B(*this)
-  , _logSrc(UNKNOWN)
+  , _logSrc(JTRACE)   // Always print the warnings, notes, and assert msgs
   , _exitWhenDone(exitWhenDone)
 {}
 
@@ -116,7 +116,7 @@ jassert_internal::JAssert::~JAssert()
 #endif // ifdef DEBUG
   }
 
-  if (!ss.str().empty()) {
+  if ((jalib::getLogMask() & _logSrc) && !ss.str().empty()) {
     jassert_safe_print(ss.str().c_str());
   }
 

--- a/jalib/jassert.h
+++ b/jalib/jassert.h
@@ -79,6 +79,21 @@ extern int jassert_quiet;
  *
  */
 
+#define FOREACH_LOGSOURCE(MACRO, a, b) \
+   MACRO(JTRACE, a, b)                 \
+   MACRO(ALLOC, a, b)                  \
+   MACRO(DL, a, b)                     \
+   MACRO(DMTCP, a, b)                  \
+   MACRO(EVENT, a, b)                  \
+   MACRO(FILEP, a, b)                  \
+   MACRO(SOCKET, a, b)                 \
+   MACRO(SSH, a, b)                    \
+   MACRO(IPC, a, b)                    \
+   MACRO(PID, a, b)                    \
+   MACRO(SYSV, a, b)                   \
+   MACRO(TIMER, a, b)                  \
+   MACRO(ALL, a, b)
+
 namespace jassert_internal
 {
 

--- a/jalib/jassert.h
+++ b/jalib/jassert.h
@@ -81,6 +81,25 @@ extern int jassert_quiet;
 
 namespace jassert_internal
 {
+
+enum LogSource
+{
+  UNKNOWN = 0x00000000,
+  JTRACE  = 0x00000001,  // Always print JTRACE if compiled in
+  ALLOC   = 0x00000002,
+  DL      = 0x00000004,
+  DMTCP   = 0x00000008,
+  EVENT   = 0x00000010,
+  FILEP   = 0x00000020,
+  SOCKET  = 0x00000040,
+  SSH     = 0x00000080,
+  IPC     = 0x000000F0,  // (EVENT | FILEP | SOCKET | SSH)
+  PID     = 0x00000100,
+  SYSV    = 0x00000200,
+  TIMER   = 0x00000400,
+  ALL     = 0xFFFFFFFF,
+};
+
 class JAssert
 {
   public:
@@ -112,6 +131,8 @@ class JAssert
     /// constructor: sets members
     JAssert(bool exitWhenDone);
 
+    JAssert(LogSource logSrc, bool exitWhenDone);
+
     ///
     /// destructor: exits program if exitWhenDone is set
     ~JAssert();
@@ -129,9 +150,12 @@ class JAssert
     { Print(t); return *this; }
 
   private:
+    LogSource _logSrc;
+
     ///
     /// if set true (on construction) call exit() on destruction
     bool _exitWhenDone;
+
     dmtcp::ostringstream ss;
 };
 
@@ -221,6 +245,12 @@ void set_log_file(const jalib::string &path,
   } else jassert_internal::JAssert(false).JASSERT_CONTEXT("NOTE", \
                                                           msg).JASSERT_CONT_A
 #endif // ifdef DEBUG
+
+#define JLOG_HELPER(msg) \
+  JASSERT_CONTEXT("TRACE", msg).JASSERT_CONT_A
+
+#define JLOG(src) \
+  jassert_internal::JAssert(jassert_internal::src, false).JLOG_HELPER
 
 #define JNOTE(msg)          \
   if (jassert_quiet >= 1) { \

--- a/src/alarm.cpp
+++ b/src/alarm.cpp
@@ -34,7 +34,7 @@ static void
 checkpoint()
 {
   timeLeft = alarm(0);
-  JTRACE("*** Alarm stopped. ***") (timeLeft);
+  JLOG(DMTCP)("*** Alarm stopped. ***") (timeLeft);
 }
 
 static void
@@ -42,7 +42,7 @@ resume()
 {
   /* Need to restart the timer on resume/restart. */
   if (timeLeft > 0) {
-    JTRACE("*** Resuming alarm. ***") (timeLeft);
+    JLOG(DMTCP)("*** Resuming alarm. ***") (timeLeft);
     timeLeft = alarm(timeLeft);
   }
 }

--- a/src/ckptserializer.cpp
+++ b/src/ckptserializer.cpp
@@ -190,7 +190,7 @@ open_ckpt_to_write_hbict(int fd,
   };
 
   hbict_args[0] = hbict_path;
-  JTRACE("open_ckpt_to_write_hbict\n");
+  JLOG(DMTCP)("open_ckpt_to_write_hbict\n");
 
   if (gzip_path != NULL) {
     hbict_args[2] = const_cast<char *>("-z100");
@@ -210,7 +210,7 @@ open_ckpt_to_write_gz(int fd, int pipe_fds[2], char *gzip_path)
   };
 
   gzip_args[0] = gzip_path;
-  JTRACE("open_ckpt_to_write_gz\n");
+  JLOG(DMTCP)("open_ckpt_to_write_gz\n");
 
   return open_ckpt_to_write(fd, pipe_fds, gzip_args);
 }
@@ -247,7 +247,7 @@ perform_open_ckpt_image_fd(const char *tempCkptFilename,
 #ifdef HBICT_DELTACOMP
   char *hbict_cmd = const_cast<char *>("hbict");
   char hbict_path[PATH_MAX];
-  JTRACE("NOTICE: hbict compression is enabled\n");
+  JLOG(DMTCP)("NOTICE: hbict compression is enabled\n");
 
   use_deltacompression = test_use_compression(const_cast<char *>("HBICT"),
                                               hbict_cmd, hbict_path, 1);
@@ -319,7 +319,7 @@ test_and_prepare_for_forked_ckpt()
     return FORKED_CKPT_FAILED;
   } else if (forked_cpid > 0) {
     restore_sigchld_handler_and_wait_for_zombie(forked_cpid);
-    JTRACE("checkpoint complete\n");
+    JLOG(DMTCP)("checkpoint complete\n");
     return FORKED_CKPT_PARENT;
   } else {
     pid_t grandchild_pid = _real_sys_fork();
@@ -332,7 +332,7 @@ test_and_prepare_for_forked_ckpt()
     }
 
     /* grandchild continues; no need now to waitpid() on grandchild */
-    JTRACE("inside grandchild process");
+    JLOG(DMTCP)("inside grandchild process");
   }
   return FORKED_CKPT_CHILD;
 }
@@ -423,11 +423,11 @@ CkptSerializer::writeCkptImage(void *mtcpHdr, size_t mtcpHdrLen)
 
   tempCkptFilename += ".temp";
 
-  JTRACE("Thread performing checkpoint.") (dmtcp_gettid());
+  JLOG(DMTCP)("Thread performing checkpoint.") (dmtcp_gettid());
   createCkptDir();
   forked_ckpt_status = test_and_prepare_for_forked_ckpt();
   if (forked_ckpt_status == FORKED_CKPT_PARENT) {
-    JTRACE("*** Using forked checkpointing.\n");
+    JLOG(DMTCP)("*** Using forked checkpointing.\n");
     return;
   }
 
@@ -449,7 +449,7 @@ CkptSerializer::writeCkptImage(void *mtcpHdr, size_t mtcpHdrLen)
   // Write MTCP header
   JASSERT(Util::writeAll(fd, mtcpHdr, mtcpHdrLen) == (ssize_t)mtcpHdrLen);
 
-  JTRACE("MTCP is about to write checkpoint image.")(ckptFilename);
+  JLOG(DMTCP)("MTCP is about to write checkpoint image.")(ckptFilename);
   mtcp_writememoryareas(fd);
 
   if (use_compression) {
@@ -477,7 +477,7 @@ CkptSerializer::writeCkptImage(void *mtcpHdr, size_t mtcpHdrLen)
     _exit(0); /* grandchild exits */
   }
 
-  JTRACE("checkpoint complete");
+  JLOG(DMTCP)("checkpoint complete");
 }
 
 void

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -59,7 +59,7 @@ coordinatorAPI_EventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
     break;
 
   case DMTCP_EVENT_EXIT:
-    JTRACE("exit() in progress, disconnecting from dmtcp coordinator");
+    JLOG(DMTCP)("exit() in progress, disconnecting from dmtcp coordinator");
     CoordinatorAPI::instance().closeConnection();
     break;
 
@@ -208,7 +208,7 @@ CoordinatorAPI::instance()
 void
 CoordinatorAPI::init()
 {
-  JTRACE("Informing coordinator of new process") (UniquePid::ThisProcess());
+  JLOG(DMTCP)("Informing coordinator of new process") (UniquePid::ThisProcess());
 
   DmtcpMessage msg(DMT_UPDATE_PROCESS_INFO_AFTER_INIT_OR_EXEC);
   instance().sendMsgToCoordinator(msg, jalib::Filesystem::GetProgramName());
@@ -222,7 +222,7 @@ CoordinatorAPI::resetOnFork(CoordinatorAPI &coordAPI)
   coordAPI.updateSockFd();
   instance() = coordAPI;
 
-  JTRACE("Informing coordinator of new process") (UniquePid::ThisProcess());
+  JLOG(DMTCP)("Informing coordinator of new process") (UniquePid::ThisProcess());
 
   DmtcpMessage msg(DMT_UPDATE_PROCESS_INFO_AFTER_FORK);
   if (dmtcp_virtual_to_real_pid) {
@@ -397,7 +397,7 @@ CoordinatorAPI::waitForBarrier(const string &barrierId)
 {
   instance().sendMsgToCoordinator(DmtcpMessage(DMT_OK));
 
-  JTRACE("waiting for DMT_BARRIER_RELEASED message");
+  JLOG(DMTCP)("waiting for DMT_BARRIER_RELEASED message");
 
   char *extraData = NULL;
   DmtcpMessage msg;
@@ -405,7 +405,7 @@ CoordinatorAPI::waitForBarrier(const string &barrierId)
 
   msg.assertValid();
   if (msg.type == DMT_KILL_PEER) {
-    JTRACE("Received KILL message from coordinator, exiting");
+    JLOG(DMTCP)("Received KILL message from coordinator, exiting");
     _exit(0);
   }
 
@@ -445,7 +445,7 @@ CoordinatorAPI::startNewCoordinator(CoordinatorMode mode)
   coordinatorListenerSocket.changeFd(PROTECTED_COORD_FD);
   CoordinatorAPI::setCoordPort(coordinatorListenerSocket.port());
 
-  JTRACE("Starting a new coordinator automatically.")
+  JLOG(DMTCP)("Starting a new coordinator automatically.")
     (coordinatorListenerSocket.port());
 
   if (fork() == 0) {
@@ -490,7 +490,7 @@ CoordinatorAPI::createNewConnToCoord(CoordinatorMode mode)
   } else if (mode & COORD_ANY) {
     _coordinatorSocket = createNewSocketToCoordinator(mode);
     if (_coordinatorSocket == -1) {
-      JTRACE("Coordinator not found, trying to start a new one.");
+      JLOG(DMTCP)("Coordinator not found, trying to start a new one.");
       startNewCoordinator(mode);
       _coordinatorSocket = createNewSocketToCoordinator(mode);
       JASSERT(_coordinatorSocket != -1) (JASSERT_ERRNO)
@@ -527,7 +527,7 @@ CoordinatorAPI::sendRecvHandshake(DmtcpMessage msg,
   recvMsgFromCoordinator(&msg);
   msg.assertValid();
   if (msg.type == DMT_KILL_PEER) {
-    JTRACE("Received KILL message from coordinator, exiting");
+    JLOG(DMTCP)("Received KILL message from coordinator, exiting");
     _real_exit(0);
   }
   if (msg.type == DMT_REJECT_NOT_RUNNING) {
@@ -561,14 +561,14 @@ CoordinatorAPI::connectToCoordOnStartup(CoordinatorMode mode,
   }
 
   createNewConnToCoord(mode);
-  JTRACE("sending coordinator handshake")(UniquePid::ThisProcess());
+  JLOG(DMTCP)("sending coordinator handshake")(UniquePid::ThisProcess());
   DmtcpMessage hello_local(DMT_NEW_WORKER);
   hello_local.virtualPid = -1;
 
   DmtcpMessage hello_remote = sendRecvHandshake(hello_local, progname);
 
   JASSERT(hello_remote.virtualPid != -1);
-  JTRACE("Got virtual pid from coordinator") (hello_remote.virtualPid);
+  JLOG(DMTCP)("Got virtual pid from coordinator") (hello_remote.virtualPid);
 
   pid_t ppid = getppid();
   Util::setVirtualPidEnvVar(hello_remote.virtualPid, ppid, ppid);
@@ -604,7 +604,7 @@ CoordinatorAPI::createNewConnectionBeforeFork(string &progname)
   JASSERT(hello_remote.virtualPid != -1);
 
   if (dmtcp_virtual_to_real_pid) {
-    JTRACE("Got virtual pid from coordinator") (hello_remote.virtualPid);
+    JLOG(DMTCP)("Got virtual pid from coordinator") (hello_remote.virtualPid);
     pid_t pid = getpid();
     pid_t realPid = dmtcp_virtual_to_real_pid(pid);
     Util::setVirtualPidEnvVar(hello_remote.virtualPid, pid, realPid);
@@ -627,7 +627,7 @@ CoordinatorAPI::connectToCoordOnRestart(CoordinatorMode mode,
   }
 
   createNewConnToCoord(mode);
-  JTRACE("sending coordinator handshake")(UniquePid::ThisProcess());
+  JLOG(DMTCP)("sending coordinator handshake")(UniquePid::ThisProcess());
   DmtcpMessage hello_local(DMT_RESTART_WORKER);
   hello_local.virtualPid = -1;
   hello_local.numPeers = np;
@@ -649,7 +649,7 @@ CoordinatorAPI::connectToCoordOnRestart(CoordinatorMode mode,
     memcpy(localIP, &hello_remote.ipAddr, sizeof hello_remote.ipAddr);
   }
 
-  JTRACE("Coordinator handshake RECEIVED!!!!!");
+  JLOG(DMTCP)("Coordinator handshake RECEIVED!!!!!");
 }
 
 void
@@ -662,7 +662,7 @@ CoordinatorAPI::sendCkptFilename()
   // Tell coordinator to record our filename in the restart script
   string ckptFilename = ProcessInfo::instance().getCkptFilename();
   string hostname = jalib::Filesystem::GetCurrentHostname();
-  JTRACE("recording filenames") (ckptFilename) (hostname);
+  JLOG(DMTCP)("recording filenames") (ckptFilename) (hostname);
   DmtcpMessage msg;
   if (dmtcp_unique_ckpt_enabled && dmtcp_unique_ckpt_enabled()) {
     msg.type = DMT_UNIQUE_CKPT_FILENAME;
@@ -841,11 +841,11 @@ CoordinatorAPI::waitForCheckpointCommand()
     int retval =
       select(_coordinatorSocket + 1, &rfds, NULL, NULL, timeout);
     if (retval == 0) { // timeout expired, time for checkpoint
-      JTRACE("Timeout expired, checkpointing now.");
+      JLOG(DMTCP)("Timeout expired, checkpointing now.");
       return;
     } else if (retval > 0) {
       JASSERT(FD_ISSET(_coordinatorSocket, &rfds));
-      JTRACE("Connect request on virtual coordinator socket.");
+      JLOG(DMTCP)("Connect request on virtual coordinator socket.");
       break;
     }
     JASSERT(errno == EINTR) (JASSERT_ERRNO); /* EINTR: a signal was caught */
@@ -869,7 +869,7 @@ CoordinatorAPI::waitForCheckpointCommand()
     jalib::JServerSocket sock(_coordinatorSocket);
     cmdSock = sock.accept();
     msg.poison();
-    JTRACE("Reading from incoming connection...");
+    JLOG(DMTCP)("Reading from incoming connection...");
     cmdSock >> msg;
   } while (!cmdSock.isValid());
 
@@ -882,24 +882,24 @@ CoordinatorAPI::waitForCheckpointCommand()
   switch (msg.coordCmd) {
   // case 'b': case 'B':  // prefix blocking command, prior to checkpoint
   // command
-  // JTRACE("blocking checkpoint beginning...");
+  // JLOG(DMTCP)("blocking checkpoint beginning...");
   // blockUntilDone = true;
   // break;
   case 's': case 'S':
-    JTRACE("Received status command");
+    JLOG(DMTCP)("Received status command");
     reply.numPeers = 1;
     reply.isRunning = 1;
     break;
   case 'c': case 'C':
-    JTRACE("checkpointing...");
+    JLOG(DMTCP)("checkpointing...");
     break;
   case 'k': case 'K':
   case 'q': case 'Q':
-    JTRACE("Received KILL command from user, exiting");
+    JLOG(DMTCP)("Received KILL command from user, exiting");
     exitWhenDone = true;
     break;
   default:
-    JTRACE("unhandled user command") (msg.coordCmd);
+    JLOG(DMTCP)("unhandled user command") (msg.coordCmd);
     reply.coordCmdStatus = CoordCmdStatus::ERROR_INVALID_COMMAND;
   }
   cmdSock << reply;

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -247,7 +247,8 @@ CoordinatorAPI::connectAndSendUserCommand(char c,
                                           int *coordCmdStatus,
                                           int *numPeers,
                                           int *isRunning,
-                                          int *ckptInterval)
+                                          int *ckptInterval,
+                                          uint32_t logMask)
 {
   char *replyData = NULL;
 
@@ -263,6 +264,7 @@ CoordinatorAPI::connectAndSendUserCommand(char c,
   // send
   msg.type = DMT_USER_CMD;
   msg.coordCmd = c;
+  msg.logMask = logMask;
 
   if (c == 'i') {
     const char *interval = getenv(ENV_VAR_CKPT_INTR);

--- a/src/coordinatorapi.h
+++ b/src/coordinatorapi.h
@@ -98,7 +98,8 @@ class CoordinatorAPI
                                     int *coordCmdStatus = NULL,
                                     int *numPeers = NULL,
                                     int *isRunning = NULL,
-                                    int *ckptInterval = NULL);
+                                    int *ckptInterval = NULL,
+                                    uint32_t logMask = 0);
 
     void updateCoordCkptDir(const char *dir);
     string getCoordCkptDir(void);

--- a/src/dmtcp_command.cpp
+++ b/src/dmtcp_command.cpp
@@ -68,6 +68,7 @@ main(int argc, char **argv)
 {
   string interval = "";
   string request = "h";
+  uint32_t mask = jassert_internal::JTRACE;
 
   initializeJalib();
 
@@ -91,6 +92,10 @@ main(int argc, char **argv)
     } else if (argc > 1 &&
                (s == "-p" || s == "--coord-port" || s == "--port")) {
       setenv(ENV_VAR_NAME_PORT, argv[1], 1);
+      shift; shift;
+    } else if (argc > 1 && (s == "--debug-logs")) {
+      mask = Util::processDebugLogsArg(argv[1]);
+      request = "d";
       shift; shift;
     } else if (argv[0][0] == '-' && argv[0][1] == 'p' &&
                isdigit(argv[0][2])) { // else if -p0, for example
@@ -146,6 +151,15 @@ main(int argc, char **argv)
   case 'h':
     fprintf(stderr, theUsage, "");
     return 1;
+
+  case 'd':
+    coordinatorAPI.connectAndSendUserCommand(*cmd,
+                                             NULL,
+                                             NULL,
+                                             NULL,
+                                             NULL,
+                                             mask);
+    break;
 
   case 'i':
     setenv(ENV_VAR_CKPT_INTR, interval.c_str(), 1);

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -166,7 +166,7 @@ static bool explicitSrun = false;
 static bool enableIB2TcpPlugin = false;
 static bool enableIBPlugin = false;
 
-static bool enableAllocPlugin = true;
+static bool enableAllocPlugin = false;
 static bool enableDlPlugin = true;
 static bool enableIPCPlugin = true;
 static bool enableSvipcPlugin = true;

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -211,6 +211,7 @@ static struct PluginInfo pluginInfo[] = {               // Default value
 const size_t numLibs = sizeof(pluginInfo) / sizeof(struct PluginInfo);
 
 static CoordinatorMode allowedModes = COORD_ANY;
+static uint32_t mask = jassert_internal::UNKNOWN;
 
 // shift args
 #define shift argc--, argv++
@@ -275,6 +276,9 @@ processArgs(int *orig_argc,
       shift; shift;
     } else if (s == "--coord-logfile") {
       setenv(ENV_VAR_COORD_LOGFILE, argv[1], 1);
+      shift; shift;
+    } else if (s == "--debug-logs") {
+      mask = Util::processDebugLogsArg(argv[1]);
       shift; shift;
     } else if (argv[0][0] == '-' && argv[0][1] == 'i' &&
                isdigit(argv[0][2])) { // else if -i5, for example
@@ -581,6 +585,7 @@ main(int argc, char **argv)
                          &compId,
                          &coordInfo,
                          &localIPAddr);
+  SharedData::setLogMask(mask);
 
   // Set DLSYM_OFFSET env var(s).
   Util::prepareDlsymWrapper();

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -111,6 +111,7 @@ static const char *theUsage =
   "\n";
 
 static int requestedDebugLevel = 0;
+static uint32_t mask = jassert_internal::UNKNOWN;
 
 class RestoreTarget;
 
@@ -282,6 +283,7 @@ class RestoreTarget
                                &compId,
                                &coordInfo,
                                &localIPAddr);
+        SharedData::setLogMask(mask);
 
         Util::prepareDlsymWrapper();
       }
@@ -746,6 +748,9 @@ main(int argc, char **argv)
       shift; shift;
     } else if (s == "--coord-logfile") {
       setenv(ENV_VAR_COORD_LOGFILE, argv[1], 1);
+      shift; shift;
+    } else if (s == "--debug-logs") {
+      mask = Util::processDebugLogsArg(argv[1]);
       shift; shift;
     } else if (argv[0][0] == '-' && argv[0][1] == 'i' &&
                isdigit(argv[0][2])) { // else if -i5, for example

--- a/src/dmtcpmessagetypes.cpp
+++ b/src/dmtcpmessagetypes.cpp
@@ -41,6 +41,7 @@ DmtcpMessage::DmtcpMessage(DmtcpMessageType t /*= DMT_NULL*/)
   , coordTimeStamp(0)
   , theCheckpointInterval(DMTCPMESSAGE_SAME_CKPT_INTERVAL)
   , exitAfterCkpt(0)
+  , logMask(0)
 {
   // struct sockaddr_storage _addr;
   // socklen_t _addrlen;
@@ -123,6 +124,8 @@ dmtcp::operator<<(dmtcp::ostream &o, const DmtcpMessageType &s)
     OSHIFTPRINTF(DMT_REGISTER_NAME_SERVICE_DATA)
     OSHIFTPRINTF(DMT_NAME_SERVICE_QUERY)
     OSHIFTPRINTF(DMT_NAME_SERVICE_QUERY_RESPONSE)
+
+    OSHIFTPRINTF(DMT_UPDATE_LOGGING)
 
     OSHIFTPRINTF(DMT_OK)
 

--- a/src/dmtcpmessagetypes.h
+++ b/src/dmtcpmessagetypes.h
@@ -70,6 +70,8 @@ enum DmtcpMessageType {
   DMT_NAME_SERVICE_QUERY,
   DMT_NAME_SERVICE_QUERY_RESPONSE,
 
+  DMT_UPDATE_LOGGING,
+
   DMT_OK,                    // slave telling coordinator it is done (response
                              // to DMT_DO_*)  this means slave reached barrier
 };
@@ -120,6 +122,7 @@ struct DmtcpMessage {
   struct in_addr ipAddr;
 
   uint32_t exitAfterCkpt;
+  uint32_t logMask;
   uint32_t padding;
 
   DmtcpMessage(DmtcpMessageType t = DMT_NULL);

--- a/src/jalibinterface.cpp
+++ b/src/jalibinterface.cpp
@@ -22,6 +22,7 @@
 #include "../jalib/jalib.h"
 #include "dmtcp.h"
 #include "protectedfds.h"
+#include "shareddata.h"
 #include "syscallwrappers.h"
 #include "util.h"
 
@@ -36,6 +37,7 @@ initializeJalib()
 
   jalibFuncPtrs.writeAll = Util::writeAll;
   jalibFuncPtrs.readAll = Util::readAll;
+  jalibFuncPtrs.getLogMask = SharedData::getLogMask;
 
   INIT_JALIB_FPTR(open);
   INIT_JALIB_FPTR(fopen);

--- a/src/miscwrappers.cpp
+++ b/src/miscwrappers.cpp
@@ -91,7 +91,7 @@ extern "C" int
 close(int fd)
 {
   if (DMTCP_IS_PROTECTED_FD(fd)) {
-    JTRACE("blocked attempt to close protected fd") (fd);
+    JLOG(DMTCP)("blocked attempt to close protected fd") (fd);
     errno = EBADF;
     return -1;
   }
@@ -107,7 +107,7 @@ fclose(FILE *fp)
   }
   int fd = fileno(fp);
   if (DMTCP_IS_PROTECTED_FD(fd)) {
-    JTRACE("blocked attempt to fclose protected fd") (fd);
+    JLOG(DMTCP)("blocked attempt to fclose protected fd") (fd);
     errno = EBADF;
     return -1;
   }
@@ -120,7 +120,7 @@ closedir(DIR *dir)
   int fd = dirfd(dir);
 
   if (DMTCP_IS_PROTECTED_FD(fd)) {
-    JTRACE("blocked attempt to closedir protected fd") (fd);
+    JLOG(DMTCP)("blocked attempt to closedir protected fd") (fd);
     errno = EBADF;
     return -1;
   }
@@ -140,7 +140,7 @@ extern "C" int dup2(int oldfd, int newfd)
 extern "C" int
 pipe(int fds[2])
 {
-  JTRACE("promoting pipe() to socketpair()");
+  JLOG(DMTCP)("promoting pipe() to socketpair()");
 
   // just promote pipes to socketpairs
   return socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
@@ -152,7 +152,7 @@ pipe(int fds[2])
 extern "C" int
 pipe2(int fds[2], int flags)
 {
-  JTRACE("promoting pipe2() to socketpair()");
+  JLOG(DMTCP)("promoting pipe2() to socketpair()");
 
   // just promote pipes to socketpairs
   int newFlags = 0;
@@ -312,8 +312,8 @@ extern "C" int __clone(int (*fn)(void *arg),
  * If we discover system calls for which the 7 args strategy doesn't work,
  *  we can special case them.
  *
- * XXX: DO NOT USE JTRACE/JNOTE/JASSERT in this function; even better, do not
- *      use any STL here.  (--Kapil)
+ * XXX: DO NOT USE JLOG/JTRACE/JNOTE/JASSERT in this function; even better, do
+ *      not use any STL here.  (--Kapil)
  */
 extern "C" long
 syscall(long sys_num, ...)

--- a/src/plugin/ipc/connectionlist.cpp
+++ b/src/plugin/ipc/connectionlist.cpp
@@ -169,7 +169,7 @@ ConnectionList::deleteStaleConnections()
           << "\t->\t" << c->id() << "\n";
     }
     out << "==================================================\n";
-    JTRACE("Deleting Stale Connections") (out.str());
+    JLOG(IPC)("Deleting Stale Connections") (out.str());
   }
 #endif // ifdef DEBUG
 
@@ -243,7 +243,7 @@ ConnectionList::list()
     o << "\t" << i->first << "\t" << c->str();
     o << "\n";
   }
-  JTRACE("ConnectionList") (dmtcp_get_uniquepid_str()) (o.str());
+  JLOG(IPC)("ConnectionList") (dmtcp_get_uniquepid_str()) (o.str());
 }
 
 Connection *
@@ -400,9 +400,9 @@ ConnectionList::refill(bool isRestart)
     }
   }
   if (isRestart) {
-    JTRACE("Waiting for Missing Cons");
+    JLOG(IPC)("Waiting for Missing Cons");
     sendReceiveMissingFds();
-    JTRACE("Done waiting for Missing Cons");
+    JLOG(IPC)("Done waiting for Missing Cons");
   }
 }
 
@@ -492,7 +492,7 @@ ConnectionList::registerIncomingCons()
       out << "\n\t" << con->str() << i->first;
     }
   }
-  JTRACE("Incoming/Outgoing Cons") (in.str()) (out.str());
+  JLOG(IPC)("Incoming/Outgoing Cons") (in.str()) (out.str());
   numIncomingCons = incomingCons.size();
   if (numIncomingCons > 0) {
     SharedData::registerIncomingCons(incomingCons, fdReceiveAddr,
@@ -538,7 +538,7 @@ ConnectionList::sendReceiveMissingFds()
       outgoingCons.pop_back();
       ConnectionIdentifier *id = (ConnectionIdentifier *)maps[idx].id;
       Connection *con = getConnection(*id);
-      JTRACE("Sending Missing Con") (*id);
+      JLOG(IPC)("Sending Missing Con") (*id);
       JASSERT(Util::sendFd(restoreFd, con->getFds()[0], id, sizeof(*id),
                            maps[idx].addr, maps[idx].len) != -1);
       numOutgoingCons--;
@@ -549,7 +549,7 @@ ConnectionList::sendReceiveMissingFds()
       int fd = Util::receiveFd(restoreFd, &id, sizeof(id));
       JASSERT(fd != -1);
       Connection *con = getConnection(id);
-      JTRACE("Received Missing Con") (id);
+      JLOG(IPC)("Received Missing Con") (id);
       JASSERT(con != NULL);
       Util::dupFds(fd, con->getFds());
       numIncomingCons--;

--- a/src/plugin/ipc/event/eventconnection.h
+++ b/src/plugin/ipc/event/eventconnection.h
@@ -84,7 +84,7 @@ class EpollConnection : public Connection
       _type(type),
       _size(size)
     {
-      JTRACE("new epoll connection created");
+      JLOG(EVENT)("new epoll connection created");
     }
 
     int epollType() const { return _type; }
@@ -116,7 +116,7 @@ class EventFdConnection : public Connection
       _initval(initval),
       _flags(flags)
     {
-      JTRACE("new eventfd connection created");
+      JLOG(EVENT)("new eventfd connection created");
     }
 
     virtual void drain();
@@ -148,7 +148,7 @@ class SignalFdConnection : public Connection
         sigemptyset(&_mask);
       }
       memset(&_fdsi, 0, sizeof(_fdsi));
-      JTRACE("new signalfd  connection created");
+      JLOG(EVENT)("new signalfd  connection created");
     }
 
     virtual void drain();
@@ -182,7 +182,7 @@ class InotifyConnection : public Connection
       _flags(flags),
       _state(INOTIFY_CREATE)
     {
-      JTRACE("new inotify connection created");
+      JLOG(EVENT)("new inotify connection created");
     }
 
     int inotifyState() const { return (int)_state; }

--- a/src/plugin/ipc/event/eventwrappers.cpp
+++ b/src/plugin/ipc/event/eventwrappers.cpp
@@ -169,7 +169,7 @@ signalfd(int fd, const sigset_t *mask, int flags)
   DMTCP_PLUGIN_DISABLE_CKPT();
   int ret = _real_signalfd(fd, mask, flags);
   if (ret != -1) {
-    JTRACE("signalfd created") (fd) (flags);
+    JLOG(EVENT)("signalfd created") (fd) (flags);
     EventConnList::instance().add(ret, new SignalFdConnection(fd, mask, flags));
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
@@ -184,7 +184,7 @@ eventfd(EVENTFD_VAL_TYPE initval, int flags)
   DMTCP_PLUGIN_DISABLE_CKPT();
   int ret = _real_eventfd(initval, flags);
   if (ret != -1) {
-    JTRACE("eventfd created") (ret) (initval) (flags);
+    JLOG(EVENT)("eventfd created") (ret) (initval) (flags);
     EventConnList::instance().add(ret, new EventFdConnection(initval, flags));
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
@@ -199,7 +199,7 @@ epoll_create(int size)
   DMTCP_PLUGIN_DISABLE_CKPT();
   int ret = _real_epoll_create(size);
   if (ret != -1) {
-    JTRACE("epoll fd created") (ret) (size);
+    JLOG(EVENT)("epoll fd created") (ret) (size);
     EventConnList::instance().add(ret, new EpollConnection(size));
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
@@ -212,7 +212,7 @@ epoll_create1(int flags)
   DMTCP_PLUGIN_DISABLE_CKPT();
   int ret = _real_epoll_create1(flags);
   if (ret != -1) {
-    JTRACE("epoll fd created1") (ret) (flags);
+    JLOG(EVENT)("epoll fd created1") (ret) (flags);
     EventConnList::instance().add(ret, new EpollConnection(flags));
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
@@ -225,7 +225,7 @@ epoll_ctl(int epfd, int op, int fd, struct epoll_event *event)
   DMTCP_PLUGIN_DISABLE_CKPT();
   int ret = _real_epoll_ctl(epfd, op, fd, event);
   if (ret != -1) {
-    // JTRACE("epoll fd CTL") (ret) (epfd) (fd) (op);
+    // JLOG(EVENT)("epoll fd CTL") (ret) (epfd) (fd) (op);
     EpollConnection *con =
       (EpollConnection *)EventConnList::instance().getConnection(epfd);
     con->onCTL(op, fd, event);
@@ -241,7 +241,7 @@ epoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeout)
   int timeLeft = timeout;
   int mytime;
 
-  // JTRACE("Starting to do wait on epoll fd");
+  // JLOG(EVENT)("Starting to do wait on epoll fd");
 
   if (timeout >= 0 && timeout < 1000) {
     // Short time intervals
@@ -306,10 +306,10 @@ inotify_init()
   int fd;
 
   DMTCP_PLUGIN_DISABLE_CKPT();
-  JTRACE("Starting to create an inotify fd.");
+  JLOG(EVENT)("Starting to create an inotify fd.");
   fd = _real_inotify_init();
   if (fd > 0) {
-    JTRACE("inotify fd created") (ret);
+    JLOG(EVENT)("inotify fd created") (ret);
 
     // create the inotify object
     Connection *con = new InotifyConnection(0);
@@ -333,7 +333,7 @@ inotify_init1(int flags)
   DMTCP_PLUGIN_DISABLE_CKPT();
   int ret = _real_inotify_init1(flags);
   if (ret != -1) {
-    JTRACE("inotify1 fd created") (ret) (flags);
+    JLOG(EVENT)("inotify1 fd created") (ret) (flags);
     Connection *con = new InotifyConnection(flags);
     EventConnList::instance().add(ret, flags);
   }
@@ -357,7 +357,7 @@ inotify_add_watch(int fd, const char *pathname, uint32_t mask)
   DMTCP_PLUGIN_DISABLE_CKPT();
   int ret = _real_inotify_add_watch(fd, pathname, mask);
   if (ret != -1) {
-    JTRACE("calling inotify class methods");
+    JLOG(EVENT)("calling inotify class methods");
     InotifyConnection &inotify_con =
       (InotifyConnection *)EventConnList::instance().getConnection(fd);
 
@@ -388,7 +388,7 @@ inotify_rm_watch(int fd, int wd)
   DMTCP_PLUGIN_DISABLE_CKPT(); // The lock is released inside the macro.
   int ret = _real_inotify_rm_watch(fd, wd);
   if (ret != -1) {
-    JTRACE("remove inotify mapping from dmtcp") (ret) (fd) (wd);
+    JLOG(EVENT)("remove inotify mapping from dmtcp") (ret) (fd) (wd);
     InotifyConnection &inotify_con =
       (InotifyConnection *)EventConnList::instance().getConnection(fd);
 

--- a/src/plugin/ipc/event/util_descriptor.cpp
+++ b/src/plugin/ipc/event/util_descriptor.cpp
@@ -69,21 +69,21 @@ Util::Descriptor::Descriptor()
     descriptor_counter = 0;
     is_initialized = true;
 
-    JTRACE(" initializing the Descriptor class object");
+    JLOG(EVENT)(" initializing the Descriptor class object");
 
     // allocate memory for MAX_DESCRIPTORS that would be stored
     for (int i = 0; i < MAX_DESCRIPTORS; i++) {
       void *mem_ptr =
         jalib::JAllocDispatcher::allocate(sizeof(descriptor_types_u));
       if (MAP_FAILED == mem_ptr) {
-        JTRACE("memory allocation failed!");
+        JLOG(EVENT)("memory allocation failed!");
         break;
       } else {
         descrip_types_p[i] = (descriptor_types_u *)mem_ptr;
       }
     }
   } else {
-    JTRACE(" object has been initialized before");
+    JLOG(EVENT)(" object has been initialized before");
   }
 }
 
@@ -99,7 +99,7 @@ Util::Descriptor::Descriptor()
 Util::Descriptor::~Descriptor()
 {
   if (true == is_initialized) {
-    JTRACE("Destructor being called");
+    JLOG(EVENT)("Destructor being called");
   }
 }
 
@@ -117,13 +117,13 @@ Util::Descriptor::add_descriptor(descriptor_types_u *descriptor)
 {
   JASSERT(descriptor != NULL);
   if (descriptor_counter < MAX_DESCRIPTORS) {
-    JTRACE("Adding new descriptor")
+    JLOG(EVENT)("Adding new descriptor")
       (descriptor_counter) (descrip_types_p[descriptor_counter]);
     memcpy(descrip_types_p[descriptor_counter],
            descriptor, sizeof(descriptor_types_u));
     descriptor_counter++;
   } else {
-    JTRACE("No more memory to store additional descriptors");
+    JLOG(EVENT)("No more memory to store additional descriptors");
   }
 }
 
@@ -166,7 +166,7 @@ Util::Descriptor::remove_descriptor(descriptor_type_e type, void *descriptor)
   }
   default:
   {
-    JTRACE("Unknown descriptor type") (type);
+    JLOG(EVENT)("Unknown descriptor type") (type);
     break;
   }
   }
@@ -194,12 +194,12 @@ Util::Descriptor::get_descriptor(unsigned int index,
   bool ret_val = false;
 
   JASSERT(descriptor != NULL).Text("descriptor is NULL");
-  JTRACE("get descriptor") (index) (type);
+  JLOG(EVENT)("get descriptor") (index) (type);
   if ((descrip_types_p[index])->add_watch.type == type) {
     memcpy(descriptor, descrip_types_p[index], sizeof(descriptor_types_u));
     ret_val = true;
   } else {
-    JTRACE("descriptor type is different from type saved")
+    JLOG(EVENT)("descriptor type is different from type saved")
       (type) ((descrip_types_p[index])->add_watch.type);
   }
 
@@ -241,9 +241,9 @@ Util::Descriptor::remove_timer_descriptor(timer_t timer_id)
 
   for (i = 0; i < MAX_DESCRIPTORS; i++) {
     if ((descrip_types_p[i])->create_timer.type == TIMER_CREATE_DECRIPTOR) {
-      JTRACE("find the saved timerid that corresponds to the one passed in");
+      JLOG(EVENT)("find the saved timerid that corresponds to the one passed in");
       if ((descrip_types_p[i])->create_timer.timerid == timer_id) {
-        JTRACE("timer id found...now delete it!");
+        JLOG(EVENT)("timer id found...now delete it!");
         memset(descrip_types_p[i], 0, sizeof(descriptor_types_u));
         (descrip_types_p[i])->create_timer.type = UNUSED_DESCRIPTOR;
 
@@ -274,12 +274,12 @@ Util::Descriptor::remove_inotify_watch_descriptor(int watch_descriptor)
 
   for (i = 0; i < MAX_DESCRIPTORS; i++) {
     if ((descrip_types_p[i])->add_watch.type == INOTIFY_ADD_WATCH_DESCRIPTOR) {
-      JTRACE("find the saved watch descriptor that corresponds to the one "
+      JLOG(EVENT)("find the saved watch descriptor that corresponds to the one "
              "passed in");
 
       if ((descrip_types_p[i])->add_watch.watch_descriptor ==
           watch_descriptor) {
-        JTRACE("watch descriptor found...now delete it!") (watch_descriptor);
+        JLOG(EVENT)("watch descriptor found...now delete it!") (watch_descriptor);
         memset((descrip_types_p[i]), 0, sizeof(descriptor_types_u));
         (descrip_types_p[i])->add_watch.type = UNUSED_DESCRIPTOR;
 

--- a/src/plugin/ipc/file/fileconnection.h
+++ b/src/plugin/ipc/file/fileconnection.h
@@ -54,7 +54,7 @@ class StdioConnection : public Connection
 
     StdioConnection(int fd) : Connection(STDIO + fd)
     {
-      JTRACE("creating stdio connection") (fd) (id());
+      JLOG(FILEP)("creating stdio connection") (fd) (id());
       JASSERT(jalib::Between(0, fd, 2)) (fd)
       .Text("invalid fd for StdioConnection");
     }
@@ -169,7 +169,7 @@ class FifoConnection : public Connection
         offs++;
         _rel_path = _path.substr(offs);
       }
-      JTRACE("New Fifo connection created") (_path) (_rel_path);
+      JLOG(FILEP)("New Fifo connection created") (_path) (_rel_path);
       _in_data.clear();
     }
 

--- a/src/plugin/ipc/file/fileconnlist.cpp
+++ b/src/plugin/ipc/file/fileconnlist.cpp
@@ -234,7 +234,7 @@ FileConnList::prepareShmList()
 
       if (jalib::Filesystem::FileExists(area.name)) {
         if (_real_access(area.name, W_OK) == 0) {
-          JTRACE("Will checkpoint shared memory area") (area.name);
+          JLOG(FILEP)("Will checkpoint shared memory area") (area.name);
           int flags = Util::memProtToOpenFlags(area.prot);
           int fd = _real_open(area.name, flags, 0);
           JASSERT(fd != -1) (JASSERT_ERRNO) (area.name);
@@ -259,7 +259,7 @@ FileConnList::prepareShmList()
                              MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED,
                              -1, 0) != MAP_FAILED) (JASSERT_ERRNO);
         } else {
-          JTRACE("Will not checkpoint shared memory area") (area.name);
+          JLOG(FILEP)("Will not checkpoint shared memory area") (area.name);
         }
       } else {
         // TODO: Shared memory areas with unlinked backing files.
@@ -269,7 +269,7 @@ FileConnList::prepareShmList()
           JWARNING(false) (area.name)
           .Text("Ckpt/Restart of anonymous shared memory not supported.");
         } else {
-          JTRACE("Will recreate shm file on restart.") (area.name);
+          JLOG(FILEP)("Will recreate shm file on restart.") (area.name);
 
           // Remove the DELETED suffix.
           area.name[strlen(area.name) - strlen(DELETED_FILE_SUFFIX)] = '\0';
@@ -325,7 +325,7 @@ FileConnList::restoreShmArea(const ProcMapsArea &area, int fd)
 
   JASSERT(fd != -1) (area.name) (JASSERT_ERRNO);
 
-  JTRACE("Restoring shared memory area") (area.name) ((void *)area.addr);
+  JLOG(FILEP)("Restoring shared memory area") (area.name) ((void *)area.addr);
   void *addr = _real_mmap(area.addr, area.size, area.prot,
                           MAP_FIXED | area.flags, fd, area.offset);
   JASSERT(addr != MAP_FAILED) (area.flags) (area.prot) (JASSERT_ERRNO)
@@ -340,7 +340,7 @@ FileConnList::remapShmMaps()
     ProcMapsArea *area = &shmAreas[i];
     FileConnection *fileCon = shmAreaConn[i];
     int fd = fileCon->getFds()[0];
-    JTRACE("Restoring shared memory area") (area->name) ((void *)area->addr);
+    JLOG(FILEP)("Restoring shared memory area") (area->name) ((void *)area->addr);
     void *addr = _real_mmap(area->addr, area->size, area->prot,
                             MAP_FIXED | area->flags,
                             fd, area->offset);
@@ -375,7 +375,7 @@ FileConnList::scanForPreExisting()
 
     string device = jalib::Filesystem::GetDeviceName(fd);
 
-    JTRACE("scanning pre-existing device") (fd) (device);
+    JLOG(FILEP)("scanning pre-existing device") (fd) (device);
 
     if (dmtcp_is_bq_file && dmtcp_is_bq_file(device.c_str())) {
       if (isRegularFile) {

--- a/src/plugin/ipc/file/ptyconnection.cpp
+++ b/src/plugin/ipc/file/ptyconnection.cpp
@@ -227,7 +227,7 @@ PtyConnection::PtyConnection(int fd,
       SharedData::createVirtualPtyName(path, buf, sizeof(buf));
     }
     _virtPtsName = buf;
-    JTRACE("creating CTTY connection") (_ptsName) (_virtPtsName);
+    JLOG(FILEP)("creating CTTY connection") (_ptsName) (_virtPtsName);
 
     break;
 
@@ -248,7 +248,7 @@ PtyConnection::PtyConnection(int fd,
     // Generate new Unique buf
     SharedData::createVirtualPtyName(_ptsName.c_str(), buf, sizeof(buf));
     _virtPtsName = buf;
-    JTRACE("creating ptmx connection") (_ptsName) (_virtPtsName);
+    JLOG(FILEP)("creating ptmx connection") (_ptsName) (_virtPtsName);
     break;
 
   case PTY_SLAVE:
@@ -256,7 +256,7 @@ PtyConnection::PtyConnection(int fd,
     SharedData::getVirtPtyName(path, buf, sizeof(buf));
     _virtPtsName = buf;
     JASSERT(strlen(buf) != 0) (path);
-    JTRACE("creating pts connection") (_ptsName) (_virtPtsName);
+    JLOG(FILEP)("creating pts connection") (_ptsName) (_virtPtsName);
     break;
 
   case PTY_BSD_MASTER:
@@ -299,7 +299,7 @@ PtyConnection::drain()
     // _fds[0] is master fd
     numRead = ptmxReadAll(_fds[0], buf, maxCount);
     _ptmxIsPacketMode = ptmxTestPacketMode(_fds[0]);
-    JTRACE("_fds[0] is master(/dev/ptmx)") (_fds[0]) (_ptmxIsPacketMode);
+    JLOG(FILEP)("_fds[0] is master(/dev/ptmx)") (_fds[0]) (_ptmxIsPacketMode);
     numWritten = ptmxWriteAll(_fds[0], buf, _ptmxIsPacketMode);
     JASSERT(numRead == numWritten) (numRead) (numWritten);
   }
@@ -320,7 +320,7 @@ PtyConnection::refill(bool isRestart)
 
   if (_type == PTY_SLAVE || _type == PTY_BSD_SLAVE) {
     JASSERT(_ptsName.compare("?") != 0);
-    JTRACE("Restoring PTY slave") (_fds[0]) (_ptsName) (_virtPtsName);
+    JLOG(FILEP)("Restoring PTY slave") (_fds[0]) (_ptsName) (_virtPtsName);
     if (_type == PTY_SLAVE) {
       char buf[32];
       SharedData::getRealPtyName(_virtPtsName.c_str(), buf, sizeof(buf));
@@ -338,7 +338,7 @@ PtyConnection::refill(bool isRestart)
     JASSERT(tempfd >= 0) (_virtPtsName) (_ptsName) (JASSERT_ERRNO)
     .Text("Error Opening PTS");
 
-    JTRACE("Restoring PTS real") (_ptsName) (_virtPtsName) (_fds[0]);
+    JLOG(FILEP)("Restoring PTS real") (_ptsName) (_virtPtsName) (_fds[0]);
     Util::dupFds(tempfd, _fds);
   }
 
@@ -352,7 +352,7 @@ PtyConnection::refill(bool isRestart)
     JASSERT(tempfd >= 0) (tempfd) (JASSERT_ERRNO)
     .Text("Error opening controlling terminal /dev/tty");
 
-    JTRACE("Restoring /dev/tty for the process") (_fds[0]);
+    JLOG(FILEP)("Restoring /dev/tty for the process") (_fds[0]);
     _ptsName = _virtPtsName = "/dev/tty";
     Util::dupFds(tempfd, _fds);
   }
@@ -373,7 +373,7 @@ PtyConnection::postRestart()
   case PTY_INVALID:
 
     // tempfd = _real_open("/dev/null", O_RDWR);
-    JTRACE("Restoring invalid PTY.") (id());
+    JLOG(FILEP)("Restoring invalid PTY.") (id());
     return;
 
   case PTY_CTTY:
@@ -395,7 +395,7 @@ PtyConnection::postRestart()
       .Text("Error Opening the terminal attached with the process");
     } else {
       if (_type == PTY_CTTY) {
-        JTRACE("Unable to restore controlling terminal attached with the "
+        JLOG(FILEP)("Unable to restore controlling terminal attached with the "
                "parent process.\n"
                "Replacing it with current STDIN")
           (stdinDeviceName);
@@ -418,7 +418,7 @@ PtyConnection::postRestart()
       }
     }
 
-    JTRACE("Restoring parent CTTY for the process")
+    JLOG(FILEP)("Restoring parent CTTY for the process")
       (controllingTty) (_fds[0]);
 
     _ptsName = controllingTty;
@@ -447,12 +447,12 @@ PtyConnection::postRestart()
       ioctl(_fds[0], TIOCPKT, &packetMode);     /* Restore old packet mode */
     }
 
-    JTRACE("Restoring /dev/ptmx") (_fds[0]) (_ptsName) (_virtPtsName);
+    JLOG(FILEP)("Restoring /dev/ptmx") (_fds[0]) (_ptsName) (_virtPtsName);
     break;
   }
   case PTY_BSD_MASTER:
   {
-    JTRACE("Restoring BSD Master Pty") (_masterName) (_fds[0]);
+    JLOG(FILEP)("Restoring BSD Master Pty") (_masterName) (_fds[0]);
 
     // string slaveDeviceName =
     // _masterName.replace(0, strlen("/dev/pty"), "/dev/tty");
@@ -486,5 +486,5 @@ PtyConnection::serializeSubClass(jalib::JBinarySerializer &o)
   JSERIALIZE_ASSERT_POINT("PtyConnection");
   o&_ptsName&_virtPtsName&_masterName &_type;
   o&_flags&_mode &_preExistingCTTY;
-  JTRACE("Serializing PtyConn.") (_ptsName) (_virtPtsName);
+  JLOG(FILEP)("Serializing PtyConn.") (_ptsName) (_virtPtsName);
 }

--- a/src/plugin/ipc/file/ptyconnlist.cpp
+++ b/src/plugin/ipc/file/ptyconnlist.cpp
@@ -116,7 +116,7 @@ PtyConnList::scanForPreExisting()
 
     string device = jalib::Filesystem::GetDeviceName(fd);
 
-    JTRACE("scanning pre-existing device") (fd) (device);
+    JLOG(FILEP)("scanning pre-existing device") (fd) (device);
     if (device == ctty || device == parentCtty) {
       // Search if this is duplicate connection
       iterator conit;

--- a/src/plugin/ipc/file/ptywrappers.cpp
+++ b/src/plugin/ipc/file/ptywrappers.cpp
@@ -280,14 +280,14 @@ access(const char *path, int mode)
 static int
 ptsname_r_work(int fd, char *buf, size_t buflen)
 {
-  JTRACE("Calling ptsname_r");
+  JLOG(FILEP)("Calling ptsname_r");
 
   Connection *c = PtyConnList::instance().getConnection(fd);
   PtyConnection *ptyCon = (PtyConnection *)c;
 
   string virtPtsName = ptyCon->virtPtsName();
 
-  JTRACE("ptsname_r") (virtPtsName);
+  JLOG(FILEP)("ptsname_r") (virtPtsName);
 
   if (virtPtsName.length() >= buflen) {
     JWARNING(false) (virtPtsName) (virtPtsName.length()) (buflen)
@@ -317,7 +317,7 @@ extern "C" char *ptsname(int fd)
 {
   /* No need to acquire Wrapper Protection lock since it will be done in
      ptsname_r */
-  JTRACE("ptsname() promoted to ptsname_r()");
+  JLOG(FILEP)("ptsname() promoted to ptsname_r()");
   static char tmpbuf[PATH_MAX];
 
   if (ptsname_r(fd, tmpbuf, sizeof(tmpbuf)) != 0) {

--- a/src/plugin/ipc/ipc.cpp
+++ b/src/plugin/ipc/ipc.cpp
@@ -242,7 +242,7 @@ extern "C" int
 close(int fd)
 {
   if (dmtcp_is_protected_fd(fd)) {
-    JTRACE("blocked attempt to close protected fd") (fd);
+    JLOG(IPC)("blocked attempt to close protected fd") (fd);
     errno = EBADF;
     return -1;
   }
@@ -262,7 +262,7 @@ fclose(FILE *fp)
   int fd = fileno(fp);
 
   if (dmtcp_is_protected_fd(fd)) {
-    JTRACE("blocked attempt to fclose protected fd") (fd);
+    JLOG(IPC)("blocked attempt to fclose protected fd") (fd);
     errno = EBADF;
     return -1;
   }
@@ -283,7 +283,7 @@ closedir(DIR *dir)
   int fd = dirfd(dir);
 
   if (dmtcp_is_protected_fd(fd)) {
-    JTRACE("blocked attempt to closedir protected fd") (fd);
+    JLOG(IPC)("blocked attempt to closedir protected fd") (fd);
     errno = EBADF;
     return -1;
   }

--- a/src/plugin/ipc/socket/connectionrewirer.cpp
+++ b/src/plugin/ipc/socket/connectionrewirer.cpp
@@ -103,7 +103,7 @@ ConnectionRewirer::checkForPendingIncoming(int restoreSockFd,
 
     Util::dupFds(fd, (i->second)->getFds());
 
-    JTRACE("restoring incoming connection") (id);
+    JLOG(SOCKET)("restoring incoming connection") (id);
     conList->erase(i);
   }
 }
@@ -156,7 +156,7 @@ ConnectionRewirer::doReconnect()
                             &_pendingUDSIncoming);
     _real_close(PROTECTED_RESTORE_UDS_SOCK_FD);
   }
-  JTRACE("Closed restore sockets");
+  JLOG(SOCKET)("Closed restore sockets");
 }
 
 void
@@ -180,7 +180,7 @@ ConnectionRewirer::openRestoreSocket(bool hasIPv4Sock,
     _ip4RestoreAddr.sin_port = htons(restoreSocket.port());
     _ip4RestoreAddrlen = sizeof(_ip4RestoreAddr);
 
-    JTRACE("opened listen socket") (restoreSocket.sockfd())
+    JLOG(SOCKET)("opened listen socket") (restoreSocket.sockfd())
       (inet_ntoa(_ip4RestoreAddr.sin_addr)) (ntohs(_ip4RestoreAddr.sin_port));
     markSocketNonBlocking(PROTECTED_RESTORE_IP4_SOCK_FD);
   }
@@ -203,7 +203,7 @@ ConnectionRewirer::openRestoreSocket(bool hasIPv4Sock,
     JASSERT(_real_listen(ip6fd, 32) == 0) (JASSERT_ERRNO);
     Util::changeFd(ip6fd, PROTECTED_RESTORE_IP6_SOCK_FD);
 
-    JTRACE("opened ip6 listen socket") (PROTECTED_RESTORE_IP6_SOCK_FD);
+    JLOG(SOCKET)("opened ip6 listen socket") (PROTECTED_RESTORE_IP6_SOCK_FD);
     markSocketNonBlocking(PROTECTED_RESTORE_IP6_SOCK_FD);
   }
 
@@ -224,7 +224,7 @@ ConnectionRewirer::openRestoreSocket(bool hasIPv4Sock,
     JASSERT(_real_listen(udsfd, 32) == 0) (JASSERT_ERRNO);
     Util::changeFd(udsfd, PROTECTED_RESTORE_UDS_SOCK_FD);
 
-    JTRACE("opened UDS listen socket")
+    JLOG(SOCKET)("opened UDS listen socket")
       (PROTECTED_RESTORE_UDS_SOCK_FD) (&_udsRestoreAddr.sun_path[1]);
     markSocketNonBlocking(PROTECTED_RESTORE_UDS_SOCK_FD);
   }
@@ -252,7 +252,7 @@ ConnectionRewirer::registerIncoming(const ConnectionIdentifier &local,
     JASSERT(false).Text("Not implemented");
   }
 
-  JTRACE("announcing pending incoming") (local);
+  JLOG(SOCKET)("announcing pending incoming") (local);
 }
 
 void
@@ -260,7 +260,7 @@ ConnectionRewirer::registerOutgoing(const ConnectionIdentifier &remote,
                                     Connection *con)
 {
   _pendingOutgoing[remote] = con;
-  JTRACE("announcing pending outgoing") (remote);
+  JLOG(SOCKET)("announcing pending outgoing") (remote);
 }
 
 void
@@ -294,7 +294,7 @@ ConnectionRewirer::registerNSData(void *addr,
     sockaddr_in *sn = (sockaddr_in*) &_restoreAddr;
     unsigned short port = htons(sn->sin_port);
     char *ip = inet_ntoa(sn->sin_addr);
-    JTRACE("Send NS information:")(id)(sn->sin_family)(port)(ip);
+    JLOG(SOCKET)("Send NS information:")(id)(sn->sin_family)(port)(ip);
     */
   }
 
@@ -321,7 +321,7 @@ ConnectionRewirer::sendQueries()
     sockaddr_in *sn = (sockaddr_in*) &remote.addr;
     unsigned short port = htons(sn->sin_port);
     char *ip = inet_ntoa(sn->sin_addr);
-    JTRACE("Send Queries. Get remote from coordinator:")(id)(sn->sin_family)(port)(ip);
+    JLOG(SOCKET)("Send Queries. Get remote from coordinator:")(id)(sn->sin_family)(port)(ip);
     */
     _remoteInfo[id] = remote;
   }

--- a/src/plugin/ipc/socket/socketconnlist.cpp
+++ b/src/plugin/ipc/socket/socketconnlist.cpp
@@ -61,7 +61,7 @@ SocketConnList::drain()
     const ConnectionIdentifier &id = it->first;
     TcpConnection *con =
       (TcpConnection *)SocketConnList::instance().getConnection(id);
-    JTRACE("recreating disconnected socket") (id);
+    JLOG(SOCKET)("recreating disconnected socket") (id);
 
     // reading from the socket, and taking the error, resulted in an
     // implicit close().
@@ -74,7 +74,7 @@ void
 SocketConnList::preCkpt()
 {
   // handshake is done after one barrier after drain
-  JTRACE("beginning handshakes");
+  JLOG(SOCKET)("beginning handshakes");
   DmtcpUniqueProcessId coordId = dmtcp_get_coord_id();
 
   // must send first to avoid deadlock
@@ -93,7 +93,7 @@ SocketConnList::preCkpt()
       ((TcpConnection *)con)->doRecvHandshakes(coordId);
     }
   }
-  JTRACE("handshaking done");
+  JLOG(SOCKET)("handshaking done");
   _hasIPv4Sock = _hasIPv6Sock = _hasUNIXSock = false;
 
   // Now check if we have IPv4, IPv6, or UNIX domain sockets to restore.
@@ -183,7 +183,7 @@ SocketConnList::scanForPreExisting()
 
     string device = jalib::Filesystem::GetDeviceName(fd);
 
-    JTRACE("scanning pre-existing device") (fd) (device);
+    JLOG(SOCKET)("scanning pre-existing device") (fd) (device);
     if (device ==
         jalib::Filesystem::GetControllingTerm()) {} else if (dmtcp_is_bq_file &&
                                                              dmtcp_is_bq_file(

--- a/src/plugin/ipc/socket/socketwrappers.cpp
+++ b/src/plugin/ipc/socket/socketwrappers.cpp
@@ -57,7 +57,7 @@ socket(int domain, int type, int protocol)
   int ret = _real_socket(domain, type, protocol);
   if (ret != -1 && dmtcp_is_running_state() && !_doNotProcessSockets) {
     Connection *con;
-    JTRACE("socket created") (ret) (domain) (type) (protocol);
+    JLOG(SOCKET)("socket created") (ret) (domain) (type) (protocol);
     if ((type & 0xff) == SOCK_RAW) {
       JASSERT(domain == AF_NETLINK) (domain) (type)
       .Text("Only Netlink Raw sockets supported");
@@ -86,7 +86,7 @@ connect(int sockfd, const struct sockaddr *serv_addr, socklen_t addrlen)
       dynamic_cast<SocketConnection *>(SocketConnList::instance().getConnection(
                                          sockfd));
     if (con == NULL) {
-      JTRACE("Connect operation on unsupported socket type.");
+      JLOG(SOCKET)("Connect operation on unsupported socket type.");
     } else {
       con->onConnect(serv_addr, addrlen, (ret == -1 && errno == EINPROGRESS));
     }
@@ -107,7 +107,7 @@ bind(int sockfd, const struct sockaddr *my_addr, socklen_t addrlen)
       dynamic_cast<SocketConnection *>(SocketConnList::instance().getConnection(
                                          sockfd));
     if (con == NULL) {
-      JTRACE("bind operation on unsupported socket type.");
+      JLOG(SOCKET)("bind operation on unsupported socket type.");
     } else {
       con->onBind((struct sockaddr *)my_addr, addrlen);
     }
@@ -126,7 +126,7 @@ listen(int sockfd, int backlog)
       dynamic_cast<SocketConnection *>(SocketConnList::instance().getConnection(
                                          sockfd));
     if (con == NULL) {
-      JTRACE("listen operation on unsupported socket type.");
+      JLOG(SOCKET)("listen operation on unsupported socket type.");
     } else {
       con->onListen(backlog);
     }
@@ -141,7 +141,7 @@ process_accept(int ret, int sockfd, struct sockaddr *addr, socklen_t *addrlen)
   JASSERT(ret != -1);
   Connection *parent = SocketConnList::instance().getConnection(sockfd);
   if (parent == NULL) {
-    JTRACE("unable to get the connection.");
+    JLOG(SOCKET)("unable to get the connection.");
     return;
   }
 
@@ -158,7 +158,7 @@ process_accept(int ret, int sockfd, struct sockaddr *addr, socklen_t *addrlen)
   }
 
   if (con == NULL) {
-    JTRACE("accept operation on unsupported socket type.");
+    JLOG(SOCKET)("accept operation on unsupported socket type.");
     return;
   } else {
     SocketConnList::instance().add(ret, dynamic_cast<Connection *>(con));
@@ -221,12 +221,12 @@ setsockopt(int sockfd,
   int ret = _real_setsockopt(sockfd, level, optname, optval, optlen);
 
   if (ret != -1 && dmtcp_is_running_state() && !_doNotProcessSockets) {
-    JTRACE("setsockopt") (ret) (sockfd) (optname);
+    JLOG(SOCKET)("setsockopt") (ret) (sockfd) (optname);
     SocketConnection *con =
       dynamic_cast<SocketConnection *>(SocketConnList::instance().getConnection(
                                          sockfd));
     if (con == NULL) {
-      JTRACE("setsockopt operation on unsupported socket type.");
+      JLOG(SOCKET)("setsockopt operation on unsupported socket type.");
       return ret;
     } else {
       con->addSetsockopt(level, optname, optval, optlen);
@@ -260,7 +260,7 @@ socketpair(int d, int type, int protocol, int sv[2])
   JASSERT(sv != NULL);
   int rv = _real_socketpair(d, type, protocol, sv);
   if (rv != -1 && dmtcp_is_running_state() && !_doNotProcessSockets) {
-    JTRACE("socketpair()") (sv[0]) (sv[1]);
+    JLOG(SOCKET)("socketpair()") (sv[0]) (sv[1]);
 
     TcpConnection *a, *b;
 

--- a/src/plugin/ipc/ssh/ssh.cpp
+++ b/src/plugin/ipc/ssh/ssh.cpp
@@ -218,7 +218,7 @@ createNewDmtcpSshdProcess()
     dup2(out[1], STDOUT_FILENO);
     dup2(err[1], STDERR_FILENO);
 
-    JTRACE("Launching ")
+    JLOG(SSH)("Launching ")
       (argv[0]) (argv[1]) (argv[2]) (argv[3]) (argv[4]) (argv[5]);
     _real_execvp(argv[0], argv);
     JASSERT(false);
@@ -340,7 +340,7 @@ prepareForExec(char *const argv[], char ***newArgv)
     prefix += dmtcp_args[i] + " ";
   }
   prefix += dmtcp_sshd_path + " ";
-  JTRACE("Prefix")(prefix);
+  JLOG(SSH)("Prefix")(prefix);
 
   // process command
   size_t semipos, pos;
@@ -445,7 +445,7 @@ updateCoordHost()
                           0,
                           0);
       if (error != 0) {
-        JTRACE("getnameinfo() failed.") (gai_strerror(error));
+        JLOG(SSH)("getnameinfo() failed.") (gai_strerror(error));
         continue;
       }
       if (Util::strStartsWith(name, hostname) ||
@@ -462,7 +462,7 @@ updateCoordHost()
     if (error == EAI_SYSTEM) {
       perror("getaddrinfo");
     } else {
-      JTRACE("Error in getaddrinfo") (gai_strerror(error));
+      JLOG(SSH)("Error in getaddrinfo") (gai_strerror(error));
     }
     inet_aton("127.0.0.1", &localhostIPAddr);
   }

--- a/src/plugin/ipc/ssh/sshdrainer.cpp
+++ b/src/plugin/ipc/ssh/sshdrainer.cpp
@@ -25,7 +25,7 @@ SSHDrainer::onData(jalib::JReaderInterface *sock)
   int startIdx = buffer.size() - sock->bytesRead();
   memcpy(&buffer[startIdx], sock->buffer(), sock->bytesRead());
 
-  // JTRACE("got buffer chunk") (sock->bytesRead());
+  // JLOG(SSH)("got buffer chunk") (sock->bytesRead());
   sock->reset();
 }
 
@@ -62,7 +62,7 @@ SSHDrainer::onTimeoutInterval()
                   theMagicDrainCookie,
                   sizeof(theMagicDrainCookie)) == 0) {
       buffer.resize(buffer.size() - sizeof(theMagicDrainCookie));
-      JTRACE("buffer drain complete") (_dataSockets[i]->socket().sockfd())
+      JLOG(SSH)("buffer drain complete") (_dataSockets[i]->socket().sockfd())
         (buffer.size()) ((_dataSockets.size()));
       _dataSockets[i]->socket() = -1; // poison socket
     } else {
@@ -108,7 +108,7 @@ SSHDrainer::beginDrainOf(int fd, int refillFd)
 void
 SSHDrainer::refill()
 {
-  JTRACE("refilling socket buffers") (_drainedData.size());
+  JLOG(SSH)("refilling socket buffers") (_drainedData.size());
 
   // write all buffers out
   map<int, vector<char> >::iterator i;

--- a/src/plugin/pid/pid.cpp
+++ b/src/plugin/pid/pid.cpp
@@ -128,7 +128,7 @@ openSharedFile(string name, int flags)
 
   jalib::string dir = jalib::Filesystem::DirName(name);
 
-  JTRACE("shared file dir:")(dir);
+  JLOG(PID)("shared file dir:")(dir);
   jalib::Filesystem::mkdir_r(dir, 0755);
 
   if ((fd =
@@ -138,7 +138,7 @@ openSharedFile(string name, int flags)
   }
   errno_bkp = errno;
 
-  JTRACE("_real_open: ")(strerror(errno))(fd)(flags);
+  JLOG(PID)("_real_open: ")(strerror(errno))(fd)(flags);
 
   if ((fd < 0) && (errno_bkp == EEXIST)) {
     errno = 0;
@@ -164,7 +164,7 @@ openOriginalToCurrentMappingFiles()
   pidMapFile = o.str();
 
   // Open and create pidMapFile if it doesn't exist.
-  JTRACE("Open dmtcpPidMapFile")(pidMapFile);
+  JLOG(PID)("Open dmtcpPidMapFile")(pidMapFile);
   if (!Util::isValidFd(PROTECTED_PIDMAP_FD)) {
     fd = openSharedFile(pidMapFile, O_RDWR);
     JASSERT(fd != -1);

--- a/src/plugin/pid/pid_miscwrappers.cpp
+++ b/src/plugin/pid/pid_miscwrappers.cpp
@@ -113,7 +113,7 @@ clone_start(void *arg)
   VirtualPidTable::instance().updateMapping(virtualTid, _real_gettid());
   sem_post(&threadArg->sem);
 
-  JTRACE("Calling user function") (virtualTid);
+  JLOG(PID)("Calling user function") (virtualTid);
   return (*fn)(thread_arg);
 }
 
@@ -158,7 +158,7 @@ __clone(int (*fn)(void *arg),
   threadArg->virtualTid = virtualTid;
   sem_init(&threadArg->sem, 0, 0);
 
-  JTRACE("Calling libc:__clone");
+  JLOG(PID)("Calling libc:__clone");
   pid_t tid = _real_clone(clone_start, child_stack, flags, threadArg,
                           parent_tidptr, newtls, child_tidptr);
 
@@ -167,7 +167,7 @@ __clone(int (*fn)(void *arg),
   }
 
   if (tid > 0) {
-    JTRACE("New thread created") (tid);
+    JLOG(PID)("New thread created") (tid);
 
     /* Wait for child thread to finish intializing.
      * We must let the child thread insert original->current tid in the
@@ -332,8 +332,8 @@ mq_notify(mqd_t mqdes, const struct sigevent *sevp)
  * If we discover system calls for which the 7 args strategy doesn't work,
  *  we can special case them.
  *
- * XXX: DO NOT USE JTRACE/JNOTE/JASSERT in this function; even better, do not
- *      use any STL here.  (--Kapil)
+ * XXX: DO NOT USE JLOG/JTRACE/JNOTE/JASSERT in this function; even better, do
+ *      not use any STL here.  (--Kapil)
  */
 extern "C" long
 syscall(long sys_num, ...)

--- a/src/plugin/pid/pidwrappers.cpp
+++ b/src/plugin/pid/pidwrappers.cpp
@@ -179,11 +179,11 @@ tcsetpgrp(int fd, pid_t pgrp)
 
   pid_t currPgrp = VIRTUAL_TO_REAL_PID(pgrp);
 
-  // JTRACE("Inside tcsetpgrp wrapper") (fd) (pgrp) (currPgrp);
+  // JLOG(PID)("Inside tcsetpgrp wrapper") (fd) (pgrp) (currPgrp);
   pid_t realPid = _real_tcsetpgrp(fd, currPgrp);
   pid_t virtualPid = REAL_TO_VIRTUAL_PID(realPid);
 
-  // JTRACE("tcsetpgrp return value") (fd) (pgrp) (currPgrp) (retval);
+  // JLOG(PID)("tcsetpgrp return value") (fd) (pgrp) (currPgrp) (retval);
   DMTCP_PLUGIN_ENABLE_CKPT();
 
   return virtualPid;
@@ -196,7 +196,7 @@ tcgetpgrp(int fd)
 
   pid_t retval = REAL_TO_VIRTUAL_PID(_real_tcgetpgrp(fd));
 
-  JTRACE("tcgetpgrp return value") (fd) (retval);
+  JLOG(PID)("tcgetpgrp return value") (fd) (retval);
   DMTCP_PLUGIN_ENABLE_CKPT();
 
   return retval;
@@ -209,7 +209,7 @@ tcgetsid(int fd)
 
   pid_t retval = REAL_TO_VIRTUAL_PID(_real_tcgetsid(fd));
 
-  JTRACE("tcgetsid return value") (fd) (retval);
+  JLOG(PID)("tcgetsid return value") (fd) (retval);
   DMTCP_PLUGIN_ENABLE_CKPT();
 
   return retval;

--- a/src/plugin/pid/virtualpidtable.cpp
+++ b/src/plugin/pid/virtualpidtable.cpp
@@ -194,6 +194,6 @@ VirtualPidTable::readVirtualTidFromFileForPtrace(pid_t tid)
 
   pid = SharedData::getPtraceVirtualId(tid);
 
-  JTRACE("Read virtual Pid/Tid from shared-area") (pid);
+  JLOG(PID)("Read virtual Pid/Tid from shared-area") (pid);
   return pid;
 }

--- a/src/plugin/svipc/sysvipc.cpp
+++ b/src/plugin/svipc/sysvipc.cpp
@@ -446,7 +446,7 @@ SysVShm::on_shmget(int shmid, key_t key, size_t size, int shmflg)
   if (!_virtIdTable.realIdExists(shmid)) {
     JASSERT(_map.find(shmid) == _map.end());
     int virtId = getNewVirtualId();
-    JTRACE("Shmid not found in table. Creating new entry")
+    JLOG(SYSV)("Shmid not found in table. Creating new entry")
       (shmid) (virtId);
     updateMapping(virtId, shmid);
     _map[virtId] = new ShmSegment(virtId, shmid, key, size, shmflg);
@@ -517,7 +517,7 @@ SysVSem::on_semget(int realSemId, key_t key, int nsems, int semflg)
   if (!_virtIdTable.realIdExists(realSemId)) {
     // JASSERT(key == IPC_PRIVATE || (semflg & IPC_CREAT) != 0) (key)
     // (realSemId);
-    JTRACE("Semid not found in table. Creating new entry") (realSemId);
+    JLOG(SYSV)("Semid not found in table. Creating new entry") (realSemId);
     int virtId = getNewVirtualId();
     JASSERT(_map.find(virtId) == _map.end());
     updateMapping(virtId, realSemId);
@@ -564,7 +564,7 @@ SysVMsq::on_msgget(int msqid, key_t key, int msgflg)
   _do_lock_tbl();
   if (!_virtIdTable.realIdExists(msqid)) {
     JASSERT(_map.find(msqid) == _map.end());
-    JTRACE("Msqid not found in table. Creating new entry") (msqid);
+    JLOG(SYSV)("Msqid not found in table. Creating new entry") (msqid);
     int virtId = getNewVirtualId();
     updateMapping(virtId, msqid);
     _map[virtId] = new MsgQueue(virtId, msqid, key, msgflg);
@@ -640,7 +640,7 @@ ShmSegment::ShmSegment(int shmid,
     _size = shminfo.shm_segsz;
     _flags = shminfo.shm_perm.mode;
   }
-  JTRACE("New Shm Segment") (_key) (_size) (_flags) (_id) (_isCkptLeader);
+  JLOG(SYSV)("New Shm Segment") (_key) (_size) (_flags) (_id) (_isCkptLeader);
 }
 
 void
@@ -729,7 +729,7 @@ ShmSegment::preCheckpoint()
     ++i;
   }
   for (; i != _shmaddrToFlag.end(); ++i) {
-    JTRACE("Unmapping shared memory segment") (_id)(i->first);
+    JLOG(SYSV)("Unmapping shared memory segment") (_id)(i->first);
     JASSERT(_real_shmdt(i->first) == 0);
 
     // We need to unmap the duplicate shared memory segments to optimize ckpt
@@ -768,7 +768,7 @@ ShmSegment::postRestart()
       (i->first) (i->second) (getpid())
     .Text("Error remapping shared memory segment on restart");
   }
-  JTRACE("Remapping shared memory segment to original address") (_id) (_realId);
+  JLOG(SYSV)("Remapping shared memory segment to original address") (_id) (_realId);
 }
 
 void
@@ -796,7 +796,7 @@ ShmSegment::preResume()
     // Unmap the reserved area.
     JASSERT(munmap((void *)i->first, _size) == 0);
 
-    JTRACE("Remapping shared memory segment")(_realId);
+    JLOG(SYSV)("Remapping shared memory segment")(_realId);
     JASSERT(_real_shmat(_realId, i->first, i->second) != (void *)-1)
       (JASSERT_ERRNO) (_realId) (_id) (_isCkptLeader)
       (i->first) (i->second) (getpid())
@@ -833,7 +833,7 @@ Semaphore::Semaphore(int semid, int realSemid, key_t key, int nsems, int semflg)
     _semval[i] = 0;
     _semadj[i] = 0;
   }
-  JTRACE("New Semaphore Segment")
+  JLOG(SYSV)("New Semaphore Segment")
     (_key) (_nsems) (_flags) (_id) (_isCkptLeader);
 }
 
@@ -967,7 +967,7 @@ MsgQueue::MsgQueue(int msqid, int realMsqid, key_t key, int msgflg)
     _key = buf.msg_perm.__key;
     _flags = buf.msg_perm.mode;
   }
-  JTRACE("New MsgQueue Created") (_key) (_flags) (_id);
+  JLOG(SYSV)("New MsgQueue Created") (_key) (_flags) (_id);
 }
 
 bool

--- a/src/plugin/svipc/sysvipcwrappers.cpp
+++ b/src/plugin/svipc/sysvipcwrappers.cpp
@@ -57,7 +57,7 @@ shmget(key_t key, size_t size, int shmflg)
   if (realId != -1) {
     SysVShm::instance().on_shmget(realId, key, size, shmflg);
     virtId = REAL_TO_VIRTUAL_SHM_ID(realId);
-    JTRACE("Creating new Shared memory segment")
+    JLOG(SYSV)("Creating new Shared memory segment")
       (key) (size) (shmflg) (realId) (virtId);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
@@ -109,7 +109,7 @@ void *shmat(int shmid, const void *shmaddr, int shmflg)
 
   if (ret != (void *)-1) {
     SysVShm::instance().on_shmat(shmid, shmaddr, shmflg, ret);
-    JTRACE("Mapping Shared memory segment") (shmid) (realShmid) (shmflg) (ret);
+    JLOG(SYSV)("Mapping Shared memory segment") (shmid) (realShmid) (shmflg) (ret);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
   return ret;
@@ -123,7 +123,7 @@ shmdt(const void *shmaddr)
   int ret = _real_shmdt(shmaddr);
   if (ret != -1) {
     SysVShm::instance().on_shmdt(shmaddr);
-    JTRACE("Unmapping Shared memory segment") (shmaddr);
+    JLOG(SYSV)("Unmapping Shared memory segment") (shmaddr);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
   return ret;
@@ -159,7 +159,7 @@ semget(key_t key, int nsems, int semflg)
   if (realId != -1) {
     SysVSem::instance().on_semget(realId, key, nsems, semflg);
     virtId = REAL_TO_VIRTUAL_SEM_ID(realId);
-    JTRACE("Creating new SysV Semaphore") (key) (nsems) (semflg);
+    JLOG(SYSV)("Creating new SysV Semaphore") (key) (nsems) (semflg);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
   return virtId;
@@ -277,7 +277,7 @@ msgget(key_t key, int msgflg)
   if (realId != -1) {
     SysVMsq::instance().on_msgget(realId, key, msgflg);
     virtId = REAL_TO_VIRTUAL_MSQ_ID(realId);
-    JTRACE("Creating new SysV Msg Queue") (key) (msgflg);
+    JLOG(SYSV)("Creating new SysV Msg Queue") (key) (msgflg);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
   return virtId;

--- a/src/plugin/timer/timerlist.cpp
+++ b/src/plugin/timer/timerlist.cpp
@@ -117,7 +117,7 @@ TimerList::removeStaleClockIds()
     }
   }
   for (size_t i = 0; i < staleClockIds.size(); i++) {
-    JTRACE("Removing stale clock") (staleClockIds[i]);
+    JLOG(TIMER)("Removing stale clock") (staleClockIds[i]);
     _clockPidList.erase(staleClockIds[i]);
   }
   staleClockIds.clear();
@@ -218,7 +218,7 @@ TimerList::postRestart()
       }
       JASSERT(_real_timer_settime(realId, tinfo.flags, &tspec, NULL) == 0)
         (virtId) (JASSERT_ERRNO);
-      JTRACE("Restoring timer") (realId) (virtId);
+      JLOG(TIMER)("Restoring timer") (realId) (virtId);
     }
   }
 }

--- a/src/plugin/timer/timerwrappers.cpp
+++ b/src/plugin/timer/timerwrappers.cpp
@@ -47,7 +47,7 @@ timer_create(clockid_t clockid, struct sigevent *sevp, timer_t *timerid)
   }
   if (ret != -1 && timerid != NULL) {
     virtId = TimerList::instance().on_timer_create(realId, clockid, sevp);
-    JTRACE("Creating new timer") (clockid) (realClockId) (realId) (virtId);
+    JLOG(TIMER)("Creating new timer") (clockid) (realClockId) (realId) (virtId);
     *timerid = virtId;
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
@@ -62,7 +62,7 @@ timer_delete(timer_t timerid)
   int ret = _real_timer_delete(realId);
   if (ret != -1) {
     TimerList::instance().on_timer_delete(timerid);
-    JTRACE("Deleted timer") (timerid);
+    JLOG(TIMER)("Deleted timer") (timerid);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
   return ret;

--- a/src/plugininfo.cpp
+++ b/src/plugininfo.cpp
@@ -115,14 +115,14 @@ PluginInfo::processBarrier(BarrierInfo *barrier)
   if (dmtcp_no_coordinator()) {
     // Do nothing.
   } else if (barrier->isGlobal()) {
-    JTRACE("Waiting for global barrier") (barrier->toString());
+    JLOG(DMTCP)("Waiting for global barrier") (barrier->toString());
     CoordinatorAPI::instance().waitForBarrier(barrier->toString());
   } else if (barrier->isLocal()) {
-    JTRACE("Waiting for local barrier") (barrier->toString());
+    JLOG(DMTCP)("Waiting for local barrier") (barrier->toString());
     SharedData::waitForBarrier(barrier->toString());
   }
 
-  JTRACE("Barrier released") (barrier->toString());
+  JLOG(DMTCP)("Barrier released") (barrier->toString());
   barrier->callback();
 }
 }

--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -720,3 +720,24 @@ SharedData::getCkptLeaderForFile(dev_t devnum, ino_t inode, void *id)
   }
   return false;
 }
+
+uint32_t
+SharedData::getLogMask(void)
+{
+  uint32_t logMask = jassert_internal::JTRACE;
+  if (initialized()) {
+    logMask |= sharedDataHeader->logMask;
+  }
+  return logMask;
+}
+
+void
+SharedData::setLogMask(uint32_t mask)
+{
+  if (initialized()) {
+    initialize();
+  }
+  Util::lockFile(PROTECTED_SHM_FD);
+  sharedDataHeader->logMask = mask;
+  Util::unlockFile(PROTECTED_SHM_FD);
+}

--- a/src/siginfo.cpp
+++ b/src/siginfo.cpp
@@ -116,7 +116,7 @@ SigInfo::saveSigHandlers()
   .Text("Error setting up signal handler");
 
   /* Now save all the signal handlers */
-  JTRACE("saving signal handlers");
+  JLOG(DMTCP)("saving signal handlers");
   for (sig = SIGRTMAX; sig > 0; --sig) {
     if (_real_syscall(SYS_rt_sigaction, sig, NULL, &sigactions[sig],
                       _NSIG / 8) < 0) {
@@ -126,7 +126,7 @@ SigInfo::saveSigHandlers()
     }
 
     if (sigactions[sig].sa_handler != SIG_DFL) {
-      JTRACE("saving signal handler (non-default) for") (sig);
+      JLOG(DMTCP)("saving signal handler (non-default) for") (sig);
     }
   }
 }
@@ -141,10 +141,10 @@ SigInfo::restoreSigHandlers()
 {
   int sig;
 
-  JTRACE("restoring signal handlers");
+  JLOG(DMTCP)("restoring signal handlers");
   for (sig = SIGRTMAX; sig > 0; --sig) {
 #ifdef VERBOSE_DEBUG
-    JTRACE("restore signal handler for") (sig);
+    JLOG(DMTCP)("restore signal handler for") (sig);
 #endif // ifdef VERBOSE_DEBUG
 
     JASSERT(_real_syscall(SYS_rt_sigaction, sig, &sigactions[sig], NULL,

--- a/src/syslogwrappers.cpp
+++ b/src/syslogwrappers.cpp
@@ -115,7 +115,7 @@ extern "C" void
 openlog(const char *ident, int option, int facility)
 {
   JASSERT(!_isSuspended);
-  JTRACE("openlog") (ident);
+  JLOG(DMTCP)("openlog") (ident);
   _real_openlog(ident, option, facility);
   _syslogEnabled = true;
 
@@ -131,7 +131,7 @@ extern "C" void
 closelog(void)
 {
   JASSERT(!_isSuspended);
-  JTRACE("closelog");
+  JLOG(DMTCP)("closelog");
   _real_closelog();
   _syslogEnabled = false;
 }

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -69,7 +69,7 @@ restore_term_settings()
      *   warning.  If we try to call tcsetattr in background, we will hang up.
      */
     int foreground = (tcgetpgrp(STDIN_FILENO) == getpgrp());
-    JTRACE("restore terminal attributes, check foreground status first")
+    JLOG(DMTCP)("restore terminal attributes, check foreground status first")
       (foreground);
     if (foreground) {
       if ((!isatty(STDIN_FILENO)
@@ -77,7 +77,7 @@ restore_term_settings()
         JWARNING(false).Text("failed to restore terminal");
       } else {
         struct winsize cur_win;
-        JTRACE("restored terminal");
+        JLOG(DMTCP)("restored terminal");
         ioctl(STDIN_FILENO, TIOCGWINSZ, (char *)&cur_win);
 
         /* ws_row/ws_col was probably not 0/0 prior to checkpoint.  We change

--- a/src/threadsync.cpp
+++ b/src/threadsync.cpp
@@ -140,32 +140,32 @@ ThreadSync::acquireLocks()
    * these locks to prevent future deadlocks due to rank violation.
    */
 
-  JTRACE("waiting for dmtcp_lock():"
+  JLOG(DMTCP)("waiting for dmtcp_lock():"
          " to get synchronized with _runCoordinatorCmd if we use DMTCP API");
   _dmtcp_lock();
 
-  JTRACE("Waiting for lock(&theCkptCanStart)");
+  JLOG(DMTCP)("Waiting for lock(&theCkptCanStart)");
   JASSERT(_real_pthread_mutex_lock(&theCkptCanStart) == 0)(JASSERT_ERRNO);
 
-  JTRACE("Waiting for libdlLock");
+  JLOG(DMTCP)("Waiting for libdlLock");
   JASSERT(_real_pthread_mutex_lock(&libdlLock) == 0) (JASSERT_ERRNO);
 
-  JTRACE("Waiting for threads creation lock");
+  JLOG(DMTCP)("Waiting for threads creation lock");
   JASSERT(_real_pthread_rwlock_wrlock(&_threadCreationLock) == 0)
     (JASSERT_ERRNO);
   _threadCreationLockAcquiredByCkptThread = true;
 
-  JTRACE("Waiting for other threads to exit DMTCP-Wrappers");
+  JLOG(DMTCP)("Waiting for other threads to exit DMTCP-Wrappers");
   JASSERT(_real_pthread_rwlock_wrlock(&_wrapperExecutionLock) == 0)
     (JASSERT_ERRNO);
   _wrapperExecutionLockAcquiredByCkptThread = true;
 
-  JTRACE("Waiting for newly created threads to finish initialization")
+  JLOG(DMTCP)("Waiting for newly created threads to finish initialization")
     (_uninitializedThreadCount);
   waitForThreadsToFinishInitialization();
 
   unsetOkToGrabLock();
-  JTRACE("Done acquiring all locks");
+  JLOG(DMTCP)("Done acquiring all locks");
 }
 
 void
@@ -173,7 +173,7 @@ ThreadSync::releaseLocks()
 {
   JASSERT(WorkerState::currentState() == WorkerState::SUSPENDED);
 
-  JTRACE("Releasing ThreadSync locks");
+  JLOG(DMTCP)("Releasing ThreadSync locks");
   JASSERT(_real_pthread_rwlock_unlock(&_wrapperExecutionLock) == 0)
     (JASSERT_ERRNO);
   _wrapperExecutionLockAcquiredByCkptThread = false;
@@ -600,7 +600,7 @@ ThreadSync::waitForThreadsToFinishInitialization()
 {
   while (_uninitializedThreadCount != 0) {
     struct timespec sleepTime = { 0, 10 * 1000 * 1000 };
-    JTRACE("sleeping")(sleepTime.tv_nsec);
+    JLOG(DMTCP)("sleeping")(sleepTime.tv_nsec);
     nanosleep(&sleepTime, NULL);
   }
 }
@@ -615,7 +615,7 @@ ThreadSync::incrementUninitializedThreadCount()
       (JASSERT_ERRNO);
     _uninitializedThreadCount++;
 
-    // JTRACE(":") (_uninitializedThreadCount);
+    // JLOG(DMTCP)(":") (_uninitializedThreadCount);
     JASSERT(_real_pthread_mutex_unlock(&uninitializedThreadCountLock) == 0)
       (JASSERT_ERRNO);
   }
@@ -633,7 +633,7 @@ ThreadSync::decrementUninitializedThreadCount()
     JASSERT(_uninitializedThreadCount > 0) (_uninitializedThreadCount);
     _uninitializedThreadCount--;
 
-    // JTRACE(":") (_uninitializedThreadCount);
+    // JLOG(DMTCP)(":") (_uninitializedThreadCount);
     JASSERT(_real_pthread_mutex_unlock(&uninitializedThreadCountLock) == 0)
       (JASSERT_ERRNO);
   }

--- a/src/threadsync.h
+++ b/src/threadsync.h
@@ -24,16 +24,16 @@
 
 
 #define WRAPPER_EXECUTION_DISABLE_CKPT()           \
-  /*JTRACE("Acquiring wrapperExecutionLock");*/    \
+  /*JLOG(DMTCP)("Acquiring wrapperExecutionLock");*/    \
   bool __wrapperExecutionLockAcquired =            \
     dmtcp::ThreadSync::wrapperExecutionLockLock(); \
   if (__wrapperExecutionLockAcquired) {            \
-    /*JTRACE("Acquired wrapperExecutionLock"); */  \
+    /*JLOG(DMTCP)("Acquired wrapperExecutionLock"); */  \
   }
 
 #define WRAPPER_EXECUTION_ENABLE_CKPT()              \
   if (__wrapperExecutionLockAcquired) {              \
-    /*JTRACE("Releasing wrapperExecutionLock"); */   \
+    /*JLOG(DMTCP)("Releasing wrapperExecutionLock"); */   \
     dmtcp::ThreadSync::wrapperExecutionLockUnlock(); \
   }
 

--- a/src/threadwrappers.cpp
+++ b/src/threadwrappers.cpp
@@ -62,7 +62,7 @@ clone_start(void *arg)
    */
   ThreadSync::decrementUninitializedThreadCount();
 
-  JTRACE("Calling user function") (dmtcp_gettid());
+  JLOG(DMTCP)("Calling user function") (dmtcp_gettid());
   int ret = thread->fn(thread->arg);
 
   ThreadList::threadExit();
@@ -117,7 +117,7 @@ __clone(int (*fn)(void *arg),
                           ptid, tls, ctid);
 
   if (tid == -1) {
-    JTRACE("Clone call failed")(JASSERT_ERRNO);
+    JLOG(DMTCP)("Clone call failed")(JASSERT_ERRNO);
     ThreadSync::decrementUninitializedThreadCount();
     ThreadList::threadIsDead(thread);
   }
@@ -163,7 +163,7 @@ pthread_start(void *arg)
 
   ThreadSync::threadFinishedInitialization();
   void *result = (*pthread_fn)(thread_arg);
-  JTRACE("Thread returned") (virtualTid);
+  JLOG(DMTCP)("Thread returned") (virtualTid);
   WRAPPER_EXECUTION_DISABLE_CKPT();
   ThreadList::threadExit();
 

--- a/src/uniquepid.cpp
+++ b/src/uniquepid.cpp
@@ -106,7 +106,7 @@ UniquePid::ThisProcess(bool disableJTrace /*=false*/)
                              ::getpid(),
                              nsecs);
     if (disableJTrace == false) {
-      JTRACE("recalculated process UniquePid...") (theProcess());
+      JLOG(DMTCP)("recalculated process UniquePid...") (theProcess());
     }
   }
 
@@ -205,7 +205,7 @@ UniquePid::resetOnFork(const UniquePid &newId)
 {
   // parentProcess() is for inspection tools
   parentProcess() = ThisProcess();
-  JTRACE("Explicitly setting process UniquePid") (newId);
+  JLOG(DMTCP)("Explicitly setting process UniquePid") (newId);
   theProcess() = newId;
 }
 
@@ -218,7 +218,7 @@ UniquePid::isNull() const
 void
 UniquePid::serialize(jalib::JBinarySerializer &o)
 {
-  // NOTE: Do not put JTRACE/JNOTE/JASSERT in here
+  // NOTE: Do not put JLOG(DMTCP)/JNOTE/JASSERT in here
   UniquePid theCurrentProcess, theParentProcess;
 
   if (o.isWriter()) {

--- a/src/util_exec.cpp
+++ b/src/util_exec.cpp
@@ -542,7 +542,7 @@ Util::runMtcpRestore(int is32bitElf,
     buf,
     NULL
   };
-  JTRACE("launching mtcp_restart --fd")(fd)(path);
+  JLOG(DMTCP)("launching mtcp_restart --fd")(fd)(path);
 
   // Create the placeholder for "MTCP_OLDPERS" environment.
   // setenv("MTCP_OLDPERS_DUMMY", "XXXXXXXXXXXXXXXX", 1);
@@ -586,7 +586,7 @@ Util::runMtcpRestore(int is32bitElf,
     newEnv[dummyEnvironIndex] = dummyEnviron;
   }
 
-  JTRACE("Args/Env Sizes")
+  JLOG(DMTCP)("Args/Env Sizes")
     (newArgsSize) (newEnvSize) (argvSize) (envSize) (argvSizeDiff);
 
   execve(newArgs[0], newArgs, newEnv);
@@ -608,7 +608,7 @@ Util::adjustRlimitStack()
     if (!(oldPersonality & ADDR_COMPAT_LAYOUT)) {
       // Force ADDR_COMPAT_LAYOUT for libs in high mem, to avoid vdso conflict
       personality(oldPersonality & ADDR_COMPAT_LAYOUT);
-      JTRACE("setting ADDR_COMPAT_LAYOUT");
+      JLOG(DMTCP)("setting ADDR_COMPAT_LAYOUT");
       setenv("DMTCP_ADDR_COMPAT_LAYOUT", "temporarily is set", 1);
     }
   }
@@ -618,7 +618,7 @@ Util::adjustRlimitStack()
     if (rlim.rlim_cur != RLIM_INFINITY) {
       char buf[100];
       sprintf(buf, "%lu", rlim.rlim_cur); // "%llu" for BSD/Mac OS
-      JTRACE("setting rlim_cur for RLIMIT_STACK") (rlim.rlim_cur);
+      JLOG(DMTCP)("setting rlim_cur for RLIMIT_STACK") (rlim.rlim_cur);
       setenv("DMTCP_RLIMIT_STACK", buf, 1);
 
       // Force kernel's internal compat_va_layout to 0; Force libs to high mem.

--- a/src/util_misc.cpp
+++ b/src/util_misc.cpp
@@ -781,3 +781,33 @@ Util::allowGdbDebug(int currentDebugLevel)
     }
   }
 }
+
+
+#define STRINGIFY_ENUM(x)   #x
+
+#define IF_START(x, a, b) \
+  if (strcmp(a, STRINGIFY_ENUM(x)) == 0) { \
+    b |= jassert_internal::x;
+
+#define STRCMP(x, a, b) \
+  } else if (strcmp(a, STRINGIFY_ENUM(x)) == 0) { \
+    b |= jassert_internal::x;
+
+#define IF_END(x, a, b) \
+  } else { \
+    b |= jassert_internal::x; \
+  }
+
+uint32_t
+Util::processDebugLogsArg(char *logString)
+{
+  char *logSrc = strtok(logString, ",");
+  uint32_t mask = jassert_internal::JTRACE;
+  while (logSrc) {
+    IF_START(UNKNOWN, logSrc, mask)
+    FOREACH_LOGSOURCE(STRCMP, logSrc, mask)
+    IF_END(UNKNOWN, logSrc, mask)
+    logSrc = strtok(NULL, ",");
+  }
+  return mask;
+}


### PR DESCRIPTION
This PR adds a new option: `--debug-logs` to `dmtcp_launch` ,
`dmtcp_command`, and `dmtcp_restart`. Using this option a user can specify
a comma-separated list of plugins. For the plugins that are specified,
debug logs will be displayed. Note the logs can be enabled independently
at checkpoint time, or at restart time, or at runtime.