### PR TITLE
Remove DLSYM_DEFAULT/DLSYM_DEFAULT_DEBUG; not used

### DIFF
--- a/include/dmtcp_dlsym.h
+++ b/include/dmtcp_dlsym.h
@@ -34,16 +34,6 @@
 # undef __USE_GNU
 #endif
 
-// #define DLSYM_DEFAULT_DO_DEBUG
-
-#ifdef DLSYM_DEFAULT_DO_DEBUG
-# define DLSYM_DEFAULT_DEBUG(handle,symbol,info) \
-    JNOTE("dmtcp_dlsym (RTLD_NEXT==-1l)")(symbol)(handle) \
-         (info.dli_fname)(info.dli_saddr)
-#else
-# define DLSYM_DEFAULT_DEBUG(handle,symbol,info)
-#endif
-
 EXTERNC void *dmtcp_dlsym(void *handle, const char *symbol);
 EXTERNC void *dmtcp_dlvsym(void *handle, char *symbol, const char *version);
 

--- a/src/plugin/pid/pid.h
+++ b/src/plugin/pid/pid.h
@@ -1,5 +1,5 @@
 #include "dmtcp.h"
 
-// Defines DLSYM_DEFAULT and NEXT_FNC_DEFAULT
+// Defines NEXT_FNC_DEFAULT
 // Needed to handle GNU symbol versioning.
 #include "dmtcp_dlsym.h"


### PR DESCRIPTION
These are stray C constants that were not removed as part of PR #456 (and related PRs for 2.4 and 3.0 branches).  These constants are no longer used.

(n the case of the 2.4 branch, this should be pushed in only after PR #494 is pushed in.  This is the port of PR #456 to 2.4.7.)