### PR TITLE
Fix deadlock when a process is forked in the resume phase

### DIFF
--- a/src/threadsync.cpp
+++ b/src/threadsync.cpp
@@ -207,6 +207,7 @@ ThreadSync::resetLocks()
   uninitializedThreadCountLock = newCountLock;
   pthread_mutex_t newPreResumeThreadCountLock = PTHREAD_MUTEX_INITIALIZER;
   preResumeThreadCountLock = newPreResumeThreadCountLock;
+  preResumeThreadCount = 0; // Reset the thread count post fork
 
   pthread_mutex_t newDestroyDmtcpWorker = PTHREAD_MUTEX_INITIALIZER;
   destroyDmtcpWorkerLock = newDestroyDmtcpWorker;


### PR DESCRIPTION
We need to reset the `preResumeThreadCount` in the child process in the
atfork_child handler. Otherwise, if a process is forked in the resume
phase, this can lead to a deadlock, where the checkpoint thread that's
created for the child process in the fork() wrapper gets blocked in
waitForUserThreadsToFinishPreResumeCB(). This is because the child process
inherits the non-zero value of `preResumeThreadCount` from the parent.