### PR TITLE
Fix dmtcp_dlvsym (handling of versioned symbols)

### DIFF
--- a/src/dmtcp_dlsym.cpp
+++ b/src/dmtcp_dlsym.cpp
@@ -302,8 +302,15 @@ get_dt_tags(void *handle, dt_tag *tags)
  * data), we need to manually adjust at access time.
  */
 
+// Note that the dynamic tags for the sections of the virtual
+//   library, linux-vdso.so, have to be handled specially, since their d_ptr
+//   is an offset, and not an absolute address.
+// QUESTION:
+//   Since we handle linux-vdso.so directly, what is the "else" condition for?
 #define ADJUST_DYN_INFO_RO(dst, map, dyn)                   \
-  if (dyn->d_un.d_ptr > map->l_addr) {                      \
+  if ( strstr(map->l_name, "linux-vdso.so") ) {             \
+    dst = (__typeof(dst))(map->l_addr + dyn->d_un.d_ptr);   \
+  } else if (dyn->d_un.d_ptr > map->l_addr) {               \
     dst = (__typeof(dst))dyn->d_un.d_ptr;                   \
   } else {                                                  \
     dst = (__typeof(dst))(map->l_addr + dyn->d_un.d_ptr);   \


### PR DESCRIPTION
* get_dt_tags() sees relative addresses for tags in linux-vdso.so.
  These must be converted to absolute addresses.

In version 3.0 (master), the previous code worked only if linux-vdso.so was at highest address.
   This commit is more robust.  It explicitly checks for linux-vdso.so,
   since this is the only library using relative addresses.
For some reason, the original bug fix by @rohgarg was never pushed into the 2.x (now 2.6) branch.

The commit only changes two or three lines of code. But please see the comment that explains why this commit is important. It can occur on a second restart after a first checkppoint, and was observed directly in RHEL 6.6.

This bug fix was contributed by:

1) Johannes Stoelp
2) Laurent Buchard
3) Pankaj Mehta

from: Synopsys, Inc.