### PR TITLE
C++: string host = NULL fails on 32-bit DMTCP

### DIFF
--- a/src/util_init.cpp
+++ b/src/util_init.cpp
@@ -91,7 +91,7 @@ void Util::getCoordHostAndPort(CoordinatorMode mode,
 }
 void Util::setCoordPort(int port)
 {
-  string host = NULL;
+  string host = "";
   // mode will be ignored, since this is not the first time we call this.
   Util::getCoordHostAndPort(COORD_ANY, host, &port);
 }


### PR DESCRIPTION
This is a fix for df0fe3ff30109f16fa6e33915efab196f065b9c0 :
  "fixup! Fix misc. issues pointed out by static analysis"
In changing a C string to a C++ string, code was created: `string host = NULL`.
This errors out when DMTCP is configured as --enable-m32.  It should be: `string host = ""`.