### PR TITLE
screen test is failing due to bad pty; skip test

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -1009,7 +1009,9 @@ if HAS_SCRIPT == "yes":
 # SHOULD HAVE screen RUN SOMETHING LIKE:  bash -c ./test/dmtcp1
 # FIXME: Currently fails on dekaksi due to DMTCP not honoring
 #        "Async-signal-safe functions" in signal handlers (see man 7 signal)
-if HAS_SCREEN == "yes":
+# **** Pty SUPPORT IN 2.5 BRANCH IS FLAKY.
+# **** screen NEEDS PTY; DON'T RUN SCREEN TEST UNTIL PTY FIXED.
+if HAS_SCREEN == "yes" and False:
   S=3*DEFAULT_S
   if sys.version_info[0:2] >= (2,6):
     runTest("screen",    3,  ["env TERM=vt100 " + SCREEN +


### PR DESCRIPTION
For 2.5, it's best to turn off the autotest for 'screen' until some time in the future when we fix it.  (Or we may choose to fix it only for the 3.0 master branch.)