### PR TITLE
Remove code that attempts to set stack max to 256 MB at restart

### DIFF
--- a/src/mtcp/mtcp_check_vdso.ic
+++ b/src/mtcp/mtcp_check_vdso.ic
@@ -305,7 +305,6 @@ void mtcp_check_vdso(char **environ)
       int i = mtcp_sys_readlink("/proc/self/exe", runtime, PATH_MAX);
       if ( i != -1)
       { char *argv[MAX_ARGS+1];
-        struct rlimit rlim;
 
         /* "make" has the capability to raise RLIMIT_STACK to infinity.
          * This is a problem.  When the kernel (2.6.24 or later) detects this,
@@ -318,34 +317,6 @@ void mtcp_check_vdso(char **environ)
          *  pthread_create to be ARCH_STACK_DEFAULT_SIZE if rlimit is set to be
          *  unlimited. We follow the same default.
          */
-//#ifdef __x86_64__
-//# define ARCH_STACK_DEFAULT_SIZE (32 * 1024 * 1024)
-//#else
-//# define ARCH_STACK_DEFAULT_SIZE (2 * 1024 * 1024)
-//#endif
-        /*
-         * XXX: TODO: Due to some reason, manual restart of checkpointed
-         *  processes fails if ARCH_STACK_DEFAULT_SIZE is less than 256MB. It
-         *  has to do with VDSO. The location of VDSO section conflicts with the
-         *  location of process libraries and hence it is unmapped which causes
-         *  failure during the restarting phase. If we set the stack limit to
-         *  256 MB or higher, we do not see this bug.
-         * It should also be noted that the process will later call setrlimit
-         *  to set the resource limits to their pre-checkpoint values.
-         */
-#define ARCH_STACK_DEFAULT_SIZE (256 * 1024 * 1024)
-
-        int rlimit_failed = 0;
-        if ( -1 == mtcp_sys_getrlimit(RLIMIT_STACK, &rlim) ||
-             ( rlim.rlim_cur = rlim.rlim_max = ARCH_STACK_DEFAULT_SIZE,
-               rlimit_failed |= mtcp_sys_setrlimit(RLIMIT_STACK, &rlim),
-               rlimit_failed |= mtcp_sys_getrlimit(RLIMIT_STACK, &rlim),
-               rlimit_failed || rlim.rlim_max == RLIM_INFINITY )
-           ) {
-          MTCP_PRINTF("Failed to reduce RLIMIT_STACK to %d\n",
-                      ARCH_STACK_DEFAULT_SIZE);
-          mtcp_sys_exit(1);
-        }
         write_args(argv, "/proc/self/cmdline");
         runtime[i] = '\0';
         setenv_oldpers(oldpers, environ);


### PR DESCRIPTION
dmtcp restart code attempts to increase the stack limit max to the ARCH_MAX ie, 256 MB. This fails to succeed when dmtcp is run under PBS (mom). PBS sets the stack max to whatever the system ulimit max was at startup (ie, value of ulimit -s). If the ulimit -s was unlimited, then pbs_mom leaves it as unlimited and that is the only case when dmtcp restart code works (since it is then able to increase the stack max to 256 MB).

The code block where dmtcp attempts to set the stack max could be removed. It could simply inherit whatever the current max limits are from the environment. Attempting to set the stack max does not make much sense anyway, since if it was limited by the parent (to lower than 256 MB), the call will ALWAYS fail. And if it was not limited then its already large and dmtcp would just work.

This fixes the issue #453