### PR TITLE
Add 'if' cond to memcpy(), to stop gcc-7 warning

### DIFF
--- a/jalib/jsocket.cpp
+++ b/jalib/jsocket.cpp
@@ -184,7 +184,9 @@ jalib::JSocket::connect(const struct  sockaddr *addr,
 
   memset(&addrbuf, 0, sizeof(addrbuf));
   JASSERT(addrlen <= sizeof(addrbuf)) (addrlen) (sizeof(addrbuf));
-  memcpy(&addrbuf, addr, addrlen);
+  // if condition needed to stop gcc-7.x warning: -Wstringop-overflow=
+  if (addrlen <= sizeof(addrbuf))
+    memcpy ( &addrbuf, addr, addrlen );
   JWARNING(addrlen == sizeof(sockaddr_in)) (addrlen)
     (sizeof(sockaddr_in)).Text("may not be correct socket type");
   if (port != -1) {


### PR DESCRIPTION
We do a JASSERT before memcpy() to ensure that the size_t, `n`, is not too large.  But the gcc-7 compiler with `-Wall` doesn't recognize our JASSERT(), and thinks that `n` could be too large.  So, we add an 'if' condition to satisfy `gcc-7 -Wall`.

This is a two-line change, plus a one-line comment: easy to review.