### PR TITLE
VDSO fix for i386.

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -777,7 +777,14 @@ static void unmap_memory_areas_and_restore_vdso(RestoreInfo *rinfo)
       mtcp_abort();
     }
     MTCP_ASSERT(vvar == vvarStart);
-    mtcp_memcpy(vvarStart, rinfo->vvarStart, vvarEnd - vvarStart);
+    // On i386, only the first page is readable. Reading beyond that
+    // results in a bus error.
+    // Arguably, this is a bug in the kernel, since /proc/*/maps indicates
+    // that both pages of vvar memory have read permission.
+    // This issue arose due to a change in the Linux kernel pproximately in
+    // version 4.0
+    // TODO: Find a way to automatically detect the readable bytes.
+    mtcp_memcpy(vvarStart, rinfo->vvarStart, MTCP_PAGE_SIZE);
 #endif
   }
 }


### PR DESCRIPTION
Apparently, the second vvar page is not readable and so a memcpy()
results in a BUS error. This commit tries to hack through it by ignoring
the second vvar page.

This is a port of PR #469 from master to the 2.5 branch.