### PR TITLE
Delay ckpt-thread initialization during fork.

### DIFF
--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -361,7 +361,6 @@ DmtcpWorker::resetOnFork()
 
   // new ( &theInstance ) DmtcpWorker ( false );
 
-  ThreadList::resetOnFork();
   ThreadSync::initMotherOfAll();
 
   DmtcpWorker::_exitInProgress = false;

--- a/src/execwrappers.cpp
+++ b/src/execwrappers.cpp
@@ -41,6 +41,7 @@
 #include "shareddata.h"
 #include "syscallwrappers.h"
 #include "syslogwrappers.h"
+#include "threadlist.h"
 #include "threadsync.h"
 #include "uniquepid.h"
 #include "util.h"
@@ -189,7 +190,18 @@ fork()
   pthread_atfork_enabled = true;
   pid_t childPid = _real_fork();
 
-  if (childPid == -1) {} else if (childPid == 0) { /* child process */
+  if (childPid == -1) {
+  } else if (childPid == 0) { /* child process */
+    // ThreadList::resetOnFork calls pthread_create which in turn calls
+    // malloc/calloc, etc. This can result in a deadlock if the parent process
+    // was holding malloc-lock while forking and might reset the lock only
+    // during atfork_child handler. Because our own atfork_child handler is
+    // called at the very beginning, the parent process won't have a chance to
+    // reset the lock. Calling ThreadList::resetOnFork here ensures that any
+    // such locks would have been reset by the caller and hence it's safe to
+    // call pthread_creat at this point.
+    ThreadList::resetOnFork();
+
     /* NOTE: Any work that needs to be done for the newly created child
      * should be put into pthread_atfork_child() function. That function is
      * hooked to the libc:fork() and will be called right after the new


### PR DESCRIPTION
ThreadList::resetOnFork calls pthread_create which in turn calls
malloc/calloc, etc. This can result in a deadlock if the parent process
was holding malloc-lock while forking and might reset the lock only
during atfork_child handler. Because our own atfork_child handler is
called at the very beginning, the parent process won't have a chance to
reset the lock. Calling ThreadList::resetOnFork here ensures that any
such locks would have been reset by the caller and hence it's safe to
call pthread_creat at this point.