### PR TITLE
Do not reset the NS (publish-subscribe) database on checkpoint/resume.

### DIFF
--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -470,7 +470,7 @@ void DmtcpCoordinator::updateMinimumState(WorkerState::eWorkerState oldState)
       exitAfterCkptOnce = false;
     } else {
       JNOTE ( "building name service database" );
-      lookupService.reset();
+      // lookupService.reset();
       broadcastMessage ( DMT_DO_REGISTER_NAME_SERVICE_DATA );
     }
   }


### PR DESCRIPTION
This is necessary when one wants to use the publish/subscribe service before checkpoint, and throughout checkpoint and resume.