### PR TITLE
pid: Fix an error introduced in 30c03f23

### DIFF
--- a/src/plugin/pid/pid.cpp
+++ b/src/plugin/pid/pid.cpp
@@ -20,6 +20,12 @@
  ****************************************************************************/
 
 #include <sys/types.h>
+
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif // ifndef _GNU_SOURCE
+#include <sched.h>
+
 #include "jalloc.h"
 #include "jassert.h"
 #include "jconvert.h"


### PR DESCRIPTION
Apparently, on some old distros, the code fails to compile without this
include file. *ALSO, which is commit 30c03f23 ?  I don't find it anywhere.  Is there a corresponding PR?*