### PR TITLE
Reduced verbosity of several test programs.

### DIFF
--- a/test/dmtcp2.c
+++ b/test/dmtcp2.c
@@ -5,9 +5,14 @@ int
 main(int argc, char *argv[])
 {
   int count = 1;
+  FILE *fp = fopen("/dev/null", "w");
+  if (fp == NULL) {
+    printf("fopen(/dev/null, ...) failed! \n");
+    exit(1);
+  }
 
   while (1) {
-    printf("%2d\n", count++);
+    fprintf(fp, "%d\n", count++);
   }
   return 0;
 }

--- a/test/dmtcp3.c
+++ b/test/dmtcp3.c
@@ -52,8 +52,8 @@ threadMain(void *_n)
     numWaiting--;
     pthread_mutex_unlock(&mutex);
 
-    if (count++ % 1000 == 0) {
-      printf("thread%3d: %8d\n", *n, count / 1000);
+    if (count++ % 10000 == 0) {
+      printf("thread%3d: %8d\n", *n, count / 10000);
     }
   }
 

--- a/test/file1.c
+++ b/test/file1.c
@@ -52,11 +52,14 @@ main()
   unlink(filename);
 
   while (1) {
-    if (count % (int)1e6 == 0) {
+    // Print count every second.
+    if (count % 1000 == 0) {
       printf("%ld ", count);
       fflush(stdout);
     }
     fprintf(fp, "%ld", count++);
+    // Sleep for a millisecond so we don't fill up the disk too quickly.
+    usleep(1000);
   }
 
   fprintf(stdout, "I have returned\n");

--- a/test/file2.c
+++ b/test/file2.c
@@ -73,11 +73,14 @@ main()
   }
 
   while (1) {
-    if (count % (int)1e6 == 0) {
+    // Print count every second.
+    if (count % 1000 == 0) {
       printf("%ld ", count);
       fflush(stdout);
     }
     fprintf(fp, "%ld", count++);
+    // Sleep for a millisecond so we don't fill up the disk too quickly.
+    usleep(1000);
   }
 
   return 0;

--- a/test/openmp-1.c
+++ b/test/openmp-1.c
@@ -39,7 +39,6 @@ run()
         printf("Thread %d doing section 1\n", tid);
         for (i = 0; i < N; i++) {
           c[i] = a[i] + b[i];
-          printf("Thread %d: c[%d]= %f\n", tid, i, c[i]);
         }
       }
 
@@ -48,7 +47,6 @@ run()
         printf("Thread %d doing section 2\n", tid);
         for (i = 0; i < N; i++) {
           d[i] = a[i] * b[i];
-          printf("Thread %d: d[%d]= %f\n", tid, i, d[i]);
         }
       }
     }  /* end of sections */

--- a/test/pthread2.c
+++ b/test/pthread2.c
@@ -57,17 +57,22 @@ static void *
 threadMain(void *data)
 {
   int id = *(int *)data;
+  int count = 0;
 
-  while (1) {
+  if (id % 1000 == 0) {
     printf("Worker: %d (%ld) alive. numWorkers: %d\n",
            id, (long)syscall(SYS_gettid), numWorkers);
+  }
 
+  while (1) {
     // usleep(100*1000);
     pthread_mutex_lock(&mutex);
     if (numWorkers > maxWorkers) {
       numWorkers--;
-      printf("Worker: %d (%ld) exiting: numWorkers: %d\n",
-             id, (long)syscall(SYS_gettid), numWorkers);
+      if (id % 1000 == 0) {
+        printf("Worker: %d (%ld) exiting: numWorkers: %d\n",
+               id, (long)syscall(SYS_gettid), numWorkers);
+      }
       pthread_mutex_unlock(&mutex);
       free(data);
       pthread_exit(NULL);

--- a/test/pthread4.c
+++ b/test/pthread4.c
@@ -29,7 +29,6 @@ child_thread(void *arg)
   for (i = 0; i < NUM_THREADS_2; i++) {
     pthread_t my_child;
     int rc = pthread_create(&my_child, NULL, child_thread_2, NULL);
-    printf("b"); fflush(stdout);
     if (rc == 0) {
       pthread_join(my_child, NULL);
     }


### PR DESCRIPTION
The file tests were filling up the disk space at an alarming rate
especially when coupled with --slow and caused CI tests to fail if the
test box had lower disk space.

Similarly, reduced the frequency of unwanted printfs from some test
cases to allow for better debugging with manual launches.