### PR TITLE
Fix PMI issues

### DIFF
--- a/plugin/batch-queue/rm_main.cpp
+++ b/plugin/batch-queue/rm_main.cpp
@@ -40,8 +40,17 @@ void dmtcp_event_hook(DmtcpEvent_t event, DmtcpEventData_t* data)
   JTRACE("Start");
 
   switch (event) {
-  case DMTCP_EVENT_THREADS_SUSPEND:
-    JTRACE("DMTCP_EVENT_THREADS_SUSPEND");
+  // DMTCP_EVENT_LEADER_ELECTION is used here instead of
+  // DMTCP_EVENT_THREADS_SUSPEND is because rm_shutdown_pmi()
+  // will close the PMI socket. close() will not remove the socket
+  // from the socket connection list if it is called when DMTCP is
+  // not in running state. The socket plugin will still treat the
+  // fd as a socket, while it may already be opened as another file
+  // type by other plugins. Here if we close the socket in the leader election
+  // event, the ipc plugin will remove it as a stale connection
+  // immediately in the same phase.
+  case DMTCP_EVENT_LEADER_ELECTION:
+    JTRACE("DMTCP_EVENT_LEADER_ELECTION");
     runUnderRMgr();
     rm_shutdown_pmi();
     break;

--- a/plugin/batch-queue/rm_pmi.cpp
+++ b/plugin/batch-queue/rm_pmi.cpp
@@ -143,7 +143,7 @@ extern "C" int PMI_Init( int *spawned )
 // pmi is correctly initialized.
 extern "C" void *dlsym(void *handle, const char *symbol)
 {
-  if (strcmp(symbol, "PMI_Init") == 0) {
+  if (symbol && strcmp(symbol, "PMI_Init") == 0) {
     return (void *)PMI_Init;
   }
   return _real_dlsym(handle, symbol);

--- a/plugin/batch-queue/rm_utils.cpp
+++ b/plugin/batch-queue/rm_utils.cpp
@@ -87,12 +87,12 @@ int dmtcp::findLib_byfunc(string fname, string &libpath)
       continue;
     }
 
-    void *handle = dlopen(libpath.c_str(),RTLD_LAZY);
+    void *handle = _real_dlopen(libpath.c_str(),RTLD_LAZY);
     if( handle == NULL ){
       //JTRACE("Cannot open libpath, skip")(libpath);
       continue;
     }
-    void *fptr = dlsym(handle,fname.c_str());
+    void *fptr = _real_dlsym(handle,fname.c_str());
     if( fptr != NULL ){
       // Able to find the requested symbol.
       //JTRACE("Found libpath by content:")(fname)(libpath);


### PR DESCRIPTION
1. Redirect `PMI_Init()` to our wrapper, if the pmi library is opened by `dlopen()`.
2. Remove the pmi socket as a stale connection.