### PR TITLE
Fix deadlock in system() wrapper when the child crashes

### DIFF
--- a/src/glibcsystem.cpp
+++ b/src/glibcsystem.cpp
@@ -104,6 +104,9 @@ out:
     do {
       if (TEMP_FAILURE_RETRY(waitpid(pid, &status, 0)) != pid) {
         status = -1;
+        if (status == -1 && errno == ECHILD) {
+          break;
+        }
       }
     } while (WIFEXITED(status) == 0);
   }


### PR DESCRIPTION
When the child process crashes (for example, with a SEGFAULT), the
system wrapper should return with -1. However, in our case, we'd get
stuck in an infinite loop because the waitpid call would return -1. This
behavior of waitpid is expected [1], and our code wasn't checking for
this behavior correctly.

[1] Acc. to the waitpid man page, this can happen "for one's own child
if the action for SIGCHLD is set to SIG_IGN." Note that we do set SIG_IGN
as the action for SIGCHILD at the start of the `do_system()` function.