### PR TITLE
Add:  dmtcp_restart --debug-restart-pause ...

### DIFF
--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -450,11 +450,12 @@ startNewCoordinator(CoordinatorMode mode)
   JASSERT(coordinatorListenerSocket.isValid())
     (coordinatorListenerSocket.port()) (JASSERT_ERRNO) (host) (port)
     .Text("Failed to create socket to coordinator port."
-          "\nIf msg is \"Address already in use\","
-             " this may be an old coordinator."
+          "\nIf the above message (sterror) is:"
+          "\n           \"Address already in use\" or \"Bad file descriptor\","
+          "\n  then this may be an old coordinator."
           "\nEither try again a few seconds or a minute later,"
-          "\nOr kill other coordinators on this host and port:"
-          "\n    dmtcp_command ---coord-host XXX --coord-port XXX"
+          "\nOr kill other coordinator (using same host and port):"
+          "\n    dmtcp_command ---coord-host XXX --coord-port YYY --quit"
           "\nOr specify --join-coordinator if joining existing computation.");
   // Now dup the sockfd to
   coordinatorListenerSocket.changeFd(PROTECTED_COORD_FD);

--- a/src/mtcp/mtcp_header.h
+++ b/src/mtcp/mtcp_header.h
@@ -50,7 +50,7 @@ typedef union _MtcpHeader {
     void *vvarStart;
     void *vvarEnd;
     void (*post_restart)(double);
-    void (*post_restart_debug)(double);
+    void (*post_restart_debug)(double, int);
     ThreadTLSInfo motherofall_tls_info;
     int tls_pid_offset;
     int tls_tid_offset;

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -125,7 +125,7 @@ typedef struct RestoreInfo {
   struct timeval startValue;
 #endif
   MYINFO_GS_T myinfo_gs;
-  int mtcp_restart_pause;  // Used by env. var. DMTCP_RESTART_PAUSE0
+  int mtcp_restart_pause;  // Used by env. var. DMTCP_RESTART_PAUSE
 } RestoreInfo;
 static RestoreInfo rinfo;
 
@@ -257,8 +257,8 @@ main(int argc, char *argv[], char **environ)
       rinfo.stderr_fd = mtcp_strtol(argv[1]);
       shift; shift;
     } else if (mtcp_strcmp(argv[0], "--mtcp-restart-pause") == 0) {
-      rinfo.mtcp_restart_pause = 1; /* true */
-      shift;
+      rinfo.mtcp_restart_pause = argv[1][0] - '0'; /* true */
+      shift; shift;
     } else if (mtcp_strcmp(argv[0], "--simulate") == 0) {
       simulate = 1;
       shift;
@@ -686,8 +686,8 @@ restorememoryareas(RestoreInfo *rinfo_ptr)
 
   if (restore_info.mtcp_restart_pause) {
     MTCP_PRINTF(
-      "\nStopping due to env. var DMTCP_RESTART_PAUSE0 or MTCP_RESTART_PAUSE0\n"
-      "(DMTCP_RESTART_PAUSE0 can be set after creating the checkpoint image.)\n"
+      "\nStopping due to env. var DMTCP_RESTART_PAUSE or MTCP_RESTART_PAUSE\n"
+      "(DMTCP_RESTART_PAUSE can be set after creating the checkpoint image.)\n"
       "Attach to the computation with GDB from another window:\n"
       "(This won't work well unless you configure DMTCP with --enable-debug)\n"
       "  gdb PROGRAM_NAME %d\n"
@@ -695,7 +695,7 @@ restorememoryareas(RestoreInfo *rinfo_ptr)
       "  (gdb) list\n"
       "  (gdb) p dummy = 0\n", mtcp_sys_getpid()
     );
-    restore_info.post_restart_debug(readTime);
+    restore_info.post_restart_debug(readTime, restore_info.mtcp_restart_pause);
     // int dummy = 1;
     // while (dummy);
   } else {

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -85,6 +85,8 @@ static void Thread_RestoreSigState(Thread *th);
 // Without this, libdmtcp.so will depend on libdmtcp_plugin.so being loaded
 static pid_t _real_getpid(void)
 {
+  JWARNING("_real_getpid")
+          .Text("FIXME: _real_getpid returning virtual pid, not real pid.");
   // libc caches pid of the process and hence after restart, libc:getpid()
   // returns the pre-ckpt value.
   return (pid_t)_real_syscall(SYS_getpid);
@@ -706,7 +708,7 @@ ThreadList::waitForAllRestored(Thread *thread)
   Thread_RestoreSigState(thread);
 
   if (thread == motherofall) {
-    /* If DMTCP_RESTART_PAUSE==4, sleep 15 seconds to allow gdb attach.*/
+    /* If DMTCP_RESTART_PAUSE==4, wait for gdb attach.*/
     char * pause_param = getenv("DMTCP_RESTART_PAUSE");
     if (pause_param == NULL) {
       pause_param = getenv("MTCP_RESTART_PAUSE");
@@ -716,10 +718,8 @@ ThreadList::waitForAllRestored(Thread *thread)
 #ifdef HAS_PR_SET_PTRACER
       prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0); // For: gdb attach
 #endif // ifdef HAS_PR_SET_PTRACER
-      struct timespec delay = { 15, 0 }; /* 15 seconds */
-      printf("Pausing 15 seconds. Do:  gdb <PROGNAME> %d\n",
-             dmtcp_virtual_to_real_pid(getpid()));
-      nanosleep(&delay, NULL);
+      int dummy = 1;
+      while (dummy);
 #ifdef HAS_PR_SET_PTRACER
       prctl(PR_SET_PTRACER, 0, 0, 0, 0); // Revert permission to default.
 #endif // ifdef HAS_PR_SET_PTRACER
@@ -731,7 +731,7 @@ ThreadList::waitForAllRestored(Thread *thread)
  *
  *****************************************************************************/
 void
-ThreadList::postRestartDebug(double readTime)
+ThreadList::postRestartDebug(double readTime, int restartPause)
 { // Don't try to print before debugging.  Who knows what is working yet?
   int dummy = 1;
 #ifndef DEBUG
@@ -739,22 +739,29 @@ ThreadList::postRestartDebug(double readTime)
   printf("\n** DMTCP: It appears DMTCP not configured with '--enable-debug'\n");
   printf("**        If GDB doesn't show source, re-configure and re-compile\n");
 #endif
-  // If we're here, user set env. to DMTCP_RESTART_PAUSE=4, & is expecting this.
-  while (dummy);
-  // User should have done GDB attach if we're here.
+  if (restartPause == 1) {
+    // If we're here, user set env. to DMTCP_RESTART_PAUSE==0; is expecting this
+    while (dummy);
+    // User should have done GDB attach if we're here.
 #ifdef HAS_PR_SET_PTRACER
-  prctl(PR_SET_PTRACER, 0, 0, 0, 0); // Revert permission to default: no ptracer
+    prctl(PR_SET_PTRACER, 0, 0, 0, 0); // Revert to default: no ptracer
+  }
 #endif
-  postRestart();
+  static char restartPauseStr[2];
+  restartPauseStr[0] = '0' + restartPause;
+  restartPauseStr[1] = '\0';
+  setenv("DMTCP_RESTART_PAUSE", restartPauseStr, 1);
+  postRestart(readTime);
 }
 
+// threadlist.h sets these as defaulkt arguments: readTime=0.0, restartPause=0
 void
 ThreadList::postRestart(double readTime)
 {
   Thread *thread;
   sigset_t tmp;
 
-  /* If DMTCP_RESTART_PAUSE==2, sleep 15 seconds and allow gdb attach. */
+  /* If DMTCP_RESTART_PAUSE==2, wait for gdb attach. */
   char * pause_param = getenv("DMTCP_RESTART_PAUSE");
   if (pause_param == NULL) {
     pause_param = getenv("MTCP_RESTART_PAUSE");
@@ -763,10 +770,10 @@ ThreadList::postRestart(double readTime)
 #ifdef HAS_PR_SET_PTRACER
     prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0); // Allow 'gdb attach'
 #endif // ifdef HAS_PR_SET_PTRACER
-    struct timespec delay = { 15, 0 }; /* 15 seconds */
-    printf("Pausing 15 seconds. Do:  gdb <PROGNAME> %ld\n",
-           (long)THREAD_REAL_TID());
-    nanosleep(&delay, NULL);
+    // In src/mtcp_restart.c, we printed to user:
+    // "Stopping due to env. var DMTCP_RESTART_PAUSE or MTCP_RESTART_PAUSE ..."
+    int dummy = 1;
+    while (dummy);
 #ifdef HAS_PR_SET_PTRACER
     prctl(PR_SET_PTRACER, 0, 0, 0, 0);   // Revert permission to default.
 #endif // ifdef HAS_PR_SET_PTRACER
@@ -844,7 +851,7 @@ restarthread(void *threadv)
   }
 
   if (thread == motherofall) { // if this is a user thread
-    /* If DMTCP_RESTART_PAUSE==3, sleep 15 seconds to allow gdb attach.*/
+    /* If DMTCP_RESTART_PAUSE==3, wait for gdb attach.*/
     char * pause_param = getenv("DMTCP_RESTART_PAUSE");
     if (pause_param == NULL) {
       pause_param = getenv("MTCP_RESTART_PAUSE");
@@ -854,10 +861,10 @@ restarthread(void *threadv)
 #ifdef HAS_PR_SET_PTRACER
       prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY, 0, 0, 0); // For: gdb attach
 #endif // ifdef HAS_PR_SET_PTRACER
-      struct timespec delay = { 15, 0 }; /* 15 seconds */
-      printf("Pausing 15 seconds. Do:  gdb <PROGNAME> %d\n",
-             dmtcp_virtual_to_real_pid(getpid()));
-      nanosleep(&delay, NULL);
+      // In src/mtcp_restart.c, we printed to user:
+      // "Stopping due to env. var DMTCP_RESTART_PAUSE or MTCP_RESTART_PAUSE .."
+      int dummy = 1;
+      while (dummy);
 #ifdef HAS_PR_SET_PTRACER
       prctl(PR_SET_PTRACER, 0, 0, 0, 0); // Revert permission to default.
 #endif // ifdef HAS_PR_SET_PTRACER

--- a/src/threadlist.h
+++ b/src/threadlist.h
@@ -53,7 +53,7 @@ void resumeThreads();
 void waitForAllRestored(Thread *thisthread);
 void writeCkpt();
 void postRestart(double readTime = 0.0);
-void postRestartDebug(double readTime = 0.0);
+void postRestartDebug(double readTime, int restartPause);
 }
 }
 #endif // ifndef THREADLIST_H

--- a/src/util_init.cpp
+++ b/src/util_init.cpp
@@ -157,8 +157,8 @@ Util::initializeLogFile(string tmpDir, string procname, string prevLogPath)
   }
   a << "\n========================================\n";
 
-  // This cause an error when configure is done with --enable-debug
-  // JLOG(a.str().c_str());
+  // This causes an error when configure is done with --enable-logging
+  //   JLOG(a.str().c_str());
 #else // ifdef LOGGING
   JASSERT_SET_LOG("", tmpDir, UniquePid::ThisProcess().toString());
 #endif // ifdef LOGGING


### PR DESCRIPTION
There are two unrelated commits here, but it's simpler than separating out an extra, trivial PR, and later re-merging it.

COMMIT 1:  Trivial: 
  Change some text for user that clarifies about conflict w/ old coord; Also, fix a buggy comment.

COMMIT 2:  Add a new flag, --debug-restart-pause, for dmtcp_restart.
  The user can now choose any of four locations to stop and debug very easily.
  Instead of setting an environment variable, creating a new ckpt image, etc., one can directly
    debug on restart from an old ckpt image.  Setting --debug-restart-pause to 1, 2, 3, or 4
    specifies where the code stops with `int dummy = 1; while (dummy);`.
    One then does a gdb attach, and `(gdb) print dummy = 0`
    So, one can quickly get to a chosen location and use the usual debugging trick to continue in GDB.