### PR TITLE
Remove gcc warning in util_misc.cpp and pathvirt.cpp for 2.5 branch

### DIFF
--- a/plugin/pathvirt/pathvirt.cpp
+++ b/plugin/pathvirt/pathvirt.cpp
@@ -735,7 +735,7 @@ resolve_symlink(const char *path)
       && S_ISLNK(statBuf.st_mode)) {
     char buf[PATH_MAX];
     memset(buf, 0, sizeof(buf));
-    _real_readlink(path, buf, sizeof(buf) - 1);
+    JASSERT(_real_readlink(path, buf, sizeof(buf) - 1) != -1);
     return virtual_to_physical_path(buf);
   }
 

--- a/src/util_misc.cpp
+++ b/src/util_misc.cpp
@@ -657,13 +657,13 @@ void Util::allowGdbDebug(int currentDebugLevel)
   if (Util::isValidFd(PROTECTED_DEBUG_SOCKET_FD)) {
     int requestedDebugLevel = 0;
     // Inform parent of current level
-    write(PROTECTED_DEBUG_SOCKET_FD,
-          &currentDebugLevel,
-          sizeof(currentDebugLevel));
+    JASSERT(write(PROTECTED_DEBUG_SOCKET_FD,
+                  &currentDebugLevel,
+                  sizeof(currentDebugLevel)) != -1);
     // Read the requested level from the parent
-    read(PROTECTED_DEBUG_SOCKET_FD,
-         &requestedDebugLevel,
-         sizeof(requestedDebugLevel));
+    JASSERT(read(PROTECTED_DEBUG_SOCKET_FD,
+                 &requestedDebugLevel,
+                 sizeof(requestedDebugLevel)) != -1);
     if (currentDebugLevel == requestedDebugLevel) {
       // Wait for GDB to connect if the requested level
       // matches the current level


### PR DESCRIPTION
This should be easy to review.