### PR TITLE
DMTCP_RESTART_PAUSE: Fixing bug in commit 7ecf5f4a

### DIFF
--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -691,8 +691,6 @@ ThreadList::postRestart(double readTime)
   Thread *thread;
   sigset_t tmp;
 
-  SharedData::postRestart();
-
   /* If DMTCP_RESTART_PAUSE set, sleep 15 seconds and allow gdb attach. */
   if (getenv("MTCP_RESTART_PAUSE") || getenv("DMTCP_RESTART_PAUSE")) {
 #ifdef HAS_PR_SET_PTRACER
@@ -706,6 +704,8 @@ ThreadList::postRestart(double readTime)
     prctl(PR_SET_PTRACER, 0, 0, 0, 0);   // Revert permission to default.
 #endif // ifdef HAS_PR_SET_PTRACER
   }
+
+  SharedData::postRestart();
 
   /* Fill in the new mother process id */
   motherpid = THREAD_REAL_TID();


### PR DESCRIPTION
* DMTCP_RESTART_PAUSE was designed to stop for debugging as soon as we entered libdmtcp from mtcp_restart.
* In commit 7ecf5f4a, it was mistakenly decided to handle all postRestart events of all plugins before allowing the user to debug.