### PR TITLE
Second restart fails if vdso conflict w/ user data

### DIFF
--- a/src/plugin/ipc/ipc.cpp
+++ b/src/plugin/ipc/ipc.cpp
@@ -334,7 +334,7 @@ dup2(int oldfd, int newfd)
     process_fd_event(SYS_dup, oldfd, newfd);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
-  return newfd;
+  return res;
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)) && __GLIBC_PREREQ(2, 9)

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -446,11 +446,40 @@ writememoryarea(int fd, Area *area, int stack_was_seen)
     /* Kernel won't let us munmap this.  But we don't need to restore it. */
     JTRACE("skipping over [stack] segment (not the orig stack)")
       (addr) (area->size);
-  } else if (0 == strcmp(area->name, "[vsyscall]") ||
-             0 == strcmp(area->name, "[vectors]") ||
-             0 == strcmp(area->name, "[vvar]") ||
-             0 == strcmp(area->name, "[vdso]")) {
+  } else if (0 == strcmp(area -> name, "[vsyscall]") ||
+             0 == strcmp(area -> name, "[vectors]") ||
+             0 == strcmp(area -> name, "[vvar]"))
+             // NOTE: We can't trust kernel's "[vdso]" label here.  See below.
+  {
     JTRACE("skipping over memory special section")
+      (area->name) (addr) (area->size);
+  } else if ( area->__addr == ProcessInfo::instance().vdsoStart() ) {
+    //vDSO issue:
+    //    As always, we never want to save the vdso section.  We will use
+    //  the vdso section code provided by the kernel on restart.  Further,
+    //  the user code on restart has already been initialized and so it
+    //  will continue to use the original vdso section determined during
+    //  program launch.  Luckily, during the DMTCP_INIT event, DMTCP recorded
+    //  this vdso address when it called ProcessInfo::instance().init().
+    //    Now, here's the bad news.  During the first restart, the kernel
+    //  may choose to locate the vdso at a new address.  So, in
+    //  src/mtcp/mtcp_restart, DMTCP will mremap the kernel's vdso back
+    //  to the original address known during program launch.  This is as
+    //  it should be.  But when DMTCP does an mremap of vdso, the kernel
+    //  fails to update its own "[vds0]" label.  So, during the second
+    //  checkpoint (after the first restart), we can't trust the "[vdso]"
+    //  label to tell us where the vdso section really is.  And it's even
+    //  worse.  During mtcp_restart, we may have done the mremap, and there
+    //  may even now be some user data that was restored to the address
+    //  where the kernel thinks the "[vdso]" label belongs.  So, we would
+    //  be saving the original vdso section (which is wrong), and we would
+    //  be failing to save the user's memory that was restored into the
+    //  location labelled by the kernel's "[vdso]" label.  This last
+    //  case is even worse, since we have now failed to restore some user data. 
+    //    This was observed to happen in RHEL 6.6.  The solution is to
+    //  trust DMTCP for the vdso location (as in the if condition above),
+    //  and not to trust the kernel's "[vdso]" label.
+    JTRACE("skipping vDSO special section")
       (area->name) (addr) (area->size);
   } else if (area->prot == 0 ||
              (area->name[0] == '\0' &&


### PR DESCRIPTION
The commit only changes two or three lines of code.  But please see the comment that explains why this commit is important.  It can occur on a second restart after a first checkppoint, and was observed directly in RHEL 6.6.

This bug fix was contributed by:
1) Johannes Stoelp
2) Laurent Buchard
3) Pankaj Mehta

from: Synopsys, Inc.