### PR TITLE
Make it compilable with LLVM

### DIFF
--- a/contrib/infiniband/ibvctx.c
+++ b/contrib/infiniband/ibvctx.c
@@ -120,9 +120,11 @@ DECL_FPTR(req_notify_cq);
 #include "get_cq_from_pointer.ic"
 #include "get_qp_from_pointer.ic"
 #include "get_srq_from_pointer.ic"
+/* keys.ic should be included before ibv_wr_ops_recv.ic, because it declares
+ * a function sqe_update_lkey, which is used inside ibv_wr_ops_recv.ic. */
+#include "keys.ic"
 #include "ibv_wr_ops_recv.ic"
 #include "ibv_wr_ops_send.ic"
-#include "keys.ic"
 
 int
 dmtcp_infiniband_enabled(void) { return 1; }


### PR DESCRIPTION
The error message when compiled with LLVM before the commit:

./keys.ic:17:6: error: conflicting types for 'sge_update_lkey'
void sge_update_lkey(struct ibv_sge * list, int len)
     ^
./ibv_wr_ops_recv.ic:7:3: note: previous implicit declaration is here
  sge_update_lkey(wr->sg_list, wr->num_sge);
  ^