### PR TITLE
Fix: Coordinator/Host IP is incorrectly calculated

### DIFF
--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -1309,6 +1309,7 @@ calcLocalAddr()
         JASSERT(sizeof localhostIPAddr == sizeof s->sin_addr);
         if ( strncmp( name, hostname, sizeof hostname ) == 0 ) {
           success = true;
+          memcpy(&localhostIPAddr, &s->sin_addr, sizeof s->sin_addr);
           break; // Stop here.  We found a matching hostname.
         }
         if (!at_least_one_match) { // Prefer the first match over later ones.

--- a/src/plugin/ipc/ssh/ssh.cpp
+++ b/src/plugin/ipc/ssh/ssh.cpp
@@ -513,6 +513,7 @@ updateCoordHost()
         JASSERT(sizeof localhostIPAddr == sizeof s->sin_addr);
         if ( strncmp( name, hostname, sizeof hostname ) == 0 ) {
           success = true;
+          memcpy(&localhostIPAddr, &s->sin_addr, sizeof s->sin_addr);
           break; // Stop here.  We found a matching hostname.
         }
         if (!at_least_one_match) { // Prefer the first match over later ones.


### PR DESCRIPTION
Applications which launch processes on remote machine won't be able to run under DMTCP due to
incorrect evaluation of host IP as well as coordinator IP. Problem is localhostIPAddr structure
is empty and code breaks the loop without doing a memcpy.