### PR TITLE
mtcp_restart: Remove assert introduced in 72df6746

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -638,7 +638,9 @@ restorememoryareas(RestoreInfo *rinfo_ptr)
   if (rinfo_ptr->saved_brk != NULL) {
     // Now, we can do the pending mtcp_sys_brk(rinfo.saved_brk).
     // It's now safe to do this, even though it can munmap memory holding rinfo.
-    MTCP_ASSERT(mtcp_sys_brk(rinfo_ptr->saved_brk) == 0);
+    if (mtcp_sys_brk(rinfo_ptr->saved_brk) != 0) {
+       MTCP_PRINTF("error restoring brk: %d\n", mtcp_sys_errno);
+    }
   }
 
 #if defined(__i386__) || defined(__x86_64__)


### PR DESCRIPTION
The brk call fails on Debian for bash because of alignment conflict
between heap and mtcp_restart.