### PR TITLE
dmtcp_restart: Fix a bug with debug logging

### DIFF
--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -251,7 +251,6 @@ class RestoreTarget
     {
       UniquePid::ThisProcess() = _pInfo.upid();
       UniquePid::ParentProcess() = _pInfo.uppid();
-      Util::initializeLogFile(_pInfo.procname());
 
       if (createIndependentRootProcesses) {
         DmtcpUniqueProcessId compId = _pInfo.compGroup().upid();
@@ -307,6 +306,7 @@ class RestoreTarget
                                &compId,
                                &coordInfo,
                                &localIPAddr);
+        Util::initializeLogFile(SharedData::getTmpDir(), _pInfo.procname());
 
         Util::prepareDlsymWrapper();
       }


### PR DESCRIPTION
Even when compiled with the logs enabled, the logs weren't getting written
out to the log file(s) in the tmp directory. The issue was that the log file
was never opened correctly for writing.  This patch fixes this issue.