### PR TITLE
test/plugin-init: INIT event before libc init'ed

### DIFF
--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -97,6 +97,12 @@ distclean: clean
 	#${MAKE} -C credentials distclean
 	rm -f Makefile
 
+# plugin-init will call the INIT event in libdmtcp_plugin-init.so
+libdmtcp_plugin-init.so: plugin-init.cpp
+	${CXX} ${CXXFLAGS} -shared -fPIC -o $@ $<
+plugin-init: libdmtcp_plugin-init.so
+	# Don't create executable.  Only the library, above, used on test/sleep1
+
 readline: readline.c
 ifeq ($(HAS_READLINE),yes)
 	$(CC) -o $@ $< $(CFLAGS) $(READLINE_LIBS)

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -771,6 +771,10 @@ runTest("plugin-example-db", 2, ["--with-plugin "+
                              "env EXAMPLE_DB_KEY=2 EXAMPLE_DB_KEY_OTHER=1 "+
                              "./test/dmtcp1"])
 
+runTest("plugin-init", 1, ["--with-plugin "+
+                             PWD+"/test/libdmtcp_plugin-init.so "+
+                             "./test/dmtcp1"])
+
 # Test special case:  gettimeofday can be handled within VDSO segment.
 runTest("gettimeofday",  1, ["./test/gettimeofday"])
 

--- a/test/plugin-init.cpp
+++ b/test/plugin-init.cpp
@@ -1,0 +1,35 @@
+//File: dmtcp_init_issue.cpp
+#include <iostream>
+#include <sys/types.h>
+#include <unistd.h>
+#include "dmtcp.h"
+void dmtcp_event_hook(DmtcpEvent_t event, DmtcpEventData_t* data)
+{
+  switch (event)
+  {
+    case DMTCP_EVENT_INIT:
+    {
+      /* This next line caused a crash in DMTCP 2.5.2 using g++-6.2.
+       * The call to std::cout invokes libstdc++.so, which calls malloc(),
+       * which calls the DMTCP wrapper for malloc.  The DMTCP malloc()
+       * wrapper then tries to initialize DMTCP before the DmtcpWorker
+       * constructor, and therefore even before libc:malloc() can
+       * be initialized.  At this early stage, DMTCP:malloc() should
+       * simply call libc.so:malloc(), without trying to initialize DMTCP
+       * (which is fixed in DMTCP-2.6.0 and beyond).
+       */
+      std::cout << "DMTCP_EVENT_INIT, PID=" << getpid() << std::endl ;
+      break ;
+    }
+    default:
+    {
+      break ;
+    }
+  }
+}
+
+int main(int argc, char* argv[])
+{
+  // dmtcp_checkpoint() ;
+  while (1);
+}


### PR DESCRIPTION
This test is added to both the master/3.0 and the 2.6 branches.  (See the next PR for details.)

In addition, the 2.6 branch was failing this test, and an additional commit will be added to the 2.6 branch to fix this., in the next PR.