### PR TITLE
DMTCP_RESTART_PAUSE0 (for version 2.5.1)

### DIFF
--- a/src/mtcp/mtcp_header.h
+++ b/src/mtcp/mtcp_header.h
@@ -48,7 +48,8 @@ typedef union _MtcpHeader {
     void *vdsoEnd;
     void *vvarStart;
     void *vvarEnd;
-    void (*post_restart) ();
+    void (*post_restart)();
+    void (*post_restart_debug)();
     ThreadTLSInfo motherofall_tls_info;
     int tls_pid_offset;
     int tls_tid_offset;

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -101,17 +101,21 @@ typedef struct RestoreInfo {
   VA vvarStart;
   VA vvarEnd;
   fnptr_t post_restart;
+  fnptr_t post_restart_debug;
   // NOTE: Update the offset when adding fields to the RestoreInfo struct
   // See note below in the restart_fast_path() function.
   fnptr_t restorememoryareas_fptr;
-  //void (*post_restart)();
-  //void (*restorememoryareas_fptr)();
+
+  // void (*post_restart)();
+  // void (*post_restart_debug)();
+  // void (*restorememoryareas_fptr)();
   int use_gdb;
   int text_offset;
   ThreadTLSInfo motherofall_tls_info;
   int tls_pid_offset;
   int tls_tid_offset;
   MYINFO_GS_T myinfo_gs;
+  int mtcp_restart_pause;  // Used by env. var. DMTCP_RESTART_PAUSE0
 } RestoreInfo;
 static RestoreInfo rinfo;
 
@@ -206,17 +210,12 @@ MTCP_PRINTF("Attach for debugging.");
 #endif
 
   rinfo.fd = -1;
+  rinfo.mtcp_restart_pause = 0; /* false */
   rinfo.use_gdb = 0;
   rinfo.text_offset = -1;
   shift;
   while (argc > 0) {
-    // Flags for standalone debugging
-    if (argc == 1) {
-      // We would use MTCP_PRINTF, but it's also for output of util/readdmtcp.sh
-      mtcp_printf("Considering '%s' as a ckpt image.\n", argv[0]);
-      ckptImage = argv[0];
-      break;
-    } else if (mtcp_strcmp(argv[0], "--use-gdb") == 0) {
+    if (mtcp_strcmp(argv[0], "--use-gdb") == 0) {
       rinfo.use_gdb = 1;
       shift;
     } else if (mtcp_strcmp(argv[0], "--text-offset") == 0) {
@@ -229,9 +228,17 @@ MTCP_PRINTF("Attach for debugging.");
     } else if (mtcp_strcmp(argv[0], "--stderr-fd") == 0) {
       rinfo.stderr_fd = mtcp_strtol(argv[1]);
       shift; shift;
+    } else if (mtcp_strcmp(argv[0], "--mtcp-restart-pause") == 0) {
+      rinfo.mtcp_restart_pause = 1; /* true */
+      shift;
     } else if (mtcp_strcmp(argv[0], "--simulate") == 0) {
       simulate = 1;
       shift;
+    } else if (argc == 1) {
+      // We would use MTCP_PRINTF, but it's also for output of util/readdmtcp.sh
+      mtcp_printf("Considering '%s' as a ckpt image.\n", argv[0]);
+      ckptImage = argv[0];
+      break;
     } else {
       MTCP_PRINTF("MTCP Internal Error\n");
       return -1;
@@ -288,6 +295,7 @@ MTCP_PRINTF("Attach for debugging.");
   rinfo.vvarStart = mtcpHdr.vvarStart;
   rinfo.vvarEnd = mtcpHdr.vvarEnd;
   rinfo.post_restart = mtcpHdr.post_restart;
+  rinfo.post_restart_debug = mtcpHdr.post_restart_debug;
   rinfo.motherofall_tls_info = mtcpHdr.motherofall_tls_info;
   rinfo.tls_pid_offset = mtcpHdr.tls_pid_offset;
   rinfo.tls_tid_offset = mtcpHdr.tls_tid_offset;
@@ -620,9 +628,25 @@ static void restorememoryareas(RestoreInfo *rinfo_ptr)
   /* System calls and libc library calls should now work. */
 
   DPRINTF("MTCP restore is now complete.  Continuing by jumping to\n"
-          "  ThreadList:postRestart() back inside libdmtcp.so: %p...\n",
+          "  ThreadList::postRestart() back inside libdmtcp.so: %p...\n",
           restore_info.post_restart);
-  restore_info.post_restart();
+
+  if (restore_info.mtcp_restart_pause) {
+    MTCP_PRINTF(
+      "\nStopping due to env. var DMTCP_RESTART_PAUSE0 or MTCP_RESTART_PAUSE0\n"
+      "(DMTCP_RESTART_PAUSE0 can be set after creating the checkpoint image.)\n"
+      "Attach to the computation with GDB from another window:\n"
+      "(This won't work well unless you configure DMTCP with --enable-debug)\n"
+      "  gdb PROGRAM_NAME %d\n"
+      "You should now be in 'ThreadList::postRestartDebug()'\n"
+      "  (gdb) list\n"
+      "  (gdb) p dummy = 0\n", mtcp_sys_getpid()
+    );
+    restore_info.post_restart_debug();
+  } else {
+    restore_info.post_restart();
+  }
+  // NOTREACHED
 }
 
 NO_OPTIMIZE

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -272,6 +272,7 @@ static void prepareMtcpHeader(MtcpHeader *mtcpHdr)
   mtcpHdr->vvarEnd = (void*) ProcessInfo::instance().vvarEnd();
 
   mtcpHdr->post_restart = &ThreadList::postRestart;
+  mtcpHdr->post_restart_debug = &ThreadList::postRestartDebug;
   memcpy(&mtcpHdr->motherofall_tls_info,
          &motherofall->tlsInfo,
          sizeof(motherofall->tlsInfo));
@@ -685,7 +686,18 @@ void ThreadList::waitForAllRestored(Thread *thread)
 /*****************************************************************************
  *
  *****************************************************************************/
-void ThreadList::postRestart(void)
+void
+ThreadList::postRestartDebug(void)
+{ // Don't try to print before debugging.  Who knows what is working yet?
+  int dummy = 1;
+  while (dummy);
+  // User should have done GDB attach if we're here.
+  prctl(PR_SET_PTRACER, 0, 0, 0, 0); // Revert permission to default: no ptracer
+  postRestart();
+}
+
+void
+ThreadList::postRestart(void)
 {
   Thread *thread;
   sigset_t tmp;

--- a/src/threadlist.h
+++ b/src/threadlist.h
@@ -51,7 +51,8 @@ namespace dmtcp
     void resumeThreads();
     void waitForAllRestored(Thread *thisthread);
     void postRestart();
+    void postRestartDebug();
 
   };
 };
-#endif
+#endif // ifndef THREADLIST_H


### PR DESCRIPTION
__This version of PR #512 is for DMTCP 2.5.1.  This PR for 2.5.1 was already reviewed there.__

> * Workflow:
    env DMTCP_RESTART_PAUSE0=1 dmtcp_restart ckpt_*.dmtcp &
    # This stops in infinite loop in ThreadList::postRestartDebug(),
    #   which will call ThreadList::postRestart()
    # Before the infinite loop, it prints to the user to do:
    gdb PROGRAM_NAME PID
    # Full 'gdb attach' should now be working

NOTES:
* This includes postRestartDebug() as target from mtcp_restart,
  where postRestartDebug() has the infinite loop.
* In commit a8cfd6666, we removed '-g' as default.  It should be added back
  in this commit, before this new commit.