### PR TITLE
DMTCP_RESTART_PAUSE=[1234] (for version 3.0)

### DIFF
--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -488,13 +488,19 @@ runMtcpRestart(int is32bitElf, int fd, ProcessInfo *pInfo)
     }
   }
 
-  /* If DMTCP_RESTART_PAUSE0 set, mtcp_restart will loop until gdb attach.*/
+  /* If DMTCP_RESTART_PAUSE==1, mtcp_restart will loop until gdb attach.*/
   bool mtcp_restart_pause = false;
-  if (getenv("MTCP_RESTART_PAUSE0") || getenv("DMTCP_RESTART_PAUSE0")) {
+  char * pause_param = getenv("DMTCP_RESTART_PAUSE");
+  if (pause_param == NULL) {
+    pause_param = getenv("MTCP_RESTART_PAUSE");
+  }
+  if (pause_param != NULL && pause_param[0] == '1' && pause_param[1] == '\0') {
 #ifdef HAS_PR_SET_PTRACER
     prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0); // For: gdb attach
 #endif // ifdef HAS_PR_SET_PTRACER
     mtcp_restart_pause = true;
+    // If mtcp_restart_pause == true, mtcp_restart will invoke
+    //     postRestartDebug() in the checkpoint image instead of postRestart().
   }
 
   char *const newArgs[] = {

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -488,10 +488,21 @@ runMtcpRestart(int is32bitElf, int fd, ProcessInfo *pInfo)
     }
   }
 
+  /* If DMTCP_RESTART_PAUSE0 set, mtcp_restart will loop until gdb attach.*/
+  bool mtcp_restart_pause = false;
+  if (getenv("MTCP_RESTART_PAUSE0") || getenv("DMTCP_RESTART_PAUSE0")) {
+#ifdef HAS_PR_SET_PTRACER
+    prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0); // For: gdb attach
+#endif // ifdef HAS_PR_SET_PTRACER
+    mtcp_restart_pause = true;
+  }
+
   char *const newArgs[] = {
     (char *)mtcprestart.c_str(),
     const_cast<char *>("--fd"), fdBuf,
     const_cast<char *>("--stderr-fd"), stderrFdBuf,
+    // This flag must be last, since it may become NULL
+    ( mtcp_restart_pause ? const_cast<char *>("--mtcp-restart-pause") : NULL ),
     NULL
   };
 

--- a/src/mtcp/mtcp_header.h
+++ b/src/mtcp/mtcp_header.h
@@ -50,6 +50,7 @@ typedef union _MtcpHeader {
     void *vvarStart;
     void *vvarEnd;
     void (*post_restart)(double);
+    void (*post_restart_debug)(double);
     ThreadTLSInfo motherofall_tls_info;
     int tls_pid_offset;
     int tls_tid_offset;

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -457,9 +457,9 @@ restart_fast_path()
   // rinfo.restorememoryareas_fptr(&rinfo);
   // Intel icc-13.1.3 output uses register rbp here.  It's no longer available.
   asm volatile(
-   // 96 = offsetof(RestoreInfo, rinfo.restorememoryareas_fptr)
+   // 104 = offsetof(RestoreInfo, rinfo.restorememoryareas_fptr)
    // NOTE: Update the offset when adding fields to the RestoreInfo struct
-   "movq    96+rinfo(%%rip), %%rdx;" /* rinfo.restorememoryareas_fptr */
+   "movq    104+rinfo(%%rip), %%rdx;" /* rinfo.restorememoryareas_fptr */
    "leaq    rinfo(%%rip), %%rdi;"    /* &rinfo */
    "movl    $0, %%eax;"
    "call    *%%rdx"

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -119,20 +119,6 @@ static void
 restart()
 {
   restore_term_settings();
-
-  /* If DMTCP_RESTART_PAUSE2 set, sleep 15 seconds to allow gdb attach.*/
-  if (getenv("MTCP_RESTART_PAUSE2") || getenv("DMTCP_RESTART_PAUSE2")) {
-#ifdef HAS_PR_SET_PTRACER
-    prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0); // For: gdb attach
-#endif // ifdef HAS_PR_SET_PTRACER
-    struct timespec delay = { 15, 0 }; /* 15 seconds */
-    printf("Pausing 15 seconds. Do:  gdb <PROGNAME> %d\n",
-           dmtcp_virtual_to_real_pid(getpid()));
-    nanosleep(&delay, NULL);
-#ifdef HAS_PR_SET_PTRACER
-    prctl(PR_SET_PTRACER, 0, 0, 0, 0); // Revert permission to default.
-#endif // ifdef HAS_PR_SET_PTRACER
-  }
 }
 
 static DmtcpBarrier terminalBarriers[] = {

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -297,6 +297,7 @@ prepareMtcpHeader(MtcpHeader *mtcpHdr)
   mtcpHdr->vvarEnd = (void *)ProcessInfo::instance().vvarEnd();
 
   mtcpHdr->post_restart = &ThreadList::postRestart;
+  mtcpHdr->post_restart_debug = &ThreadList::postRestartDebug;
   memcpy(&mtcpHdr->motherofall_tls_info,
          &motherofall->tlsInfo,
          sizeof(motherofall->tlsInfo));
@@ -691,6 +692,21 @@ ThreadList::waitForAllRestored(Thread *thread)
 /*****************************************************************************
  *
  *****************************************************************************/
+void
+ThreadList::postRestartDebug(double readTime)
+{ // Don't try to print before debugging.  Who knows what is working yet?
+  int dummy = 1;
+#ifndef DEBUG
+  // printf may fail, but we'll risk it to let user know this:
+  printf("\n** DMTCP: It appears DMTCP not configured with '--enable-debug'\n");
+  printf("**        If GDB doesn't show source, re-configure and re-compile\n");
+#endif
+  while (dummy);
+  // User should have done GDB attach if we're here.
+  prctl(PR_SET_PTRACER, 0, 0, 0, 0); // Revert permission to default: no ptracer
+  postRestart();
+}
+
 void
 ThreadList::postRestart(double readTime)
 {

--- a/src/threadlist.h
+++ b/src/threadlist.h
@@ -53,6 +53,7 @@ void resumeThreads();
 void waitForAllRestored(Thread *thisthread);
 void writeCkpt();
 void postRestart(double readTime = 0.0);
+void postRestartDebug(double readTime = 0.0);
 }
 }
 #endif // ifndef THREADLIST_H

--- a/src/util_exec.cpp
+++ b/src/util_exec.cpp
@@ -555,22 +555,20 @@ Util::runMtcpRestore(int is32bitElf,
   // newEnv[2] = NULL; newEnv[3] and newEnv[4] are available so that
   // they can easily be used to modify envp inside mtcp_restart.c:main().
   // for debugging in GDB.  These appear _after_ final NULL  of newEnv[].
-  char *newEnv[7] = { NULL, NULL, NULL,
-                      const_cast<char *>("MTCP_RESTART_PAUSE=1"),
-                      const_cast<char *>("DMTCP_RESTART_PAUSE=1"),
-                      const_cast<char *>("MTCP_RESTART_PAUSE2=1"),
-                      const_cast<char *>("DMTCP_RESTART_PAUSE2=1") };
+  char *newEnv[] = { NULL, NULL, NULL,
+                      const_cast<char *>("MTCP_RESTART_PAUSE=0"),
+                      const_cast<char *>("DMTCP_RESTART_PAUSE=0") };
 
   // Will put ENV_PTR("MTCP_OLDPERS") here.
   newEnv[dummyEnvironIndex] = (char *)dummyEnviron;
   newEnv[pathIndex] = (getenv("PATH") ? ENV_PTR("PATH") : NULL);
 
   size_t newArgsSize = 0;
-  for (int i = 0; newArgs[i] != 0; i++) {
+  for (int i = 0; newArgs[i] != NULL; i++) {
     newArgsSize += strlen(newArgs[i]) + 1;
   }
   size_t newEnvSize = 0;
-  for (int i = 0; newEnv[i] != 0; i++) {
+  for (int i = 0; newEnv[i] != NULL; i++) {
     newEnvSize += strlen(newEnv[i]) + 1;
   }
   size_t originalArgvEnvSize = argvSize + envSize;


### PR DESCRIPTION
__I've tested this and it works now.  Please review.__

* Workflow:
>    env DMTCP_RESTART_PAUSE0=1 dmtcp_restart ckpt_*.dmtcp &
    # This stops in infinite loop in ThreadList::postRestartDebug(),
    #   which will call ThreadList::postRestart()
    # Before the infinite loop, it prints to the user to do:
    gdb PROGRAM_NAME PID
    # Full 'gdb attach' should now be working

NOTES:
* This includes postRestartDebug() as target from mtcp_restart,
  where postRestartDebug() has the infinite loop.
* In commit a8cfd6666, we had removed '-g' as default.  I added a print statement with the `gdb attach` advice that reminds the user to configure DMTCP with `--enable-debug