### PR TITLE
fixup! C++: string host = NULL fails on 32-bit DMTCP

### DIFF
--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -165,7 +165,7 @@ void CoordinatorAPI::resetOnFork(CoordinatorAPI& coordAPI)
 void CoordinatorAPI::setupVirtualCoordinator(CoordinatorInfo *coordInfo,
                                              struct in_addr  *localIP)
 {
-  string host = NULL;
+  string host = "";
   int port = UNINITIALIZED_PORT;
   Util::getCoordHostAndPort(COORD_NONE, host, &port);
   _coordinatorSocket = jalib::JServerSocket(jalib::JSockAddr::ANY, port);


### PR DESCRIPTION
Apparently, we had missed this one. This only affects us when running with the `--no-coordinator` flag.