### PR TITLE
pid-plugin: Save and restore CPU affinities for threads

### DIFF
--- a/test/sched_test.c
+++ b/test/sched_test.c
@@ -49,7 +49,8 @@ main()
         perror("Error getting CPU affinity for child");
         //return -1;
       } else {
-        //assert(CPU_ISSET(i, &cset));
+        // Turning this off for Travis containers
+        //assert(CPU_ISSET(i, &cset) && CPU_COUNT(&cset) == 1);
         printf("CPU affinity for (%d) is (%d)\n", ret, i);
       }
       sleep(1);


### PR DESCRIPTION
This fixes issue #203 (and possibly even #605).