### PR TITLE
WSL fix: now mostly works if not using 'make check'

### DIFF
--- a/configure
+++ b/configure
@@ -5803,7 +5803,9 @@ else
 fi
 if test "$is_wsl" == "yes"; then
 
-$as_echo "#define WSL \$wsl_version" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define WSL $wsl_version
+_ACEOF
 
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $is_wsl" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -413,7 +413,7 @@ else
   is_wsl='no'
 fi
 if test "$is_wsl" == "yes"; then
-  AC_DEFINE([WSL],[$wsl_version],[This is WSL (Windows Subsystem for Linux.])
+  AC_DEFINE_UNQUOTED([WSL],[$wsl_version],[This is WSL (Windows Subsystem for Linux.])
 fi
 AC_MSG_RESULT([$is_wsl])
 

--- a/src/plugin/ipc/connection.cpp
+++ b/src/plugin/ipc/connection.cpp
@@ -95,8 +95,11 @@ Connection::restoreOptions()
   // (VIRTUAL_TO_REAL_PID(_fcntlOwner));
 
   errno = 0;
+#ifndef WSL
+  // WSL doesn't seem to support this yet (as of Windows 10 build 1803)
   JASSERT(fcntl(_fds[0], F_SETSIG, (int)_fcntlSignal) == 0)
     (_fds[0]) (_fcntlSignal) (JASSERT_ERRNO);
+#endif
 }
 
 void


### PR DESCRIPTION
This should be easy to review.  he PR has two tiny commits to fix bugs.

Now, `bin/dmtcp_launch -i 5 test/dmtcp1` works, as well as several other random tests by hand.  But for some reason, `make check` is failing.  When running `python autotest.py -v dmtcp1`, it seems to show some problems with `fcntl` and `F_SETOWN`.  But we can leave for another day digging into this remaining mystery.