### PR TITLE
Avoid recursive call to shmdt() wrapper (for master: 3.0)

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -76,6 +76,7 @@ EXTERNC int dmtcp_batch_queue_enabled(void) __attribute__((weak));
 EXTERNC int dmtcp_modify_env_enabled(void) __attribute__((weak));
 EXTERNC int dmtcp_ptrace_enabled(void) __attribute__((weak));
 EXTERNC int dmtcp_unique_ckpt_enabled(void) __attribute__((weak));
+EXTERNC bool dmtcp_svipc_inside_shmdt(void) __attribute__((weak));
 
 
 /*

--- a/src/miscwrappers.cpp
+++ b/src/miscwrappers.cpp
@@ -28,6 +28,7 @@
 #include "protectedfds.h"
 #include "syscallwrappers.h"
 #include "threadsync.h"
+#include "util.h"
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 13) && __GLIBC_PREREQ(2, 4)
 #include <sys/inotify.h>
@@ -552,7 +553,12 @@ syscall(long sys_num, ...)
   case SYS_shmdt:
   {
     SYSCALL_GET_ARG(const void *, shmaddr);
-    ret = shmdt(shmaddr);
+    if (dmtcp_svipc_inside_shmdt != NULL &&
+        dmtcp_svipc_inside_shmdt()) {
+      ret = _real_syscall(SYS_shmdt, shmaddr);
+    } else {
+      ret = shmdt(shmaddr);
+    }
     break;
   }
   case SYS_shmctl:

--- a/src/plugin/pid/pid_miscwrappers.cpp
+++ b/src/plugin/pid/pid_miscwrappers.cpp
@@ -468,7 +468,12 @@ syscall(long sys_num, ...)
   case SYS_shmdt:
   {
     SYSCALL_GET_ARG(const void *, shmaddr);
-    ret = shmdt(shmaddr);
+    if (dmtcp_svipc_inside_shmdt != NULL &&
+        dmtcp_svipc_inside_shmdt()) {
+      ret = _real_syscall(SYS_shmdt, shmaddr);
+    } else {
+      ret = shmdt(shmaddr);
+    }
     break;
   }
   case SYS_shmctl:

--- a/src/plugin/svipc/sysvipcwrappers.cpp
+++ b/src/plugin/svipc/sysvipcwrappers.cpp
@@ -39,6 +39,21 @@ using namespace dmtcp;
 
 static struct timespec ts_100ms = { 0, 100 * 1000 * 1000 };
 
+/*
+ * In Open MPI 2.0, shmdt() is intercepted by modifying libraries' global offset
+ * table, meaning that _real_shmdt() will be redirected into OpenMPI's hook
+ * function, instead of libc's shmdt(). The hook function finally calls syscall()
+ * with the corresponding syscall number. The inside_shmdt variable indicates
+ * if the code is inside our shmdt() wrapper. If so, our syscall wrapper simply
+ * calls _real_syscall(), avoiding the recursive call to the shmdt() wrapper.
+ * See the wrapper of syscall() in miscwrappers.cpp and pid_miscwrappers.cpp.
+ *
+ * FIXME: for the long term, we need to think about the case where user code
+ * modifies its own global offset table.
+ *
+ * */
+static __thread bool inside_shmdt = false;
+
 /******************************************************************************
  *
  * SysV Shm Methods
@@ -115,16 +130,24 @@ void *shmat(int shmid, const void *shmaddr, int shmflg)
   return ret;
 }
 
+EXTERNC bool
+dmtcp_svipc_inside_shmdt()
+{
+  return inside_shmdt;
+}
+
 extern "C"
 int
 shmdt(const void *shmaddr)
 {
   DMTCP_PLUGIN_DISABLE_CKPT();
+  inside_shmdt = true;
   int ret = _real_shmdt(shmaddr);
   if (ret != -1) {
     SysVShm::instance().on_shmdt(shmaddr);
     JTRACE("Unmapping Shared memory segment") (shmaddr);
   }
+  inside_shmdt = false;
   DMTCP_PLUGIN_ENABLE_CKPT();
   return ret;
 }


### PR DESCRIPTION
Duplicate of #472 