### PR TITLE
Reset the coordinator socket on restart.

### DIFF
--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -160,6 +160,16 @@ void CoordinatorAPI::resetOnFork(CoordinatorAPI& coordAPI)
   instance()._nsSock.close();
 }
 
+/* Recompute the protected coordinator fd and reset the coordiantor socket.
+ *
+ * Used to handle the case where protectedFdBase() has changed, for example,
+ * on restart.
+ * */
+void CoordinatorAPI::resetCoordSocketFd()
+{
+  _coordinatorSocket = jalib::JSocket(PROTECTED_COORD_FD);
+}
+
 // FIXME:  Does "virtual coordinator" mean coordinator built into the
 //         the current process (no separate process?)
 void CoordinatorAPI::setupVirtualCoordinator(CoordinatorInfo *coordInfo,

--- a/src/coordinatorapi.h
+++ b/src/coordinatorapi.h
@@ -54,6 +54,7 @@ namespace dmtcp
       static void init();
       static void restart();
       static void resetOnFork(CoordinatorAPI& coordAPI);
+      void resetCoordSocketFd();
 
       void setupVirtualCoordinator(CoordinatorInfo *coordInfo,
                                    struct in_addr  *localIP);

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -684,6 +684,12 @@ void ThreadList::postRestart(void)
   Thread *thread;
   sigset_t tmp;
 
+  /* On restart, if the system has a different limit on open file descriptors,
+   * we need to reset the base protected fd and the coordinator socket.
+   */
+  Util::setProtectedFdBase();
+  CoordinatorAPI::instance().resetCoordSocketFd();
+
   SharedData::postRestart();
 
   /* If DMTCP_RESTART_PAUSE set, sleep 15 seconds and allow gdb attach. */


### PR DESCRIPTION
This solves the issue where on restart there is a larger open file
descriptor limit.