### PR TITLE
dmtcp_coordinator: Use higher resolution timer for coordTimeStamp

### DIFF
--- a/src/uniquepid.cpp
+++ b/src/uniquepid.cpp
@@ -101,7 +101,7 @@ UniquePid::ThisProcess(bool disableJTrace /*=false*/)
 
   if (theProcess() == nullProcess()) {
     JASSERT(clock_gettime(CLOCK_MONOTONIC, &value) == 0);
-    nsecs = value.tv_sec * 100000000L + value.tv_nsec;
+    nsecs = value.tv_sec * 1000000000L + value.tv_nsec;
     theProcess() = UniquePid(theUniqueHostId(),
                              ::getpid(),
                              nsecs);


### PR DESCRIPTION
An issue was observed where multiple parallel launches/restarts of independent computations on a single node would up using the incorrect shared-data files. The reason was that since a shared-data file's name is generated using the following tuple: _<hostid, virt. pid, coordinator timestamp>_, multiple independent coordinators would end up generating the same values when they were launched in parallel.

The fix is to use a nanosecond resolution timer for generating the coordinator timestamp. Although this doesn't fix the issue entirely, it does reduce the chances of two independently launched computations on a node mapping the same shared-data file. 