### PR TITLE
pathvirt: patch new prefix env var before execve().

### DIFF
--- a/src/execwrappers.cpp
+++ b/src/execwrappers.cpp
@@ -496,6 +496,19 @@ static vector<string> patchUserEnv (vector<string> env, const char* filename)
   ldPreloadStr += getUpdatedLdPreload(filename, userPreloadStr.c_str());
 
   result.push_back(ldPreloadStr);
+
+  /*
+   * The path virtualization plugin tries to set the new prefix env var on
+   * restart. However, for some applications (e.g. bash), setenv() won't affect
+   * the envp area, possibly because the application has its private copy of
+   * the env vars. We need to patch the right env vars before calling execve().
+   * */
+  if (getenv("DMTCP_NEW_PATH_PREFIX")) {
+    string pathVirt = "DMTCP_NEW_PATH_PREFIX=";
+    pathVirt += getenv("DMTCP_NEW_PATH_PREFIX");
+    result.push_back(pathVirt);
+  }
+
   if (dbg) {
     out << "     addenv[dmtcp]:" << result.back() << '\n';
   }


### PR DESCRIPTION
This should be a temp fix. In the long term, we need to think about
how to inject new env vars for applications that have private copy
of env vars.