### PR TITLE
dmtcp_launch: Fix the behavior of -j when -p is not specified

### DIFF
--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -395,7 +395,7 @@ processArgs(int *orig_argc,
       (getenv(ENV_VAR_NAME_PORT) == NULL ||
        getenv(ENV_VAR_NAME_PORT)[0]== '\0') &&
       allowedModes != COORD_NEW) {
-    allowedModes = COORD_NEW;
+    allowedModes = (allowedModes == COORD_ANY) ? COORD_NEW : allowedModes;
     // Use static; some compilers save string const on local stack otherwise.
     static const char *default_port = STRINGIFY(DEFAULT_PORT);
     setenv(ENV_VAR_NAME_PORT, default_port, 1);


### PR DESCRIPTION
This is a port of changes from a recent commit: 8085468 for `dmtcp_restart` to `dmtcp_launch`.