### PR TITLE
[BUGFIX] dmtcp_restart ignores -j flag if there no -p flag

### DIFF
--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -843,7 +843,7 @@ main(int argc, char **argv)
   if ((getenv(ENV_VAR_NAME_PORT) == NULL ||
        getenv(ENV_VAR_NAME_PORT)[0]== '\0') &&
       allowedModes != COORD_NEW) {
-    allowedModes = COORD_NEW;
+    allowedModes = (allowedModes == COORD_ANY) ? COORD_NEW : allowedModes;
     setenv(ENV_VAR_NAME_PORT, STRINGIFY(DEFAULT_PORT), 1);
     JTRACE("No port specified\n"
            "Setting mode to --new-coordinator --coord-port "


### PR DESCRIPTION
The help message says that with "-j" flag, dmtcp_restart tries to join
to default port. In fact it fails to do so, unless the port is
specified.

The commit fixes this bug.