### PR TITLE
Don't initialize DMTCP before libc is initialized (DMTCP-2.6)

### DIFF
--- a/src/plugin/alloc/mallocwrappers.cpp
+++ b/src/plugin/alloc/mallocwrappers.cpp
@@ -34,11 +34,15 @@ extern "C" void *calloc(size_t nmemb, size_t size)
   return retval;
 }
 
+extern "C" int dmtcpInMalloc;
+int dmtcpInMalloc = 0;
 extern "C" void *malloc(size_t size)
 {
+  dmtcpInMalloc = 1;
   DMTCP_PLUGIN_DISABLE_CKPT();
   void *retval = _real_malloc ( size );
   DMTCP_PLUGIN_ENABLE_CKPT();
+  dmtcpInMalloc = 0;
   return retval;
 }
 

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -97,6 +97,12 @@ distclean: clean
 	#${MAKE} -C credentials distclean
 	rm -f Makefile
 
+# plugin-init will call the INIT event in libdmtcp_plugin-init.so
+libdmtcp_plugin-init.so: plugin-init.cpp
+	${CXX} ${CXXFLAGS} -shared -fPIC -o $@ $<
+plugin-init: libdmtcp_plugin-init.so
+	# Don't create executable.  Only the library, above, used on test/sleep1
+
 readline: readline.c
 ifeq ($(HAS_READLINE),yes)
 	$(CC) -o $@ $< $(CFLAGS) $(READLINE_LIBS)

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -775,6 +775,10 @@ runTest("plugin-example-db", 2, ["--with-plugin "+
                              "env EXAMPLE_DB_KEY=2 EXAMPLE_DB_KEY_OTHER=1 "+
                              "./test/dmtcp1"])
 
+runTest("plugin-init", 1, ["--with-plugin "+
+                             PWD+"/test/libdmtcp_plugin-init.so "+
+                             "./test/dmtcp1"])
+
 # Test special case:  gettimeofday can be handled within VDSO segment.
 runTest("gettimeofday",  1, ["./test/gettimeofday"])
 

--- a/test/plugin-init.cpp
+++ b/test/plugin-init.cpp
@@ -1,0 +1,36 @@
+//File: dmtcp_init_issue.cpp
+#include <iostream>
+#include <sys/types.h>
+#include <unistd.h>
+#include "dmtcp.h"
+void dmtcp_event_hook(DmtcpEvent_t event, DmtcpEventData_t* data)
+{
+  switch (event)
+  {
+    case DMTCP_EVENT_INIT:
+    {
+      /* This next line caused a crash in DMTCP 2.5.2 using g++-6.2.
+       * The call to std::cout invokes libstdc++.so, which calls malloc(),
+       * which calls the DMTCP wrapper for malloc.  The DMTCP malloc()
+       * wrapper then tries to initialize DMTCP before the DmtcpWorker
+       * constructor, and therefore even before libc:malloc() can
+       * be initialized.  At this early stage, DMTCP:malloc() should
+       * simply call libc.so:malloc(), without trying to initialize DMTCP
+       * (which is fixed in DMTCP-2.6.0 and beyond).
+       */
+      std::cout << "DMTCP_EVENT_INIT, PID=" << getpid() << std::endl ;
+      break ;
+    }
+    default:
+    {
+      break ;
+    }
+  }
+  DMTCP_NEXT_EVENT_HOOK(event, data);
+}
+
+int main(int argc, char* argv[])
+{
+  // dmtcp_checkpoint() ;
+  while (1);
+}


### PR DESCRIPTION
github wouldn't let me update my branch.  I'll close this and open a new PR with the same name.

This is for the 2.6 branch.  It fixes a bug (isolated to the 2.x branch).  See `test/plugin-init.cpp' comments for an analysis of the bug.  In essence, a call to std::cout at the INIT event causes `dmtcp_initialize()` to be called before libc.so has been initialized.  As a result, a call to libc:malloc() fails.

This bug report was contributed by:

1) Johannes Stoelp
2) Laurent Buchard
3) Pankaj Mehta

from: Synopsys, Inc.