### PR TITLE
dmtcp_dlsym: Fix a crash when link_map doesn't contain vDSO entry

### DIFF
--- a/src/dmtcp_dlsym.cpp
+++ b/src/dmtcp_dlsym.cpp
@@ -472,17 +472,15 @@ dlsym_default_internal_flag_handler(void *handle,
     /* If the caller specified a specific library name, only search through
      * that.
      */
-    if (libname != NULL && strlen(map->l_name) > 0 &&
-        !strstr(map->l_name, libname)) {
-      map = map->l_next;
-      continue;
+    if (libname == NULL ||
+        (strlen(map->l_name) > 0 && strstr(map->l_name, libname)))  {
+      // Search current library
+      result = dlsym_default_internal_library_handler((void*) map,
+                                                      symbol,
+                                                      version,
+                                                      tags_p,
+                                                      default_symbol_index_p);
     }
-    // Search current library
-    result = dlsym_default_internal_library_handler((void*) map,
-                                                    symbol,
-                                                    version,
-                                                    tags_p,
-                                                    default_symbol_index_p);
     if (result) {
       return result;
     }


### PR DESCRIPTION
The commit: 3dff1b3 added a warning for the user that would be triggered
when the checkpoint and the restart machines had incompatible vDSO
layouts. The warning was added as a nice-to-have feature where earlier the
restart would have just crashed without a clue. The code would determine
the layout using a minor extension to the `dmtcp_dlsym` function.

However, the current implementation would lead to a crash if the vDSO
section was not listed as part of the link_map. We have now observed this
issue on two separate systems -- a user reported this in issue #566 and
@jiajuncao separately observed this on a CentOS 7.2 system. This patch
fixes this problem by ensuring that `dmtcp_dlsym` doesn't crash in the
corner cases.