### PR TITLE
Bug fix for commit 21d13fd5 (PR #712)

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -1310,7 +1310,8 @@ remapMtcpRestartToReservedArea(RestoreInfo *rinfo)
   }
 
   VA target_addr = rinfo->restore_addr;
-  for (size_t i = 0; i < num_regions; i++) {
+  size_t i;
+  for (i = 0; i < num_regions; i++) {
     void *addr = mtcp_sys_mmap(mem_regions[i].addr + restore_region_offset,
                                mem_regions[i].size,
                                mem_regions[i].prot,


### PR DESCRIPTION
-  ‘for’ loop initial declarations only allowed in C99 mode

This is an easy one-line review.  Please review quickly.