### PR TITLE
Fix return value of dup2 wrapper in ipc plugin

### DIFF
--- a/src/plugin/ipc/ipc.cpp
+++ b/src/plugin/ipc/ipc.cpp
@@ -334,7 +334,7 @@ dup2(int oldfd, int newfd)
     process_fd_event(SYS_dup, oldfd, newfd);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
-  return newfd;
+  return res;
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)) && __GLIBC_PREREQ(2, 9)


### PR DESCRIPTION
This PR provides an obvious one-line fix.  Please review this quickly.

This bug was reported by Pankaj Mehta at Synopsys.