### PR TITLE
Simple workaround to handle GS in a per-thread storage

### DIFF
--- a/src/mtcp/mtcp_header.h
+++ b/src/mtcp/mtcp_header.h
@@ -33,7 +33,7 @@ typedef unsigned long int segreg_t;
 
 typedef struct _ThreadTLSInfo {
   segreg_t fs, gs;  // thread local storage pointers
-  struct user_desc gdtentrytls[1];
+  struct user_desc gdtentrytls[2];
 } ThreadTLSInfo;
 
 #define MTCP_SIGNATURE "MTCP_HEADER_v2.2\n"

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -1100,7 +1100,7 @@ void restore_libc(ThreadTLSInfo *tlsInfo, int tls_pid_offset,
 
   /* Now pass this to the kernel, so it can adjust the segment descriptor.
    * This will make different kernel calls according to the CPU architecture. */
-  if (tls_set_thread_area (&(tlsInfo->gdtentrytls[0]), myinfo_gs) != 0) {
+  if (tls_set_thread_area (&(tlsInfo->gdtentrytls[0]), &(tlsInfo->gdtentrytls[1])) != 0) {
     MTCP_PRINTF("Error restoring GDT TLS entry; errno: %d\n", mtcp_sys_errno);
     mtcp_abort();
   }

--- a/src/mtcp/restore_libc.c
+++ b/src/mtcp/restore_libc.c
@@ -302,14 +302,14 @@ tls_set_thread_area(void *uinfo, MYINFO_GS_T dummy)
 
 static void* get_tls_base_addr()
 {
-  struct user_desc gdtentrytls;
+  struct user_desc gdtentrytls[2];
 
-  gdtentrytls.entry_number = get_tls_segreg() / 8;
-  if (tls_get_thread_area(&gdtentrytls, myinfo_gs) == -1) {
+  gdtentrytls[0].entry_number = get_tls_segreg() / 8;
+  if (tls_get_thread_area(&gdtentrytls[0], &gdtentrytls[1]) == -1) {
     PRINTF("Error getting GDT TLS entry: %d\n", errno);
     _exit(0);
   }
-  return (void *)(*(unsigned long *)&(gdtentrytls.base_addr));
+  return (void *)(*(unsigned long *)&(gdtentrytls[0].base_addr));
 }
 
 // Returns value for AT_SYSINFO in kernel's auxv
@@ -512,7 +512,7 @@ void TLSInfo_SaveTLSState (ThreadTLSInfo *tlsInfo)
  */
   i = tlsInfo->TLSSEGREG / 8;
   tlsInfo->gdtentrytls[0].entry_number = i;
-  if (tls_get_thread_area (&(tlsInfo->gdtentrytls[0]), myinfo_gs) == -1) {
+  if (tls_get_thread_area (&(tlsInfo->gdtentrytls[0]), &(tlsInfo->gdtentrytls[1])) == -1) {
     PRINTF("Error saving GDT TLS entry: %d\n", errno);
     _exit(0);
   }
@@ -547,7 +547,7 @@ void TLSInfo_RestoreTLSState(ThreadTLSInfo *tlsInfo)
 
   /* Now pass this to the kernel, so it can adjust the segment descriptor.
    * This will make different kernel calls according to the CPU architecture. */
-  if (tls_set_thread_area (&(tlsInfo->gdtentrytls[0]), myinfo_gs) != 0) {
+  if (tls_set_thread_area (&(tlsInfo->gdtentrytls[0]), &(tlsInfo->gdtentrytls[1])) != 0) {
     PRINTF("Error restoring GDT TLS entry: %d\n", errno);
     mtcp_abort();
   }

--- a/src/mtcp/tlsutil.h
+++ b/src/mtcp/tlsutil.h
@@ -21,15 +21,17 @@ int arch_prctl();
 #if 1
 // These calls need to be made from both DMTCP and mtcp_restart
 /* ARE THE _GS OPERATIONS NECESSARY? */
-#  define tls_get_thread_area(uinfo, myinfo_gs) \
+#  define tls_get_thread_area(uinfo, uinfo2) \
     ( mtcp_inline_syscall(arch_prctl,2,ARCH_GET_FS, \
          (unsigned long int)(&(((struct user_desc *)uinfo)->base_addr))), \
-      mtcp_inline_syscall(arch_prctl,2,ARCH_GET_GS, &myinfo_gs) \
+      mtcp_inline_syscall(arch_prctl,2,ARCH_GET_GS, \
+         (unsigned long int)(&(((struct user_desc *)uinfo2)->base_addr))) \
     )
-#  define tls_set_thread_area(uinfo, myinfo_gs) \
+#  define tls_set_thread_area(uinfo, uinfo2) \
     ( mtcp_inline_syscall(arch_prctl,2,ARCH_SET_FS, \
 	*(unsigned long int *)&(((struct user_desc *)uinfo)->base_addr)), \
-      mtcp_inline_syscall(arch_prctl,2,ARCH_SET_GS, myinfo_gs) \
+      mtcp_inline_syscall(arch_prctl,2,ARCH_SET_GS, \
+	*(unsigned long int *)&(((struct user_desc *)uinfo2)->base_addr)) \
     )
 # else
 /* ARE THE _GS OPERATIONS NECESSARY? */


### PR DESCRIPTION
Work-around allowing DMTCP to save the GS register in a per-thread manner, like already done for FS (like depicted in issue #607)
This fix is valid for 2.5 branch but would need a little work for being merged with master (conflicts from reformatting stuff).

Feel free to edit if necessary.
Thanks.