### PR TITLE
Lowering RLIMIT_NOFILE can cause crash

### DIFF
--- a/jalib/jalib.cpp
+++ b/jalib/jalib.cpp
@@ -29,6 +29,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 
 #include "jalib.h"
 #include "jassert.h"
@@ -135,9 +137,12 @@ dup(int oldfd)
   REAL_FUNC_PASSTHROUGH(int, dup) (oldfd);
 }
 
-int
-dup2(int oldfd, int newfd)
-{
+int dup2(int oldfd, int newfd) {
+  struct rlimit file_limit;
+  getrlimit(RLIMIT_NOFILE, &file_limit);
+  JASSERT ( (unsigned int)newfd < file_limit.rlim_cur )
+          (newfd)(file_limit.rlim_cur)
+          .Text("dup2: newfd is >= current limit on number of files");
   REAL_FUNC_PASSTHROUGH(int, dup2) (oldfd, newfd);
 }
 

--- a/src/nosyscallsreal.c
+++ b/src/nosyscallsreal.c
@@ -40,6 +40,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <sys/resource.h>
 #include <sys/select.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>

--- a/src/syscallsreal.c
+++ b/src/syscallsreal.c
@@ -1019,6 +1019,10 @@ _real_closedir(DIR *dir)
   REAL_FUNC_PASSTHROUGH(closedir) (dir);
 }
 
+int _real_setrlimit(int resource, const struct rlimit *rlim) {
+  REAL_FUNC_PASSTHROUGH (setrlimit) (resource, rlim);
+}
+
 LIB_PRIVATE
 int
 _real_mkstemp(char *template)

--- a/src/syscallwrappers.h
+++ b/src/syscallwrappers.h
@@ -33,10 +33,10 @@
 #include <signal.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <sys/resource.h>
 #include <sys/sem.h>
 #include <sys/shm.h>
 #include <sys/socket.h>
-#include <sys/types.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
@@ -204,6 +204,7 @@ LIB_PRIVATE extern __thread int thread_performing_dlopen_dlsym;
   MACRO(close)                        \
   MACRO(fclose)                       \
   MACRO(closedir)                     \
+  MACRO(setrlimit)                    \
   MACRO(dup)                          \
   MACRO(dup2)                         \
   MACRO(dup3)                         \
@@ -359,6 +360,7 @@ int _real_mkstemp(char *ttemplate);
 int _real_close(int fd);
 int _real_fclose(FILE *fp);
 int _real_closedir(DIR *dir);
+int _real_setrlimit(int resource, const struct rlimit *rlim);
 void _real_exit(int status);
 int _real_dup(int oldfd);
 int _real_dup2(int oldfd, int newfd);

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -801,6 +801,8 @@ runTest("shared-fd2",     2, ["./test/shared-fd2"])
 
 runTest("stale-fd",      2, ["./test/stale-fd"])
 
+runTest("rlimit-nofile",      2, ["./test/rlimit-nofile"])
+
 # Disable procfd1 until we fix readlink
 #runTest("procfd1",       2, ["./test/procfd1"])
 

--- a/test/rlimit-nofile.c
+++ b/test/rlimit-nofile.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <sys/resource.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#define CHILD "child_process"
+
+int main(int argc, char* argv[])
+{
+  if (argc == 2 && strcmp(argv[1], CHILD) == 0) {
+    // Child process
+    printf("Child process initialized.  (parent pid: %d)\n", getpid());
+    while (1);
+  }
+
+  // Parent DMTCP  lib was already initizlied using default RLIMIT_NOFILE.
+  // This fd_limit should cause the child to initialize with different limits.
+  // Verify that this does not create inconcsistency in DMTCP protectedFdBase.
+  struct rlimit fd_limit = {4096/2, 4096/2} ;
+  int retStatus = getrlimit(RLIMIT_NOFILE, &fd_limit) ;
+  if( retStatus == -1 ) {
+    perror("getrlimit"); exit(1);
+  }
+  if (fd_limit.rlim_cur < fd_limit.rlim_max) {
+    fd_limit.rlim_cur = fd_limit.rlim_max;
+  } else {
+    fd_limit.rlim_cur = fd_limit.rlim_cur/2;
+    fd_limit.rlim_max = fd_limit.rlim_cur;
+  }
+  retStatus = setrlimit(RLIMIT_NOFILE, &fd_limit) ;
+  if( retStatus == -1 ) {
+    perror("setrlimit"); exit(1);
+  }
+  int childpid = fork();
+  if (childpid == 0) {
+    char *myargv[] = {NULL, CHILD, NULL};
+    myargv[0] = argv[0];
+    execvp(argv[0], myargv);
+  } else {
+    waitpid(childpid, NULL, 0);
+  }
+}


### PR DESCRIPTION
    * The commit now checks for a static protected fd base less than 1024,
       and triggers assert during init/exec/restart if the current
       RLIMIT_NOFILE will not leave enough fd's for the protected fd's.
    * The commit adds a wrapper around setrlimit, to refuse to reduce
       RLIMIT_NO below 1024.
    * In the second commit, an autotest was added to check if the user lowered RLIMIT_NOFILE,
      but not below 1024.  This test should pass.