### PR TITLE
mtcp_restart: Correctly check return value of mtcp_sys_brk()

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -645,7 +645,7 @@ restorememoryareas(RestoreInfo *rinfo_ptr)
   if (rinfo_ptr->saved_brk != NULL) {
     // Now, we can do the pending mtcp_sys_brk(rinfo.saved_brk).
     // It's now safe to do this, even though it can munmap memory holding rinfo.
-    if (mtcp_sys_brk(rinfo_ptr->saved_brk) != 0) {
+    if ((intptr_t)mtcp_sys_brk(rinfo_ptr->saved_brk) == -1) {
        MTCP_PRINTF("error restoring brk: %d\n", mtcp_sys_errno);
     }
   }


### PR DESCRIPTION
`mtcp_sys_brk()` is an inline assembly call. It returns the kernel return
value on success, and -1 on failure. Note that the kernel, unlike the
glibc `brk()` wrapper, returns the new program break on success, and
the current program break on failure.