### PR TITLE
Remove DLSYM_DEFAULT/DLSYM_DEFAULT_DEBUG; not used (for 3.0/master)

### DIFF
--- a/include/dmtcp_dlsym.h
+++ b/include/dmtcp_dlsym.h
@@ -34,16 +34,6 @@
 # undef __USE_GNU
 #endif // ifdef __USE_GNU_NOT_SET
 
-// #define DLSYM_DEFAULT_DO_DEBUG
-
-#ifdef DLSYM_DEFAULT_DO_DEBUG
-# define DLSYM_DEFAULT_DEBUG(handle, symbol, info)        \
-  JNOTE("dmtcp_dlsym (RTLD_NEXT==-1l)")(symbol)(handle) \
-  (info.dli_fname)(info.dli_saddr)
-#else // ifdef DLSYM_DEFAULT_DO_DEBUG
-# define DLSYM_DEFAULT_DEBUG(handle, symbol, info)
-#endif // ifdef DLSYM_DEFAULT_DO_DEBUG
-
 EXTERNC void *dmtcp_dlsym(void *handle, const char *symbol);
 EXTERNC void *dmtcp_dlvsym(void *handle, char *symbol, const char *version);
 

--- a/src/plugin/pid/pid.h
+++ b/src/plugin/pid/pid.h
@@ -1,5 +1,5 @@
 #include "dmtcp.h"
 
-// Defines DLSYM_DEFAULT and NEXT_FNC_DEFAULT
+// Defines NEXT_FNC_DEFAULT
 // Needed to handle GNU symbol versioning.
 #include "dmtcp_dlsym.h"


### PR DESCRIPTION
This is a copy of PR #493 for the 3.0/master branch.