### PR TITLE
Add API to skip checkpointing of plugin-specified memory regions

### DIFF
--- a/include/dmtcp.h.in
+++ b/include/dmtcp.h.in
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include "procmapsarea.h"
 
 #ifndef __USE_GNU
 # define __USE_GNU_NOT_SET
@@ -360,6 +361,22 @@ EXTERNC void dmtcp_get_new_file_path(const char *abspath,
 __attribute((weak));
 EXTERNC int dmtcp_must_overwrite_file(const char *path) __attribute((weak));
 
+/*
+ * This callback can be used by plugins to inform the DMTCP core memory
+ * checkpointing engine that the specified region of memory has cutouts
+ * ("holes"). The cutouts are not written out to the checkpoint image.
+ *
+ * The callback should return 1 if the region contains cutouts, 0 otherwise.
+ * If the plugin determines that the region has cutouts, i.e., if it returns 1,
+ * it's the responsibility of the plugin to fill the `writeRegions` iovec array
+ * in the `area` argument appropriately. The regions specified in the iovec
+ * array are written out to the checkpoint image using the writev() system call.
+ */
+EXTERNC int dmtcp_skip_memory_region_ckpting(ProcMapsArea *area)
+__attribute((weak));
+#define dmtcp_skip_memory_region_ckpting(r) \
+  (dmtcp_skip_memory_region_ckpting ? \
+   dmtcp_skip_memory_region_ckpting(r) : DMTCP_NOT_PRESENT)
 
 EXTERNC void dmtcp_initialize(void) __attribute((weak));
 

--- a/include/procmapsarea.h
+++ b/include/procmapsarea.h
@@ -23,12 +23,14 @@
 #define PROCMAPSAREA_H
 #include <stdint.h>
 #include <sys/types.h>
+#include <sys/uio.h>
 
 // MTCP_PAGE_SIZE must be page-aligned:  multiple of sysconf(_SC_PAGESIZE).
 #define MTCP_PAGE_SIZE        4096
 #define MTCP_PAGE_MASK        (~(MTCP_PAGE_SIZE - 1))
 #define MTCP_PAGE_OFFSET_MASK (MTCP_PAGE_SIZE - 1)
 #define FILENAMESIZE          1024
+#define MAX_NUM_HOLES         180
 
 #ifndef HIGHEST_VA
 
@@ -56,7 +58,8 @@ typedef char *VA;  /* VA = virtual address */
 
 typedef enum ProcMapsAreaProperties {
   DMTCP_ZERO_PAGE = 0x0001,
-  DMTCP_SKIP_WRITING_TEXT_SEGMENTS = 0x0002
+  DMTCP_SKIP_WRITING_TEXT_SEGMENTS = 0x0002,
+  DMTCP_AREA_WITH_PLUGIN_SPECIFIED_HOLES = 0x0004,
 } ProcMapsAreaProperties;
 
 typedef union ProcMapsArea {
@@ -101,6 +104,9 @@ typedef union ProcMapsArea {
     uint64_t properties;
 
     char name[FILENAMESIZE];
+
+    uint64_t numWriteRegions;
+    struct iovec writeRegions[MAX_NUM_HOLES];
   };
   char _padding[4096];
 } ProcMapsArea;

--- a/include/util.h
+++ b/include/util.h
@@ -131,6 +131,7 @@ bool isSysVShmArea(const ProcMapsArea &area);
 bool isIBShmArea(const ProcMapsArea &area);
 
 ssize_t writeAll(int fd, const void *buf, size_t count);
+ssize_t writevAll(int fd, const struct iovec *iov, int iovcnt);
 ssize_t readAll(int fd, void *buf, size_t count);
 ssize_t skipBytes(int fd, size_t count);
 

--- a/src/mtcp/mtcp_util.ic
+++ b/src/mtcp/mtcp_util.ic
@@ -243,6 +243,23 @@ void mtcp_mkdir(const char *dir)
   mtcp_sys_mkdir(tmp, S_IRWXU);
 }
 
+int mtcp_readvfile(int fd, struct iovec *iov, int iovcnt)
+{
+  int i = 0;
+  int count = 0;
+  int readC = 0;
+
+  while (i < iovcnt) {
+    readC = mtcp_readfile(fd, iov[i].iov_base, iov[i].iov_len);
+    if (readC != iov[i].iov_len) {
+      return count + readC;
+    }
+    count += readC;
+    i++;
+  }
+  return 0;
+}
+
 int mtcp_readfile(int fd, void *buf, size_t size)
 {
   int mtcp_sys_errno;

--- a/src/nosyscallsreal.c
+++ b/src/nosyscallsreal.c
@@ -45,6 +45,7 @@
 #include <sys/syscall.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <sys/uio.h>
 #include <syslog.h>
 #include <unistd.h>
 #include "constants.h"
@@ -152,6 +153,12 @@ ssize_t
 _real_write(int fd, const void *buf, size_t count)
 {
   REAL_FUNC_PASSTHROUGH_TYPED(ssize_t, write) (fd, buf, count);
+}
+
+ssize_t
+_real_writev(int fd, const struct iovec *iov, int iovcnt)
+{
+  REAL_FUNC_PASSTHROUGH_TYPED(ssize_t, writev) (fd, iov, iovcnt);
 }
 
 int

--- a/src/procselfmaps.cpp
+++ b/src/procselfmaps.cpp
@@ -245,5 +245,10 @@ ProcSelfMaps::getNextArea(ProcMapsArea *area)
 
   area->properties = 0;
 
+  memset(area->writeRegions, 0, sizeof(area->writeRegions));
+  area->numWriteRegions = 1;
+  area->writeRegions[0].iov_base = area->addr;
+  area->writeRegions[0].iov_len = area->size;
+
   return 1;
 }

--- a/src/syscallsreal.c
+++ b/src/syscallsreal.c
@@ -46,6 +46,7 @@
 #include <sys/syscall.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <sys/uio.h>
 #include <unistd.h>
 #include "constants.h"
 #include "dmtcp_dlsym.h"
@@ -561,6 +562,13 @@ ssize_t
 _real_write(int fd, const void *buf, size_t count)
 {
   REAL_FUNC_PASSTHROUGH_TYPED(ssize_t, write) (fd, buf, count);
+}
+
+LIB_PRIVATE
+ssize_t
+_real_writev(int fd, const struct iovec *iov, int iovcnt)
+{
+  REAL_FUNC_PASSTHROUGH_TYPED(ssize_t, writev) (fd, iov, iovcnt);
 }
 
 LIB_PRIVATE

--- a/src/syscallwrappers.h
+++ b/src/syscallwrappers.h
@@ -245,6 +245,7 @@ LIB_PRIVATE extern __thread int thread_performing_dlopen_dlsym;
                                       \
   MACRO(read)                         \
   MACRO(write)                        \
+  MACRO(writev)                       \
                                       \
   MACRO(select)                       \
   MACRO(poll)                         \
@@ -469,6 +470,7 @@ int _real_munmap(void *addr, size_t length);
 
 ssize_t _real_read(int fd, void *buf, size_t count);
 ssize_t _real_write(int fd, const void *buf, size_t count);
+ssize_t _real_writev(int fd, const struct iovec *iov, int iovcnt);
 int _real_select(int nfds,
                  fd_set *readfds,
                  fd_set *writefds,

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -263,6 +263,12 @@ mtcp_writememoryareas(int fd)
       /* If an absolute pathname
        * Posix and SysV shared memory segments can be mapped as /XYZ
        */
+    } else if (dmtcp_skip_memory_region_ckpting(&area) == 1) {
+       JTRACE("Skipping region as requested by the plugin");
+       area.properties |= DMTCP_AREA_WITH_PLUGIN_SPECIFIED_HOLES;
+       Util::writeAll(fd, &area, sizeof(area));
+       Util::writevAll(fd, area.writeRegions, area.numWriteRegions);
+       continue;
     }
 
     /* Force the anonymous flag if it's a private writeable section, as the


### PR DESCRIPTION
This callback can be used by plugins to inform the DMTCP core memory
checkpointing engine that the specified region of memory has cutouts
("holes"). The cutouts are not written out to the checkpoint image.

The callback should return 1 if the region contains cutouts, 0 otherwise.
If the plugin determines that the region has cutouts, i.e., if it returns 1,
it's the responsibility of the plugin to fill the `writeRegions` iovec array
in the `area` argument appropriately. The regions specified in the iovec
array are written out to the checkpoint image using the `writev()` system call.