### PR TITLE
Fix for aarch64, no delay loop on restart

### DIFF
--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -387,6 +387,7 @@ processArgs(int *orig_argc,
   /* FIXME:  Currently, there is a bug exposed by SIGRETURN for aarch64,
    *      when we create a SIGCHLD handler for the gzip process.
    *      So, we're temporarily disabling GZIP for aarch64.
+   * NOTE:  This occurs _only_ on second CKPT of 'make check' tests.
    */
   if (getenv(ENV_VAR_COMPRESSION) == NULL /* NULL default => --gzip */ ||
       strcmp(getenv(ENV_VAR_COMPRESSION), "1") == 0) {
@@ -394,8 +395,8 @@ processArgs(int *orig_argc,
     if (getenv(ENV_VAR_QUIET) != NULL &&
         strcmp(getenv(ENV_VAR_QUIET), "0") == 0) {
       JASSERT_STDERR <<
-        "\n*** Turning off gzip compression.  The armvv8 CPU support is"
-        " still experimental.\n*** Gzip not yet supported.\n\n";
+        "\n*** Turning off gzip compression.  The armv8 CPU support is"
+        " still in beta testing.\n*** Gzip not yet supported.\n\n";
     }
   }
 #endif // if __aarch64__

--- a/src/membarrier.h
+++ b/src/membarrier.h
@@ -44,9 +44,10 @@
 # define WMB asm volatile (".arch armv7-a \n\t dsb ; dmb" : : : "memory")
 # define IMB asm volatile (".arch armv7-a \n\t isb" : : : "memory")
 #elif defined(__aarch64__)
-# define RMB asm volatile ("dsb sy ; dmb sy" : : : "memory")
-# define WMB asm volatile ("dsb sy ; dmb sy" : : : "memory")
-# define IMB asm volatile ("isb" : : : "memory")
+// Can we merge __arm__ and __aarch64__ for recent distros?
+# define RMB asm volatile (".arch armv8.1-a \n\t dsb sy\n" : : : "memory")
+# define WMB asm volatile (".arch armv8.1-a \n\t dsb sy\n" : : : "memory")
+# define IMB asm volatile (".arch armv8.1-a \n\t isb" : : : "memory")
 #else // if defined(__i386__) || defined(__x86_64__)
 # error "instruction architecture not implemented"
 #endif // if defined(__i386__) || defined(__x86_64__)

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -421,6 +421,62 @@ restore_brk(VA saved_brk, VA restore_begin, VA restore_end)
   }
 }
 
+#ifdef __aarch64__
+// From Dynamo RIO, file:  dr_helper.c
+// See https://github.com/DynamoRIO/dynamorio/wiki/AArch64-Port
+//   (self-modifying code) for background.
+# define ALIGN_FORWARD(addr,align) (void *)(((unsigned long)addr + align - 1) & ~(unsigned long)(align-1))
+# define ALIGN_BACKWARD(addr,align) (void *)((unsigned long)addr & ~(unsigned long)(align-1))
+void
+clear_icache(void *beg, void *end)
+{
+    static size_t cache_info = 0;
+    size_t dcache_line_size;
+    size_t icache_line_size;
+    typedef unsigned int* ptr_uint_t;
+    ptr_uint_t beg_uint = (ptr_uint_t)beg;
+    ptr_uint_t end_uint = (ptr_uint_t)end;
+    ptr_uint_t addr;
+
+    if (beg_uint >= end_uint)
+        return;
+
+    /* "Cache Type Register" contains:
+     * CTR_EL0 [31]    : 1
+     * CTR_EL0 [19:16] : Log2 of number of 4-byte words in smallest dcache line
+     * CTR_EL0 [3:0]   : Log2 of number of 4-byte words in smallest icache line
+     */
+    if (cache_info == 0)
+        __asm__ __volatile__("mrs %0, ctr_el0" : "=r"(cache_info));
+    dcache_line_size = 4 << (cache_info >> 16 & 0xf);
+    icache_line_size = 4 << (cache_info & 0xf);
+
+    /* Flush data cache to point of unification, one line at a time. */
+    addr = ALIGN_BACKWARD(beg_uint, dcache_line_size);
+if ((unsigned long)addr > (unsigned long)beg_uint) { while(1); }
+    do {
+        __asm__ __volatile__("dc cvau, %0" : : "r"(addr) : "memory");
+        addr += dcache_line_size;
+    } while (addr != ALIGN_FORWARD(end_uint, dcache_line_size));
+
+    /* Data Synchronization Barrier */
+    __asm__ __volatile__("dsb ish" : : : "memory");
+
+    /* Invalidate instruction cache to point of unification, one line at a time. */
+    addr = ALIGN_BACKWARD(beg_uint, icache_line_size);
+    do {
+        __asm__ __volatile__("ic ivau, %0" : : "r"(addr) : "memory");
+        addr += icache_line_size;
+    } while (addr != ALIGN_FORWARD(end_uint, icache_line_size));
+
+    /* Data Synchronization Barrier */
+    __asm__ __volatile__("dsb ish" : : : "memory");
+
+    /* Instruction Synchronization Barrier */
+    __asm__ __volatile__("isb" : : : "memory");
+}
+#endif
+
 NO_OPTIMIZE
 static void
 restart_fast_path()
@@ -438,14 +494,27 @@ restart_fast_path()
   size_t offset = (char *)&restorememoryareas - rinfo.text_addr;
   rinfo.restorememoryareas_fptr = (fnptr_t)(rinfo.restore_addr + offset);
 
-  /* For __arm__
-   *    should be able to use kernel call: __ARM_NR_cacheflush(start, end, flag)
-   *    followed by copying new text below, followed by DSB and ISB,
-   *    to eliminate need for delay loop.  But this needs more testing.
+  /* For __arm__ and __aarch64__ will need to invalidate cache after this.
    */
   mtcp_memcpy(rinfo.restore_addr, rinfo.text_addr, rinfo.text_size);
   mtcp_memcpy(rinfo.restore_addr + rinfo.text_size, &rinfo, sizeof(rinfo));
   void *stack_ptr = rinfo.restore_addr + rinfo.restore_size - MB;
+
+  // The kernel call, __ARM_NR_cacheflush is avail. for __arm__, which
+  //   requires kernel privilege to flush cache.  For __aarch64__  user-space suffices
+  //   (and glibc clear_cache() is not available in most distros)
+/*
+  // Not avail. for __aarch64__, but should try this for __arm__:
+  mtcp_sys_errno = 0;
+  int rc1 = mtcp_sys_kernel_cacheflush(rinfo.restore_addr, rinfo.restore_addr + rinfo.text_size, 0);
+  if (rc1 !=0) { MTCP_PRINTF("mtcp_sys_kernel_cacheflush failed; errno: %d\n", mtcp_sys_errno); }
+  mtcp_sys_errno = 0;
+  int rc2 = mtcp_sys_kernel_cacheflush(rinfo.restore_addr + rinfo.text_size,
+                                       rinfo.restore_addr + rinfo.text_size + sizeof(rinfo), 0);
+  if (rc2 !=0) { MTCP_PRINTF("mtcp_sys_kernel_cacheflush failed\n"); }
+  mtcp_sys_mprotect(rinfo.restore_addr, rinfo.restore_size,
+                             PROT_READ | PROT_EXEC);
+*/
 
 #if defined(__INTEL_COMPILER) && defined(__x86_64__)
   asm volatile ("mfence" ::: "memory"); // memfence() defined in dmtcpplugin.cpp
@@ -468,11 +537,31 @@ restart_fast_path()
 #endif /* if defined(__INTEL_COMPILER) && defined(__x86_64__) */
 
 #if defined(__arm__) || defined(__aarch64__)
-# if 0
-  memfence();
-# else /* if 0 */
-
-  // FIXME: Replace this code by memfence() for __aarch64__, once it is stable.
+# if defined(__aarch64__)
+  // We would like to use the GCC builtin, __sync_synchronize()
+  //  but it doesn't appear to be portable to arm/aarch64 as of Aug., 2018
+  RMB; WMB; IMB;
+  // The call to clear_icache() wasn't effective:
+  //   clear_icache(rinfo.restore_addr, rinfo.restore_addr + rinfo.restore_size);
+  // So, now we're using the loop to read memory into dummy, below, as a hack.
+  // Apparently, this assembly instruction for "invalidate cache" requires
+  //   kernel privilege:
+  //   asm volatile (".arch armv8.1-a\n\t ic iallu\n\t" : : : "memory");
+  // This logic is a hack to make sure that the cache recognizes new mmap region
+  // Why can't gcc or glibc provide a working 'man 2 cacheflush' to correspond
+  //   to the man page in Ubuntu 16.04?  (Or maybe clear_cache()?)
+  char dummy;
+  for (char *ptr = rinfo.restore_addr; ptr < rinfo.restore_addr + rinfo.restore_size; ptr++) {
+    dummy = dummy ^ *ptr;
+  }
+  asm volatile("dsb ish" : : : "memory");
+  RMB; WMB; IMB;
+# else /* else if 0 */
+  // FIXME:  Test if this delay loop is no longer needed for __arm__.
+  //     We should be able to replace this by:
+  //     mtcp_sys_kernel_cacheflush(rinfo.restore_addr,
+  //                                rinfo.restore_addr + rinfo.text_size, 0);
+  //     If that works, then delete this delay loop code.
 
   /* This delay loop was required for:
    *    ARM v7 (rev 3, v71), SAMSUNG EXYNOS5 (Flattened Device Tree)
@@ -487,14 +576,8 @@ restart_fast_path()
       for (; y > 0; y--) {}
     }
   }
-# endif /* if 0 */
+# endif /* if defined(__aarch64__) */
 #endif /* if defined(__arm__) || defined(__aarch64__) */
-
-#if 0
-  RMB; // refresh instruction cache, for new memory
-  WMB; // refresh instruction cache, for new memory
-  IMB; // refresh instruction cache, for new memory
-#endif /* if 0 */
 
   DPRINTF("We have copied mtcp_restart to higher address.  We will now\n"
           "    jump into a copy of restorememoryareas().\n");

--- a/src/mtcp/mtcp_sys.h
+++ b/src/mtcp/mtcp_sys.h
@@ -326,6 +326,7 @@ struct linux_dirent {
                               5,                                          \
                               args)
 # define mtcp_sys_munmap(args ...)    mtcp_inline_syscall(munmap, 2, args)
+# define mtcp_sys_msync(args ...)    mtcp_inline_syscall(msync, 3, args)
 # define mtcp_sys_mprotect(args ...)  mtcp_inline_syscall(mprotect, 3, args)
 # define mtcp_sys_nanosleep(args ...) mtcp_inline_syscall(nanosleep, 2, args)
 # define mtcp_sys_brk(args ...)                                            \
@@ -482,6 +483,13 @@ static unsigned int myinfo_gs;
 #  define mtcp_sys_kernel_set_tls(args ...) \
   INLINE_SYSCALL_RAW(__ARM_NR_set_tls, 1, args)
 # endif // if defined(__arm__)
+
+# ifdef __arm__
+// https://elixir.bootlin.com/linux/v3.1/source/arch/arm/include/asm/unistd.h#L411
+#  define __ARM_NR_cacheflush 0x0f0002
+#  define mtcp_sys_kernel_cacheflush(args ...) \
+  INLINE_SYSCALL_RAW(__ARM_NR_cacheflush, 3, args)
+# endif
 
 // ==================================================================
 


### PR DESCRIPTION
Should be easy to review.  The essential changes are all in the file `src/mtcp/mtcp_restart.c`.  I removed the delay loop for __aarch64__, and added different code.  The issue is that when we mmap and copy new code into it, this is _self-modifying code_.  On the ARM and ARM64 CPUs, that operation requires the program to invalidate the previous cache conctents.  Otherwise, one waits for the cache to catch up, or one observes an ILLEGAL INSTRUCTION error.

Beyond this, one needs a data and instruction barrier, so that all instructions complete and no prefetches are attempted when switching to the new memory region.

Linux/gcc/glibc don't really provide a clean way to invalidate the cache.  So, I added somewhat hackish code with clear comments about what the issues are.