### PR TITLE
Extend pty support by fixing pts related issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ language: cpp
 compiler:
   - gcc
 
-script: ./configure && make -j4 && make tests && ./test/autotest.py --retry-once
+script: ./configure && make -j4 && make tests && mkdir -p $HOME/.screen; chmod 700 $HOME/.screen; export SCREENDIR=$HOME/.screen; ./test/autotest.py --retry-once

--- a/src/plugin/ipc/file/ptyconnection.cpp
+++ b/src/plugin/ipc/file/ptyconnection.cpp
@@ -44,10 +44,18 @@ static ssize_t ptmxWriteAll(int fd, const void *buf, bool isPacketMode);
 static bool
 ptmxTestPacketMode(int masterFd)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
+  int isPacketMode = 0;
+  /*
+   * Apparently the tty_ioctl man page has a typo: the command is
+   * actually TIOCGPKT and not TIOGCPKT.
+   */
+  ioctl(masterFd, TIOCGPKT, &isPacketMode);
+  return isPacketMode;
+#else
   char tmp_buf[100];
   int slave_fd, ioctlArg, rc;
   struct pollfd pollFd = { 0 };
-
   _real_ptsname_r(masterFd, tmp_buf, 100);
 
   /* permissions not used, but _real_open requires third arg */
@@ -99,6 +107,7 @@ ptmxTestPacketMode(int masterFd)
 
   /* D. Check if command byte packet exists, and chars rec'd is longer by 1. */
   return rc == 2 && tmp_buf[0] == TIOCPKT_DATA && tmp_buf[1] == 'x';
+#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8)
 }
 
 // Also record the count read on each iteration, in case it's packet mode
@@ -212,6 +221,7 @@ PtyConnection::PtyConnection(int fd,
   , _preExistingCTTY(false)
 {
   char buf[PTS_PATH_MAX];
+  memset(&_termios_p, 0, sizeof(_termios_p));
 
   switch (_type) {
   case PTY_DEV_TTY:
@@ -285,22 +295,63 @@ PtyConnection::doLocking()
   }
 }
 
+ /*
+  * A. Drain master and slave buffer data into _buf and _slave_buf
+  * B. Refill data again both buffers; since both device are paired
+  *    so to refill master-buffer, write on slave-fd and vice versa.
+  */
 void
 PtyConnection::drain()
 {
   JASSERT(_type != PTY_EXTERNAL);
   saveOptions();
-  if (_type == PTY_MASTER && getpgrp() == tcgetpgrp(_fds[0])) {
-    const int maxCount = 10000;
-    char buf[maxCount];
-    int numRead, numWritten;
-
-    // _fds[0] is master fd
-    numRead = ptmxReadAll(_fds[0], buf, maxCount);
+  /* TODO: why tcgetattr fails for background process in 'screen' test?
+   */
+  if(tcgetpgrp(STDIN_FILENO) == getpgrp()) {
+    JASSERT(tcgetattr(_fds[0], &_termios_p) == 0) (JASSERT_ERRNO);
+  }
+  /* The previous additional check "getpgrp() == tcgetpgrp(_fds[0])" was not
+   * satisfied, since tcgetpgrp returns 0 for the master_fd. This behavior of
+   * is not documented in the man page, an arguably is either a bug in the
+   * documentation or in the kernel as version 4.4 and glibc-2.21
+   */
+  if (_type == PTY_MASTER) {
+    int numRead = 0, numWritten = 0, slaveFd;
+    char slavePtsName[100];
     _ptmxIsPacketMode = ptmxTestPacketMode(_fds[0]);
-    JTRACE("_fds[0] is master(/dev/ptmx)") (_fds[0]) (_ptmxIsPacketMode);
-    numWritten = ptmxWriteAll(_fds[0], buf, _ptmxIsPacketMode);
-    JASSERT(numRead == numWritten) (numRead) (numWritten);
+    JASSERT(_real_ptsname_r(_fds[0], slavePtsName, sizeof(slavePtsName)) == 0)
+      (_fds[0]) (JASSERT_ERRNO);
+
+    int numSlaveRead = 0, numSlaveWritten = 0;
+    numRead = ptmxReadAll(_fds[0], _buf, PTY_KERNEL_BUF_LEN);
+    /* permissions not used, but _real_open requires third arg */
+    slaveFd = _real_open(slavePtsName, O_RDWR, 0666);
+    JASSERT(slaveFd >= 0) (JASSERT_ERRNO);
+    ioctl(slaveFd, TIOCOUTQ, &numSlaveRead);
+    if (numSlaveRead > 0) {
+      numSlaveRead = Util::readAll(slaveFd, _slave_buf, numSlaveRead);
+    }
+    masterDataSize = numRead;
+    slaveDataSize = numSlaveRead;
+    /* Refill the data again into both master and slave buffer only if there
+     * was some data in the kernel buffer at checkpoint time.
+     */
+    if (numSlaveRead > 0) {
+      numWritten = ptmxWriteAll(_fds[0], _slave_buf, _ptmxIsPacketMode);
+      JTRACE("Resume-refill slave pty buffer")
+        (_fds[0]) (_ptsName) (numWritten);
+    }
+
+    /* In the readAll function, the _buf buffer is incremented by the size of
+     * header, which is int type. So, even if there is no data in the buffer,
+     * numRead will have a value equal to sizeof(int)
+     */
+    if (numRead > (int)sizeof(int)) {
+      numSlaveWritten = Util::writeAll(slaveFd, _buf, numRead);
+      JTRACE("Resume-refill master pty buffer")
+        (slaveFd) (slavePtsName) (numSlaveWritten);
+      _real_close(slaveFd);
+    }
   }
   JASSERT((_type == PTY_CTTY || _type == PTY_PARENT_CTTY) || _fcntlFlags != -1);
   if (tcgetpgrp(_fds[0]) != -1) {
@@ -310,6 +361,10 @@ PtyConnection::drain()
   }
 }
 
+ /* restart-refill is done already in postRestart. Due to the postRestart
+  * barrier, the child process will wait until restart-refill is completed
+  * in the parent process. Now we can restore slave pty here in child process.
+  */
 void
 PtyConnection::refill(bool isRestart)
 {
@@ -354,6 +409,12 @@ PtyConnection::refill(bool isRestart)
     JTRACE("Restoring /dev/tty for the process") (_fds[0]);
     _ptsName = _virtPtsName = "/dev/tty";
     Util::dupFds(tempfd, _fds);
+  }
+  /* Store terminal settings only if current process is in foreground.
+     If we try to call tcsetattr in background, the process will hang up.
+   */
+  if(tcgetpgrp(STDIN_FILENO) == getpgrp()) {
+    JASSERT(tcsetattr(_fds[0], TCSANOW, &_termios_p) == 0)(JASSERT_ERRNO);
   }
 }
 
@@ -427,26 +488,42 @@ PtyConnection::postRestart()
 
   case PTY_MASTER:
   {
-    char pts_name[80];
-
+    char slavePtsName[100];
     tempfd = _real_open("/dev/ptmx", _fcntlFlags | extraFlags);
     JASSERT(tempfd >= 0) (tempfd) (JASSERT_ERRNO)
     .Text("Error Opening /dev/ptmx");
 
     JASSERT(grantpt(tempfd) >= 0) (tempfd) (JASSERT_ERRNO);
     JASSERT(unlockpt(tempfd) >= 0) (tempfd) (JASSERT_ERRNO);
-    JASSERT(_real_ptsname_r(tempfd, pts_name, 80) == 0)
+    JASSERT(_real_ptsname_r(tempfd, slavePtsName, sizeof(slavePtsName)) == 0)
       (tempfd) (JASSERT_ERRNO);
 
-    _ptsName = pts_name;
+    _ptsName = slavePtsName;
     SharedData::insertPtyNameMap(_virtPtsName.c_str(), _ptsName.c_str());
 
     if (_type == PTY_MASTER) {
       int packetMode = _ptmxIsPacketMode;
       ioctl(_fds[0], TIOCPKT, &packetMode);     /* Restore old packet mode */
     }
-
     JTRACE("Restoring /dev/ptmx") (_fds[0]) (_ptsName) (_virtPtsName);
+
+    // restart-refill here
+    int numWritten, numSlaveWritten, slaveFd;
+    _ptmxIsPacketMode = ptmxTestPacketMode(_fds[0]);
+    if (slaveDataSize > 0) {
+      numWritten = ptmxWriteAll(_fds[0], _slave_buf, _ptmxIsPacketMode);
+      JTRACE("Restart-refill slave pty buffer")
+        (_fds[0]) (_ptsName) (numWritten);
+    }
+    if (masterDataSize > (int)sizeof(int)) {
+      /* permissions not used, but _real_open requires third arg */
+      slaveFd = _real_open(slavePtsName, O_RDWR, 0666);
+      JASSERT(slaveFd >= 0) (slaveFd) (JASSERT_ERRNO);
+      numSlaveWritten = Util::writeAll(slaveFd, _buf, masterDataSize);
+      JTRACE("Restart-refill master pty buffer")
+        (slaveFd) (slavePtsName) (numSlaveWritten);
+      _real_close(slaveFd);
+    }
     break;
   }
   case PTY_BSD_MASTER:

--- a/src/plugin/ipc/file/ptyconnection.h
+++ b/src/plugin/ipc/file/ptyconnection.h
@@ -27,8 +27,11 @@
 
 #include <sys/stat.h>
 #include <sys/types.h>
-
+#include <termios.h>
+#include <unistd.h>
 #include "connection.h"
+
+#define PTY_KERNEL_BUF_LEN  4*1024
 
 namespace dmtcp
 {
@@ -75,6 +78,11 @@ class PtyConnection : public Connection
     char _ptmxIsPacketMode;
     char _isControllingTTY;
     char _preExistingCTTY;
+    struct termios _termios_p;
+    int masterDataSize;
+    int slaveDataSize;
+    char _buf[PTY_KERNEL_BUF_LEN];
+    char _slave_buf[PTY_KERNEL_BUF_LEN];
 };
 }
 #endif // ifndef PTYCONNECTION_H

--- a/src/plugin/ipc/file/ptyconnection.h
+++ b/src/plugin/ipc/file/ptyconnection.h
@@ -59,6 +59,7 @@ class PtyConnection : public Connection
     string virtPtsName() { return _virtPtsName;  }
 
     void markPreExistingCTTY() { _preExistingCTTY = true; }
+    void markPreExistingPCTTY() { _preExistingPCTTY = true; }
 
     virtual void doLocking();
     virtual void drain();
@@ -78,6 +79,7 @@ class PtyConnection : public Connection
     char _ptmxIsPacketMode;
     char _isControllingTTY;
     char _preExistingCTTY;
+    char _preExistingPCTTY;
     struct termios _termios_p;
     int masterDataSize;
     int slaveDataSize;

--- a/src/plugin/ipc/file/ptyconnlist.cpp
+++ b/src/plugin/ipc/file/ptyconnlist.cpp
@@ -185,7 +185,24 @@ PtyConnList::processPtyConnection(int fd,
     c = new PtyConnection(fd, path, flags, mode, PtyConnection::PTY_MASTER);
   } else if (Util::strStartsWith(path, "/dev/pts/")) {
     // POSIX Slave PTY
-    c = new PtyConnection(fd, path, flags, mode, PtyConnection::PTY_SLAVE);
+    PtyConnection *con = new PtyConnection(fd,
+                                           path,
+                                           flags,
+                                           mode,
+                                           PtyConnection::PTY_SLAVE);
+    /*
+     * '/dev/pts/_' can also point to controlling terminal,
+     *  especially when program tries to open controlling terminal
+     *  with open system call.
+     */
+    string ctty = jalib::Filesystem::GetControllingTerm();
+    string parentCtty = jalib::Filesystem::GetControllingTerm(getppid());
+    if (device == parentCtty) {
+        con -> markPreExistingPCTTY();
+    } else if (device == ctty) {
+        con -> markPreExistingCTTY();
+    }
+    c = (Connection *)con;
   } else {
     JASSERT(false) (path).Text("Unimplemented file type.");
   }

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -1008,7 +1008,7 @@ if HAS_SCRIPT == "yes":
 # Maybe this will work after new pty plugin PR is added.
 #   Review whether to include this test then, and make depend on HAS_RECENT_PTY
 #   that will be set in 'configure'.
-SCREEN_TEST_WORKS = False
+SCREEN_TEST_WORKS = True
 if HAS_SCREEN == "yes" and SCREEN_TEST_WORKS:
   S=3*DEFAULT_S
   if sys.version_info[0:2] >= (2,6):


### PR DESCRIPTION
Ptys are now supported by DMTCP. This version refills pty buffers on both resume and restart. It handles both packet mode and non-packet mode. This checks for kernel version 3.8.0 or later in order to support packet mode.
This also saves and restores the terminal's settings.
Resolve the issue in opening controlling terminal by name.