### PR TITLE
Bug fix for commit 18e0aa04 (bad use of snprintf)

### DIFF
--- a/src/mtcp/restore_libc.h
+++ b/src/mtcp/restore_libc.h
@@ -49,15 +49,16 @@ extern "C" {
     /* In some cases, the user stack may be very small (less than 10KB). */  \
     /* We will overrun the buffer with just two extra stack frames. */       \
     char buf[256];                                                           \
-    int c = snprintf(buf, sizeof(buf) - 1, "[%d] %s:%d in %s; REASON= " fmt, \
+    int c = snprintf(buf, sizeof(buf), "[%d] %s:%d in %s; REASON= " fmt,     \
                      getpid(), __FILE__, __LINE__, __FUNCTION__,             \
                      ## __VA_ARGS__);                                        \
-    if (c == sizeof(buf) - 1) {                                              \
-      buf[c] = '\n';                                                         \
+    if (c >= sizeof(buf)) {                                                  \
+      c = sizeof(buf)-1;                                                     \
     }                                                                        \
+    buf[c] = '\n'; /* c is number of chars written (excl. null char.) */     \
     /* assign to rc in order to avoid 'unused result' compiler warnings */   \
     ssize_t rc __attribute__((unused));                                      \
-    rc = write(PROTECTED_STDERR_FD, buf, c + 1);                             \
+    rc = write(PROTECTED_STDERR_FD, buf, c+1);                               \
   } while (0);
 
 #ifdef LOGGING


### PR DESCRIPTION
This should be easy to review.

The key is to read `man snprintf` carefully for what shoudl be the return value.  snprintf returns the number of characters that _would_ have been written (not counting the final null character).  This return value, `rc`, may be larger than the parameter `n` (max size to be printed), and the user must test `if (rc >n) ...`.  The original code assumed that snprintf returned the actual number of characters (i.e., `rc<=n`), which is not correct.

This bug was exposed using gcc-7.x, which issues a warning for this.

@karya0, by the way, `git blame` seems to indicate that the original code was yours -- but back in your younger years.  :-)