### PR TITLE
Fixed code to add MAP_GROWSDOWN flag for stack region

### DIFF
--- a/src/mtcp/mtcp_header.h
+++ b/src/mtcp/mtcp_header.h
@@ -43,6 +43,7 @@ typedef union _MtcpHeader {
   struct {
     char signature[MTCP_SIGNATURE_LEN];
     void *saved_brk;
+    void *end_of_stack;
     void *restore_addr;
     size_t restore_size;
     void *vdsoStart;

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -50,7 +50,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <unistd.h>
+#include <stddef.h>
 
 #include "../membarrier.h"
 #include "config.h"
@@ -102,6 +102,7 @@ typedef struct RestoreInfo {
   VA vdsoEnd;
   VA vvarStart;
   VA vvarEnd;
+  VA endOfStack;
   fnptr_t post_restart;
   fnptr_t post_restart_debug;
   // NOTE: Update the offset when adding fields to the RestoreInfo struct
@@ -130,8 +131,8 @@ typedef struct RestoreInfo {
 static RestoreInfo rinfo;
 
 /* Internal routines */
-static void readmemoryareas(int fd);
-static int read_one_memory_area(int fd);
+static void readmemoryareas(int fd, VA endOfStack);
+static int read_one_memory_area(int fd, VA endOfStack);
 #if 0
 static void adjust_for_smaller_file_size(Area *area, int fd);
 #endif /* if 0 */
@@ -319,6 +320,7 @@ main(int argc, char *argv[], char **environ)
   rinfo.vdsoEnd = mtcpHdr.vdsoEnd;
   rinfo.vvarStart = mtcpHdr.vvarStart;
   rinfo.vvarEnd = mtcpHdr.vvarEnd;
+  rinfo.endOfStack = mtcpHdr.end_of_stack;
   rinfo.post_restart = mtcpHdr.post_restart;
   rinfo.post_restart_debug = mtcpHdr.post_restart_debug;
   rinfo.motherofall_tls_info = mtcpHdr.motherofall_tls_info;
@@ -557,6 +559,7 @@ mtcp_simulateread(int fd, MtcpHeader *mtcpHdr)
   mtcp_printf("**** brk (sbrk(0)): %p\n", mtcpHdr->saved_brk);
   mtcp_printf("**** vdso: %p..%p\n", mtcpHdr->vdsoStart, mtcpHdr->vdsoEnd);
   mtcp_printf("**** vvar: %p..%p\n", mtcpHdr->vvarStart, mtcpHdr->vvarEnd);
+  mtcp_printf("**** end of stack: %p\n", mtcpHdr->end_of_stack);
 
   Area area;
   mtcp_printf("\n**** Listing ckpt image area:\n");
@@ -654,10 +657,9 @@ restorememoryareas(RestoreInfo *rinfo_ptr)
    *   Similarly for vvar.
    */
   unmap_memory_areas_and_restore_vdso(&restore_info);
-
   /* Restore memory areas */
   DPRINTF("restoring memory areas\n");
-  readmemoryareas(restore_info.fd);
+  readmemoryareas(restore_info.fd, restore_info.endOfStack);
 
   /* Everything restored, close file and finish up */
 
@@ -921,10 +923,10 @@ unmap_memory_areas_and_restore_vdso(RestoreInfo *rinfo)
  *
  **************************************************************************/
 static void
-readmemoryareas(int fd)
+readmemoryareas(int fd, VA endOfStack)
 {
   while (1) {
-    if (read_one_memory_area(fd) == -1) {
+    if (read_one_memory_area(fd, endOfStack) == -1) {
       break; /* error */
     }
   }
@@ -940,7 +942,7 @@ readmemoryareas(int fd)
 
 NO_OPTIMIZE
 static int
-read_one_memory_area(int fd)
+read_one_memory_area(int fd, VA endOfStack)
 {
   int mtcp_sys_errno;
   int imagefd;
@@ -959,6 +961,20 @@ read_one_memory_area(int fd)
       && mtcp_sys_brk(NULL) != area.addr + area.size) {
     DPRINTF("WARNING: break (%p) not equal to end of heap (%p)\n",
             mtcp_sys_brk(NULL), area.addr + area.size);
+  }
+  /* MAP_GROWSDOWN flag is required for stack region on restart to make
+   * stack grow automatically when application touches any address within the
+   * guard page region(usually, one page less then stack's start address).
+   *
+   * The end of stack is detected dynamically at checkpoint time. See
+   * prepareMtcpHeader() in threadlist.cpp and ProcessInfo::growStack()
+   * in processinfo.cpp.
+   */
+  if (area.name[0] && mtcp_strstr(area.name, "stack")
+      || (area.endAddr == endOfStack)) {
+    area.flags = area.flags | MAP_GROWSDOWN;
+    DPRINTF("Detected stack area. End of stack (%p); Area end address (%p)\n",
+            endOfStack, area.endAddr);
   }
 
   // We could have replaced MAP_SHARED with MAP_PRIVATE in writeckpt.cpp

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -212,7 +212,7 @@ ProcessInfo::growStack()
     } else if ((VA)&area >= area.addr && (VA)&area < area.endAddr) {
       JTRACE("Original stack area") ((void *)area.addr) (area.size);
       stackArea = area;
-
+      _endOfStack = (uintptr_t) area.endAddr;
       /*
        * When using Matlab with dmtcp_launch, sometimes the bottom most
        * page of stack (the page with highest address) which contains the
@@ -276,7 +276,7 @@ ProcessInfo::init()
   _elfType = Elf_64;
 #endif // ifdef CONFIG_M32
 
-  _vdsoStart = _vdsoEnd = _vvarStart = _vvarEnd = 0;
+  _vdsoStart = _vdsoEnd = _vvarStart = _vvarEnd = _endOfStack = 0;
 
   processRlimit();
 
@@ -781,7 +781,7 @@ ProcessInfo::serialize(jalib::JBinarySerializer &o)
     & _gettimeofday_offset & _time_offset;
   o & _compGroup & _numPeers & _noCoordinator & _argvSize & _envSize;
   o & _restoreBufAddr & _savedHeapStart & _savedBrk;
-  o & _vdsoStart & _vdsoEnd & _vvarStart & _vvarEnd;
+  o & _vdsoStart & _vdsoEnd & _vvarStart & _vvarEnd & _endOfStack;
   o & _ckptDir & _ckptFileName & _ckptFilesSubDir;
 
   JTRACE("Serialized process information")

--- a/src/processinfo.h
+++ b/src/processinfo.h
@@ -149,6 +149,7 @@ class ProcessInfo
 
     bool vdsoOffsetMismatch(uint64_t f1, uint64_t f2,
                             uint64_t f3, uint64_t f4);
+    uint64_t endOfStack(void) const { return _endOfStack; }
 
     string getCkptFilename() const { return _ckptFileName; }
 
@@ -212,6 +213,7 @@ class ProcessInfo
     uint64_t _vdsoEnd;
     uint64_t _vvarStart;
     uint64_t _vvarEnd;
+    uint64_t _endOfStack;
 
     uint64_t _clock_gettime_offset;
     uint64_t _getcpu_offset;

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -290,7 +290,7 @@ prepareMtcpHeader(MtcpHeader *mtcpHdr)
   memset(mtcpHdr, 0, sizeof(*mtcpHdr));
   strncpy(mtcpHdr->signature, MTCP_SIGNATURE, strlen(MTCP_SIGNATURE) + 1);
   mtcpHdr->saved_brk = sbrk(0);
-
+  mtcpHdr->end_of_stack = (void *)ProcessInfo::instance().endOfStack();
   // TODO: Now that we have a separate mtcp dir, the code dealing with
   // restoreBuf should go in there.
   mtcpHdr->restore_addr = (void *)ProcessInfo::instance().restoreBufAddr();


### PR DESCRIPTION
The stack region of user-application doesn't grow automatically on the restart in the absence of MAP_GROWSDOWN mmap flag while remapping user-applications' memory regions. The current version of DMTCP gives segmentation fault if the user application tries to extend the stack downwards by touching any address within guard page region.