### PR TITLE
change the include file order for Fedora

### DIFF
--- a/test/readline.c
+++ b/test/readline.c
@@ -2,11 +2,12 @@
  * gcc -o readline -Wl,--export-dynamic THIS_FILE -lreadline -lhistory -lcurses
  */
 
-#include <readline/history.h>
-#include <readline/readline.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include <readline/readline.h>
+#include <readline/history.h>
 
 int
 main()


### PR DESCRIPTION
GNU Readline Library -> Programming with GNU Readline
https://cnswww.cns.cwru.edu/php/chet/readline/readline.html 
The order of the includes failed on the Fedora and the new order of the include files is consistent with the GNU manual.