### PR TITLE
Fix bad restart_script.sh location when --ckptdir is used

### DIFF
--- a/src/restartscript.cpp
+++ b/src/restartscript.cpp
@@ -532,8 +532,8 @@ void writeScript(const string& ckptDir,
 
   fclose ( fp );
   {
-    string filename = RESTART_SCRIPT_BASENAME "." RESTART_SCRIPT_EXT;
     string dirname = jalib::Filesystem::DirName(uniqueFilename);
+    string filename = dirname + "/" RESTART_SCRIPT_BASENAME "." RESTART_SCRIPT_EXT;
     int dirfd = open(dirname.c_str(), O_DIRECTORY | O_RDONLY);
     JASSERT(dirfd != -1) (dirname) (JASSERT_ERRNO);
 


### PR DESCRIPTION
When the coordinator is used with `--ckptdir` option (in more general way, when the coordinator's working directory and checkpoint directory are not the same), DMTCP should store the symlink next the newly created ckpt file. To do that, the `unlink` call should be called with an absolute pathname to dmtcp_restart_script.sh. 

This pattern was discovered when running two successive run in the same directory, the ckpt directory being changed through `dmtcp_set_coord_ckptdir()` API call. During the second run, the `unlink` failed because DMTCP is looking for a script located in coordinator CWD, but the script is not there. Then, the `symlinkat` failed because a symlink already exists.

This fix simply prepends the dirname to `filename`.
Feel free to modify if necessary.