### PR TITLE
fifoconnection: Fix serialization of vector

### DIFF
--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -753,7 +753,8 @@ void
 FifoConnection::serializeSubClass(jalib::JBinarySerializer &o)
 {
   JSERIALIZE_ASSERT_POINT("FifoConnection");
-  o&_path&_rel_path&_savedRelativePath&_mode &_in_data;
+  o&_path&_rel_path&_savedRelativePath&_mode;
+  o.serializeVector(_in_data);
   JTRACE("Serializing FifoConn.") (_path) (_rel_path) (_savedRelativePath);
 }
 


### PR DESCRIPTION
It seems like the vector `_in_data` was using the incorrect serialization
primitive. This would cause problems when forking a 32-bit process from a
64-bit process. Thanks to R Balaji for catching this bug and the fix.