### PR TITLE
Eliminate static C++ objects from jassert, jfilesystem, and dmtcpworker

### DIFF
--- a/jalib/jassert.cpp
+++ b/jalib/jassert.cpp
@@ -63,10 +63,28 @@ static int errConsoleFd = -1;
 // (as a lvalue) to modifying the underlying variable.
 
 static jalib::string&
-tmpDir() { static jalib::string s; return s; }
+tmpDir()
+{
+  static jalib::string *s = NULL;
+  if (s == NULL) {
+    // Technically, this is a memory leak, but s is static and so it happens
+    // only once.
+    s = new jalib::string();
+  }
+  return *s;
+}
 
 static jalib::string&
-uniquePidStr() { static jalib::string s; return s; }
+uniquePidStr()
+{
+  static jalib::string *s = NULL;
+  if (s == NULL) {
+    // Technically, this is a memory leak, but s is static and so it happens
+    // only once.
+    s = new jalib::string();
+  }
+  return *s;
+}
 
 static int
 jwrite(int fd, const char *str)
@@ -160,7 +178,15 @@ _open_log_safe(const jalib::string &s, int protectedFd)
 }
 
 static jalib::string&
-theLogFilePath() { static jalib::string s; return s; }
+theLogFilePath() {
+  static jalib::string *s = NULL;
+  if (s == NULL) {
+    // Technically, this is a memory leak, but s is static and so it happens
+    // only once.
+    s = new jalib::string();
+  }
+  return *s;
+}
 
 void
 jassert_internal::jassert_init()

--- a/jalib/jfilesystem.cpp
+++ b/jalib/jfilesystem.cpp
@@ -176,9 +176,13 @@ jalib::Filesystem::mkdir_r(const jalib::string &dir, mode_t mode)
 jalib::string
 jalib::Filesystem::GetProgramDir()
 {
-  static jalib::string value = DirName(GetProgramPath());
-
-  return value;
+  static jalib::string *value = NULL;
+  if (value == NULL) {
+    // Technically, this is a memory leak, but value is static and so it happens
+    // only once.
+    value = new jalib::string(DirName(GetProgramPath()));
+  }
+  return *value;
 }
 
 jalib::string
@@ -206,9 +210,13 @@ jalib::Filesystem::GetProgramName()
 jalib::string
 jalib::Filesystem::GetProgramPath()
 {
-  static jalib::string value = _GetProgramExe();
-
-  return value;
+  static jalib::string *value = NULL;
+  if (value == NULL) {
+    // Technically, this is a memory leak, but value is static and so it happens
+    // only once.
+    value = new jalib::string(_GetProgramExe());
+  }
+  return *value;
 }
 
 // NOTE: ResolveSymlink returns a string, buf, allocated on the stack.
@@ -259,9 +267,14 @@ jalib::Filesystem::FileExists(const jalib::string &str)
 jalib::StringVector
 jalib::Filesystem::GetProgramArgs()
 {
-  static StringVector rv;
+  static StringVector *rv = NULL;
+  if (rv == NULL) {
+    // Technically, this is a memory leak, but rv is static and so it happens
+    // only once.
+    rv = new StringVector();
+  }
 
-  if (rv.empty()) {
+  if (rv->empty()) {
     jalib::string path = "/proc/self/cmdline";
 
     // FIXME: Replace fopen with open.
@@ -276,14 +289,14 @@ jalib::Filesystem::GetProgramArgs()
     // We should replace getdelim with our own version
     char *lineptr = (char *)JALLOC_HELPER_MALLOC(len + 1);
     while (getdelim(&lineptr, &len, '\0', args) >= 0) {
-      rv.push_back(lineptr);
+      rv->push_back(lineptr);
     }
 
     JALLOC_HELPER_FREE(lineptr);
     jalib::fclose(args);
   }
 
-  return rv;
+  return *rv;
 }
 
 jalib::IntVector

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -266,7 +266,7 @@ installSegFaultHandler()
   JASSERT(sigaction(SIGSEGV, &act, NULL) == 0) (JASSERT_ERRNO);
 }
 
-static jalib::JBuffer buf(0); // To force linkage of jbuffer.cpp
+static jalib::JBuffer *buf = NULL;
 
 // called before user main()
 // workerhijack.cpp initializes a static variable theInstance to DmtcpWorker obj
@@ -276,6 +276,11 @@ dmtcp_initialize()
   static bool initialized = false;
 
   if (initialized) {
+    if (buf == NULL) {
+      // Technically, this is a memory leak, but buf is static and so it happens
+      // only once.
+      buf = new jalib::JBuffer(0); // To force linkage of jbuffer.cpp
+    }
     return;
   }
   initialized = true;


### PR DESCRIPTION
This fixes issue #537. Apparently, on older libc/libstdc++, the library
acquires a low-level lock in its constructor. This can lead to a deadlock
when the library, in its constructor, ends up calling a DMTCP wrapper,
which then calls other helper functions that have their own static
local objects that need to acquire the same lock to be initialized.
Here's a sample stacktrace:

    __lll_lock_wait_private () from /lib64/libc.so.6
    _L_lock_16 () from /lib64/libc.so.6
    __new_exitfn () from /lib64/libc.so.6
    __cxa_atexit_internal () from /lib64/libc.so.6
    theLogFilePath () at ../jalib/jassert.cpp:171
    jassert_internal::set_log_file ()
    dmtcp::Util::initializeLogFile ()
    prepareLogAndProcessdDataFromSerialFile () at dmtcpworker.cpp:231
    dmtcp_initialize () at dmtcpworker.cpp:266
    calloc (nmemb=1, size=1040) at alloc/mallocwrappers.cpp:32
    __new_exitfn ()
    __cxa_atexit_internal ()
    __static_initialization_and_destruction_0
    __do_global_ctors_aux ()
    _init ()
    _dl_init_internal ()
    _dl_start_user ()