### PR TITLE
dmtcp_coordinator: Fix a segfault when getaddrinfo() fails

### DIFF
--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -1195,7 +1195,7 @@ calcLocalAddr()
   char hostname[HOST_NAME_MAX];
 
   JASSERT(gethostname(hostname, sizeof hostname) == 0) (JASSERT_ERRNO);
-  struct addrinfo *result;
+  struct addrinfo *result = NULL;
   struct addrinfo *res;
   int error;
   struct addrinfo hints;
@@ -1250,7 +1250,9 @@ calcLocalAddr()
     inet_aton("127.0.0.1", &localhostIPAddr);
   }
   coordHostname = hostname;
-  freeaddrinfo(result);
+  if (result) {
+    freeaddrinfo(result);
+  }
 }
 
 static void


### PR DESCRIPTION
The fourth argument to `getaddrinfo()`, `results`, is a linked-list that
is allocated when a call to `getaddrinfo()` succeeds. However, when the
call to the function fails, the linked-list remains unallocated and any
attempts to free the linked-list (using `freeaddrinfo()`) can result in
a segmentation fault. The patch ensures that the results linked-list is
freed up only after a successful allocation.