### PR TITLE
The call to exit(1) should call exit(DMTCP_FAIL_RC)

### DIFF
--- a/include/dmtcp.h.in
+++ b/include/dmtcp.h.in
@@ -413,6 +413,15 @@ EXTERNC void dmtcp_plugin_enable_ckpt(void);
 #define dmtcp_get_uniquepid_str() \
   (dmtcp_get_uniquepid_str ? dmtcp_get_uniquepid_str() : NULL)
 
+/* dmtcp_launch, dmtcp_restart return a unique rc (default: 99)
+ * TYPICAL USAGE:  exit(DMTCP_FAIL_RC)
+ * Use this to distinguish DMTCP failing versus the target application failing.
+ */
+#define DMTCP_FAIL_RC                                         \
+  (getenv("DMTCP_FAIL_RC") && atoi(getenv("DMTCP_FAIL_RC"))   \
+     ? atoi(getenv("DMTCP_FAIL_RC"))                          \
+     : 99)
+
 /// Pointer to a "void foo();" function
 typedef void (*dmtcp_fnptr_t)(void);
 #endif // ifndef DMTCP_H

--- a/src/constants.h
+++ b/src/constants.h
@@ -51,12 +51,6 @@
 #define CKPT_FILES_SUBDIR_PREFIX "ckpt_"
 #define CKPT_FILES_SUBDIR_SUFFIX "_files"
 
-/* dmtcp_launch, dmtcp_restart return a unique rc (default: 99) */
-#define DMTCP_FAIL_RC                                         \
-  (getenv("DMTCP_FAIL_RC") && atoi(getenv("DMTCP_FAIL_RC"))   \
-     ? atoi(getenv("DMTCP_FAIL_RC"))                            \
-     : 99)
-
 // Not used
 // #define X11_LISTENER_PORT_START 6000
 

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -456,7 +456,7 @@ runMtcpRestart(int is32bitElf, int fd, ProcessInfo *pInfo)
       }
       char cpid[10]; // XXX: Is 10 digits enough for a PID?
       snprintf(cpid, 10, "%d", pid);
-      char* const command[] = {"gdb",
+      char* const command[] = {const_cast<char*>("gdb"),
                                const_cast<char*>(pInfo->procSelfExe().c_str()),
                                cpid,
                                NULL};

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -71,7 +71,9 @@
 #endif /* ifdef __clang__ */
 
 void mtcp_check_vdso(char **environ);
+#ifdef FAST_RST_VIA_MMAP
 static void mmapfile(int fd, void *buf, size_t size, int prot, int flags);
+#endif
 
 #define BINARY_NAME     "mtcp_restart"
 #define BINARY_NAME_M32 "mtcp_restart-32"
@@ -1336,6 +1338,7 @@ __intel_security_check_cookie(void)
   mtcp_abort();
 }
 
+#ifdef FAST_RST_VIA_MMAP
 static void mmapfile(int fd, void *buf, size_t size, int prot, int flags)
 {
   int mtcp_sys_errno;
@@ -1360,4 +1363,4 @@ static void mmapfile(int fd, void *buf, size_t size, int prot, int flags)
     mtcp_abort();
   }
 }
-
+#endif

--- a/src/plugin/ipc/file/fileconnlist.cpp
+++ b/src/plugin/ipc/file/fileconnlist.cpp
@@ -168,7 +168,7 @@ FileConnList::preCkpt()
         string buf = jalib::Filesystem::BaseName(fileCon->savedFilePath()) +
                      ":" + fileCon->filePath() + "\n";
         JASSERT(Util::writeAll(tmpfd, buf.c_str(),
-                               buf.length()) == buf.length());
+                               buf.length()) == (int)buf.length());
       }
     }
   }

--- a/src/plugin/ipc/ssh/dmtcp_ssh.cpp
+++ b/src/plugin/ipc/ssh/dmtcp_ssh.cpp
@@ -126,8 +126,7 @@ waitForConnection(int listenSock)
 
   if (fd == -1) {
     perror("accept failed:");
-    abort();
-    exit(0);
+    exit(DMTCP_FAIL_RC);
   }
   close(listenSock);
   return fd;
@@ -145,7 +144,7 @@ main(int argc, char *argv[], char *envp[])
 
   if (argc < 2) {
     printf("***ERROR: This program shouldn't be used directly.\n");
-    exit(1);
+    exit(DMTCP_FAIL_RC);
   }
 
   /* command line parsing was assuming the location of arguments

--- a/src/plugin/ipc/ssh/dmtcp_sshd.cpp
+++ b/src/plugin/ipc/ssh/dmtcp_sshd.cpp
@@ -30,19 +30,19 @@ connectToRemotePeer(char *host, int port)
 
   if (sock == -1) {
     perror("Error creating socket: ");
-    exit(0);
+    exit(DMTCP_FAIL_RC);
   }
   memset(&saddr, 0, sizeof(saddr));
   saddr.sin_family = AF_INET;
   if (inet_aton(host, &saddr.sin_addr) == -1) {
     perror("inet_aton failed");
-    exit(0);
+    exit(DMTCP_FAIL_RC);
   }
   saddr.sin_port = htons(port);
 
   if (connect(sock, (sockaddr *)&saddr, sizeof saddr) == -1) {
     perror("Error connecting");
-    exit(0);
+    exit(DMTCP_FAIL_RC);
   }
   remotePeerSock = sock;
 }
@@ -110,7 +110,7 @@ int main(int argc, char *argv[], char *envp[])
 
   if (argc < 2) {
     printf("***ERROR: This program shouldn't be used directly.\n");
-    exit(1);
+    exit(DMTCP_FAIL_RC);
   }
 
   if (strcmp(argv[1], "--listenAddr") == 0) {
@@ -121,13 +121,13 @@ int main(int argc, char *argv[], char *envp[])
 
   if (strcmp(argv[1], "--host") != 0) {
     printf("Missing --host argument");
-    assert(0);
+    exit(DMTCP_FAIL_RC);
   }
   host = argv[2];
 
   if (strcmp(argv[3], "--port") != 0) {
     printf("Missing --port argument");
-    exit(0);
+    exit(DMTCP_FAIL_RC);
   }
   port = atoi(argv[4]);
 

--- a/src/plugin/pid/pidwrappers.cpp
+++ b/src/plugin/pid/pidwrappers.cpp
@@ -52,7 +52,7 @@ getPidFromEnvVar()
     fprintf(stderr, "ERROR at %s:%d: env var DMTCP_VIRTUAL_PID not set\n\n",
             __FILE__, __LINE__);
     sleep(5);
-    _exit(0);
+    _exit(DMTCP_FAIL_RC);
   }
   return strtol(pidstr, NULL, 10);
 }
@@ -71,7 +71,7 @@ dmtcpResetPidPpid()
     fprintf(stderr, "ERROR at %s:%d: env var DMTCP_VIRTUAL_PID not set\n\n",
             __FILE__, __LINE__);
     sleep(5);
-    _exit(0);
+    _exit(DMTCP_FAIL_RC);
   }
   _dmtcp_pid = strtol(pidstr, &virtPpidstr, 10);
   VirtualPidTable::instance().updateMapping(_dmtcp_pid, _real_getpid());
@@ -80,7 +80,7 @@ dmtcpResetPidPpid()
     fprintf(stderr, "ERROR at %s:%d: env var DMTCP_VIRTUAL_PID invalid\n\n",
             __FILE__, __LINE__);
     sleep(5);
-    _exit(0);
+    _exit(DMTCP_FAIL_RC);
   }
   virtPpid = strtol(virtPpidstr + 1, &realPpidstr, 10);
 
@@ -88,7 +88,7 @@ dmtcpResetPidPpid()
     fprintf(stderr, "ERROR at %s:%d: env var DMTCP_VIRTUAL_PID invalid\n\n",
             __FILE__, __LINE__);
     sleep(5);
-    _exit(0);
+    _exit(DMTCP_FAIL_RC);
   }
   realPpid = strtol(realPpidstr + 1, NULL, 10);
 

--- a/src/threadsync.cpp
+++ b/src/threadsync.cpp
@@ -396,7 +396,7 @@ ThreadSync::wrapperExecutionLockLock()
       if (retVal != 0 && retVal != EDEADLK) {
         fprintf(stderr, "ERROR %d at %s:%d %s: Failed to acquire lock\n",
                 errno, __FILE__, __LINE__, __PRETTY_FUNCTION__);
-        _exit(1);
+        _exit(DMTCP_FAIL_RC);
       }
 
       // retVal should always be 0 (success) here.
@@ -462,7 +462,7 @@ ThreadSync::wrapperExecutionLockLockExcl()
     if (retVal != 0 && retVal != EDEADLK) {
       fprintf(stderr, "ERROR %s:%d %s: Failed to acquire lock\n",
               __FILE__, __LINE__, __PRETTY_FUNCTION__);
-      _exit(1);
+      _exit(DMTCP_FAIL_RC);
     }
     lockAcquired = retVal == 0 ? true : false;
     if (!lockAcquired) {
@@ -506,7 +506,7 @@ ThreadSync::wrapperExecutionLockUnlock()
   if (_real_pthread_rwlock_unlock(&_wrapperExecutionLock) != 0) {
     fprintf(stderr, "ERROR %s:%d %s: Failed to release lock\n",
             __FILE__, __LINE__, __PRETTY_FUNCTION__);
-    _exit(1);
+    _exit(DMTCP_FAIL_RC);
   } else {
     decrementWrapperExecutionLockLockCount();
   }
@@ -532,7 +532,7 @@ ThreadSync::threadCreationLockLock()
       if (retVal != 0 && retVal != EDEADLK) {
         fprintf(stderr, "ERROR %s:%d %s: Failed to acquire lock\n",
                 __FILE__, __LINE__, __PRETTY_FUNCTION__);
-        _exit(1);
+        _exit(DMTCP_FAIL_RC);
       }
 
       // retVal should always be 0 (success) here.
@@ -564,12 +564,12 @@ ThreadSync::threadCreationLockUnlock()
             __FILE__,
             __LINE__,
             __PRETTY_FUNCTION__);
-    _exit(1);
+    _exit(DMTCP_FAIL_RC);
   }
   if (_real_pthread_rwlock_unlock(&_threadCreationLock) != 0) {
     fprintf(stderr, "ERROR %s:%d %s: Failed to release lock\n",
             __FILE__, __LINE__, __PRETTY_FUNCTION__);
-    _exit(1);
+    _exit(DMTCP_FAIL_RC);
   } else {
     decrementThreadCreationLockLockCount();
   }


### PR DESCRIPTION
On failure due to DMTCP, use: exit(DMTCP_FAIL_RC)
    
    * There is a tendency to use 'exit(1)'.  But then the end user doesn't
      know whether the target application failed or DMTCP itself failed.

Please check my logic carefully.  There are cases where we really did want `exit(0)`.  Also, where the code says something linke `exit(status)`, I did not attempt to change that.  And for `dmtcp_coordinator`, and `dmtcp_command`, I did not change things since the end user will not be confused by application failure versus DMTCP failure.

====
I added a small second commit, rather than create a separate pull request:

For the second commit to remove compiler warnings, I still have one compiler warning:
> dmtcp_restart.cpp:462:36: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]

I understand the general principle of C++.  `NULL` and `(void *)NULL` and `(char *)NULL` and `const_cast<char *>(NULL)` are all too simple, and C++ requires that the code be made more complex, because complex code will have fewer errors.  :-)   But I'm not sure what version of making it more complicated that C++ has in mind in this case.