### PR TITLE
Enhance --enable-timing

### DIFF
--- a/jalib/jtimer.cpp
+++ b/jalib/jtimer.cpp
@@ -42,9 +42,10 @@ jalib::operator-(const jalib::JTime &a, const jalib::JTime &b)
   return sec;
 }
 
-jalib::JTimeRecorder::JTimeRecorder(const jalib::string &name)
+jalib::JTimeRecorder::JTimeRecorder(const jalib::string &name, bool printToFile)
   : _name(name)
   , _isStarted(false)
+  , _printToFile(printToFile)
 {}
 
 namespace

--- a/src/barrierinfo.h
+++ b/src/barrierinfo.h
@@ -22,6 +22,7 @@
 #ifndef __BARRIERINFO_H__
 #define __BARRIERINFO_H__
 
+#include "config.h"
 #include "dmtcp.h"
 #include "dmtcpalloc.h"
 
@@ -76,6 +77,10 @@ class BarrierInfo
     void (*callback)();
     const string id;
     const string pluginName;
+#ifdef TIMING
+    double execTime;
+    double cbExecTime;
+#endif
 };
 
 static inline ostream&

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -559,14 +559,14 @@ DmtcpWorker::postCheckpoint()
 }
 
 void
-DmtcpWorker::postRestart()
+DmtcpWorker::postRestart(double ckptReadTime)
 {
   JTRACE("begin postRestart()");
   WorkerState::setCurrentState(WorkerState::RESTARTING);
 
   PluginManager::processRestartBarriers();
 #ifdef TIMING
-  PluginManager::logRestartBarrierOverhead();
+  PluginManager::logRestartBarrierOverhead(ckptReadTime);
 #endif
   JTRACE("got resume message after restart");
 

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -549,6 +549,9 @@ DmtcpWorker::postCheckpoint()
   }
 
   PluginManager::processResumeBarriers();
+#ifdef TIMING
+  PluginManager::logCkptResumeBarrierOverhead();
+#endif
 
   // Inform Coordinator of RUNNING state.
   WorkerState::setCurrentState(WorkerState::RUNNING);
@@ -562,6 +565,9 @@ DmtcpWorker::postRestart()
   WorkerState::setCurrentState(WorkerState::RESTARTING);
 
   PluginManager::processRestartBarriers();
+#ifdef TIMING
+  PluginManager::logRestartBarrierOverhead();
+#endif
   JTRACE("got resume message after restart");
 
   // Inform Coordinator of RUNNING state.

--- a/src/dmtcpworker.h
+++ b/src/dmtcpworker.h
@@ -51,7 +51,7 @@ class DmtcpWorker
     static void waitForCheckpointRequest();
     static void preCheckpoint();
     static void postCheckpoint();
-    static void postRestart();
+    static void postRestart(double ckptReadTime = 0.0);
 
     static void resetOnFork();
     static void cleanupWorker();

--- a/src/mtcp/mtcp_header.h
+++ b/src/mtcp/mtcp_header.h
@@ -49,7 +49,7 @@ typedef union _MtcpHeader {
     void *vdsoEnd;
     void *vvarStart;
     void *vvarEnd;
-    void (*post_restart)();
+    void (*post_restart)(double);
     ThreadTLSInfo motherofall_tls_info;
     int tls_pid_offset;
     int tls_tid_offset;

--- a/src/plugininfo.cpp
+++ b/src/plugininfo.cpp
@@ -21,7 +21,9 @@
 
 #include "plugininfo.h"
 #include "jassert.h"
+#include "jtimer.h"
 #include "barrierinfo.h"
+#include "config.h"
 #include "coordinatorapi.h"
 #include "dmtcp.h"
 #include "shareddata.h"
@@ -112,6 +114,9 @@ PluginInfo::processBarriers()
 void
 PluginInfo::processBarrier(BarrierInfo *barrier)
 {
+  JTIMER_NOPRINT(barrier);
+
+  JTIMER_START(barrier);
   if (dmtcp_no_coordinator()) {
     // Do nothing.
   } else if (barrier->isGlobal()) {
@@ -123,6 +128,15 @@ PluginInfo::processBarrier(BarrierInfo *barrier)
   }
 
   JTRACE("Barrier released") (barrier->toString());
+
+  JTIMER_STOP(barrier);
+  JTIMER_GETDELTA(barrier->execTime, barrier);
+
+  JTIMER_START(barrier);
+
   barrier->callback();
+
+  JTIMER_STOP(barrier);
+  JTIMER_GETDELTA(barrier->cbExecTime, barrier);
 }
 }

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -183,12 +183,13 @@ PluginManager::logCkptResumeBarrierOverhead()
 }
 
 void
-PluginManager::logRestartBarrierOverhead()
+PluginManager::logRestartBarrierOverhead(double ckptReadTime)
 {
   char logFilename[5000] = {0};
   snprintf(logFilename, sizeof(logFilename), "%s/timings.%s.csv",
            dmtcp_get_ckpt_dir(), dmtcp_get_uniquepid_str());
   std::ofstream lfile (logFilename, std::ios::out | std::ios::app);
+  lfile << "Ckpt-read time," << ckptReadTime << std::endl;
   for (int i = pluginManager->pluginInfos.size() - 1; i >= 0; i--) {
     for (int j = 0;
          j < pluginManager->pluginInfos[i]->restartBarriers.size(); j++) {

--- a/src/pluginmanager.h
+++ b/src/pluginmanager.h
@@ -51,7 +51,7 @@ class PluginManager
     static void eventHook(DmtcpEvent_t event, DmtcpEventData_t *data);
 #ifdef TIMING
     static void logCkptResumeBarrierOverhead();
-    static void logRestartBarrierOverhead();
+    static void logRestartBarrierOverhead(double ckptReadTime);
 #endif
 
   private:

--- a/src/pluginmanager.h
+++ b/src/pluginmanager.h
@@ -49,6 +49,10 @@ class PluginManager
     static void processResumeBarriers();
     static void processRestartBarriers();
     static void eventHook(DmtcpEvent_t event, DmtcpEventData_t *data);
+#ifdef TIMING
+    static void logCkptResumeBarrierOverhead();
+    static void logRestartBarrierOverhead();
+#endif
 
   private:
     void initializePlugins();

--- a/src/threadinfo.h
+++ b/src/threadinfo.h
@@ -88,6 +88,12 @@ struct Thread {
   ucontext_t savctx;     // context saved on suspend
 #endif // ifdef SETJMP
 
+  /* This field is used by the ckpt thread to store and print the time
+   * mtcp_restart took to read and map memory regions from the ckpt
+   * image. This is only used when configured with --enable-timing.
+   */
+  double ckptReadTime;
+
   Thread *next;
   Thread *prev;
 };

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -653,7 +653,9 @@ ThreadList::waitForAllRestored(Thread *thread)
     }
 
     JTRACE("before DmtcpWorker::postRestart()");
-    DmtcpWorker::postRestart(); // mtcp_restoreargv_start_addr);
+
+    DmtcpWorker::postRestart(thread->ckptReadTime);
+
     JTRACE("after DmtcpWorker::postRestart()");
 
     SigInfo::restoreSigHandlers();
@@ -684,7 +686,7 @@ ThreadList::waitForAllRestored(Thread *thread)
  *
  *****************************************************************************/
 void
-ThreadList::postRestart(void)
+ThreadList::postRestart(double readTime)
 {
   Thread *thread;
   sigset_t tmp;
@@ -738,6 +740,7 @@ ThreadList::postRestart(void)
       mtcpRestartThreadArg.virtualTid = thread->virtual_tid;
       clonearg = &mtcpRestartThreadArg;
     }
+    thread->ckptReadTime = readTime;
 
     /* Create the thread so it can finish restoring itself. */
     pid_t tid = _real_clone(restarthread,

--- a/src/threadlist.h
+++ b/src/threadlist.h
@@ -52,7 +52,7 @@ void suspendThreads();
 void resumeThreads();
 void waitForAllRestored(Thread *thisthread);
 void writeCkpt();
-void postRestart();
+void postRestart(double readTime = 0.0);
 }
 }
 #endif // ifndef THREADLIST_H


### PR DESCRIPTION
This patch allows DMTCP to dump additional information about barrier overhead, ckpt read and write times when configured with the `--enable-timing` flag. Each process of the computation writes out this information in a separate `timings.*.csv` file.