### PR TITLE
threadwrappers: Fix pid in TLS of newly-created threads

### DIFF
--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -215,22 +215,6 @@ ThreadList::initThread(Thread *th, int (*fn)(
   th->next = NULL;
   th->state = ST_RUNNING;
   th->procname[0] = '\0';
-
-  /* libpthread may recycle the thread stacks after the thread exits (due to
-   * return, pthread_exit, or pthread_cancel) by reusing them for a different
-   * thread created by a subsequent call to pthread_create().
-   *
-   * Part of thread-stack also contains the "struct pthread" with pid and tid
-   * as member fields. While reusing the stack for the new thread, the tid
-   * field is reset but the pid field is left unchanged (under the assumption
-   * that pid never changes). This causes a problem if the thread exited before
-   * checkpoint and the new thread is created after restart and hence the pid
-   * field contains the wrong value (pre-ckpt pid as opposed to current-pid).
-   *
-   * The solution is to put the motherpid in the pid slot every time a new
-   * thread is created to make sure that struct pthread has the correct value.
-   */
-  TLSInfo_UpdatePid();
 }
 
 /*****************************************************************************
@@ -255,6 +239,23 @@ ThreadList::updateTid(Thread *th)
   }
   th->tid = THREAD_REAL_TID();
   th->virtual_tid = dmtcp_gettid();
+
+  /* libpthread may recycle the thread stacks after the thread exits (due to
+   * return, pthread_exit, or pthread_cancel) by reusing them for a different
+   * thread created by a subsequent call to pthread_create().
+   *
+   * Part of thread-stack also contains the "struct pthread" with pid and tid
+   * as member fields. While reusing the stack for the new thread, the tid
+   * field is reset but the pid field is left unchanged (under the assumption
+   * that pid never changes). This causes a problem if the thread exited before
+   * checkpoint and the new thread is created after restart and hence the pid
+   * field contains the wrong value (pre-ckpt pid as opposed to current-pid).
+   *
+   * The solution is to put the motherpid in the pid slot every time a new
+   * thread is created to make sure that struct pthread has the correct value.
+   */
+  TLSInfo_UpdatePid();
+
   JTRACE("starting thread") (th->tid) (th->virtual_tid);
 
   // Check and remove any thread descriptor which has the same tid as ours.


### PR DESCRIPTION
A bug was observed where a newly-created thread post restart would end
up reusing the TLS of a thread that existed pre-checkpoint. Libpthread
decides to recycle the old TLS, and as an optimization, would not
update the pid field in the thread-block (under the assumption that
the pid never changes). Consequently, calls to pthread_cancel(), etc.,
for the newly-created thread would end up calling system calls (tgkill,
etc.) with the wrong pid and fail.

The fix is to call `TLSInfo_UpdatePid()` for any new thread in the
`clone_start()` function, which is the first thing the new thread
executes.