### PR TITLE
delayresume: allow fork()/exec() without dmtcp.

### DIFF
--- a/contrib/delayresume/delayresume.cpp
+++ b/contrib/delayresume/delayresume.cpp
@@ -15,6 +15,17 @@ __thread bool ckptInitiator = false;
 bool canResume = true;
 
 /*
+ * When the plugin is enforced, called by dmtcp core to tell whether
+ * the current thread is between post checkpointing and before resuming.
+ *
+ * See the fork() wrapper in src/execwrappers.cpp
+ */
+EXTERNC bool dmtcp_delay_resume_blocked()
+{
+  return __sync_bool_compare_and_swap(&canResume, false, false);
+}
+
+/*
  * Invoked by the user thread that initiated the checkpoint
  * to acquire the global canResume lock
  *

--- a/include/util.h
+++ b/include/util.h
@@ -77,6 +77,7 @@ EXTERNC int dmtcp_modify_env_enabled(void) __attribute__((weak));
 EXTERNC int dmtcp_ptrace_enabled(void) __attribute__((weak));
 EXTERNC int dmtcp_unique_ckpt_enabled(void) __attribute__((weak));
 EXTERNC int dmtcp_pathvirt_enabled(void) __attribute__((weak));
+EXTERNC bool dmtcp_delay_resume_blocked(void) __attribute__((weak));
 
 
 /*

--- a/src/execwrappers.cpp
+++ b/src/execwrappers.cpp
@@ -161,7 +161,12 @@ LIB_PRIVATE void pthread_atfork_child()
 
 extern "C" pid_t fork()
 {
-  if (isPerformingCkptRestart()) {
+  if (isPerformingCkptRestart() ||
+      /*
+       * We don't want any user program between post checkpointing and before
+       * resuming to run under dmtcp
+       */
+      (dmtcp_delay_resume_blocked != NULL && dmtcp_delay_resume_blocked())) {
     return _real_syscall(SYS_fork);
   }
 


### PR DESCRIPTION
When user wants to do fork()/exec() between block checkpointing
and unblock resuming, user's program should not run under dmtcp.