### PR TITLE
Restore floating point env and RLIMIT_NOFILE/STACK (v2)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -148,6 +148,7 @@ __d_libdir__libdmtcp_so_SOURCES = alarm.cpp			\
 				  plugininfo.cpp 		\
 				  pluginmanager.cpp		\
 				  popen.cpp 			\
+				  rlimitfloat.cpp 		\
 				  signalwrappers.cpp 		\
 				  siginfo.cpp 			\
 				  syslogwrappers.cpp 		\

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -185,6 +185,7 @@ am___d_libdir__libdmtcp_so_OBJECTS = alarm.$(OBJEXT) \
 	dmtcpworker.$(OBJEXT) execwrappers.$(OBJEXT) \
 	glibcsystem.$(OBJEXT) miscwrappers.$(OBJEXT) \
 	plugininfo.$(OBJEXT) pluginmanager.$(OBJEXT) popen.$(OBJEXT) \
+	rlimitfloatenv.$(OBJEXT) \
 	signalwrappers.$(OBJEXT) siginfo.$(OBJEXT) \
 	syslogwrappers.$(OBJEXT) terminal.$(OBJEXT) \
 	threadlist.$(OBJEXT) threadsync.$(OBJEXT) \
@@ -227,7 +228,8 @@ am__depfiles_remade = ./$(DEPDIR)/alarm.Po \
 	./$(DEPDIR)/nosyscallsreal.Po ./$(DEPDIR)/plugininfo.Po \
 	./$(DEPDIR)/pluginmanager.Po ./$(DEPDIR)/popen.Po \
 	./$(DEPDIR)/processinfo.Po ./$(DEPDIR)/procselfmaps.Po \
-	./$(DEPDIR)/restartscript.Po ./$(DEPDIR)/shareddata.Po \
+	./$(DEPDIR)/restartscript.Po \
+	./$(DEPDIR)/rlimitfloatenv.Po ./$(DEPDIR)/shareddata.Po \
 	./$(DEPDIR)/siginfo.Po ./$(DEPDIR)/signalwrappers.Po \
 	./$(DEPDIR)/syscallsreal.Po ./$(DEPDIR)/syslogwrappers.Po \
 	./$(DEPDIR)/terminal.Po ./$(DEPDIR)/threadlist.Po \
@@ -628,6 +630,7 @@ __d_libdir__libdmtcp_so_SOURCES = alarm.cpp			\
 				  plugininfo.cpp 		\
 				  pluginmanager.cpp		\
 				  popen.cpp 			\
+				  rlimitfloatenv.cpp 			\
 				  signalwrappers.cpp 		\
 				  siginfo.cpp 			\
 				  syslogwrappers.cpp 		\
@@ -885,6 +888,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/processinfo.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/procselfmaps.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/restartscript.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/rlimitfloatenv.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/shareddata.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/siginfo.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/signalwrappers.Po@am__quote@ # am--include-marker
@@ -1306,6 +1310,7 @@ distclean: distclean-recursive
 	-rm -f ./$(DEPDIR)/processinfo.Po
 	-rm -f ./$(DEPDIR)/procselfmaps.Po
 	-rm -f ./$(DEPDIR)/restartscript.Po
+	-rm -f ./$(DEPDIR)/rlimitfloatenv.Po
 	-rm -f ./$(DEPDIR)/shareddata.Po
 	-rm -f ./$(DEPDIR)/siginfo.Po
 	-rm -f ./$(DEPDIR)/signalwrappers.Po
@@ -1401,6 +1406,7 @@ maintainer-clean: maintainer-clean-recursive
 	-rm -f ./$(DEPDIR)/processinfo.Po
 	-rm -f ./$(DEPDIR)/procselfmaps.Po
 	-rm -f ./$(DEPDIR)/restartscript.Po
+	-rm -f ./$(DEPDIR)/rlimitfloatenv.Po
 	-rm -f ./$(DEPDIR)/shareddata.Po
 	-rm -f ./$(DEPDIR)/siginfo.Po
 	-rm -f ./$(DEPDIR)/signalwrappers.Po

--- a/src/plugin/ipc/ipc.cpp
+++ b/src/plugin/ipc/ipc.cpp
@@ -334,7 +334,7 @@ dup2(int oldfd, int newfd)
     process_fd_event(SYS_dup, oldfd, newfd);
   }
   DMTCP_PLUGIN_ENABLE_CKPT();
-  return newfd;
+  return res;
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)) && __GLIBC_PREREQ(2, 9)

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -23,10 +23,11 @@ dmtcp_register_plugin(DmtcpPluginDescriptor_t descr)
 
 namespace dmtcp
 {
-DmtcpPluginDescriptor_t dmtcp_ProcessInfo_PluginDescr();
 DmtcpPluginDescriptor_t dmtcp_Syslog_PluginDescr();
+DmtcpPluginDescriptor_t dmtcp_Rlimit_Float_PluginDescr();
 DmtcpPluginDescriptor_t dmtcp_Alarm_PluginDescr();
 DmtcpPluginDescriptor_t dmtcp_Terminal_PluginDescr();
+DmtcpPluginDescriptor_t dmtcp_ProcessInfo_PluginDescr();
 
 void
 PluginManager::initialize()
@@ -62,6 +63,7 @@ dmtcp_initialize_plugin()
 {
   // Now register the "in-built" plugins.
   dmtcp_register_plugin(dmtcp_Syslog_PluginDescr());
+  dmtcp_register_plugin(dmtcp_Rlimit_Float_PluginDescr());
   dmtcp_register_plugin(dmtcp_Alarm_PluginDescr());
   dmtcp_register_plugin(dmtcp_Terminal_PluginDescr());
   dmtcp_register_plugin(CoordinatorAPI::pluginDescr());

--- a/src/processinfo.h
+++ b/src/processinfo.h
@@ -66,7 +66,7 @@ class ProcessInfo
     void endPthreadJoin(pthread_t thread);
     void clearPthreadJoinState(pthread_t thread);
 
-    void refresh();
+    void getState();
     void refreshChildTable();
     void setRootOfProcessTree() { _isRootOfProcessTree = true; }
 

--- a/src/rlimitfloatenv.cpp
+++ b/src/rlimitfloatenv.cpp
@@ -1,0 +1,94 @@
+#include <fenv.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include "../jalib/jassert.h"
+#include "shareddata.h"
+#include "util.h"
+#include "config.h"
+#include "dmtcp.h"
+
+/*************************************************************************
+ *
+ *  Save and restore rlimit and float exception settings.
+ *
+ *************************************************************************/
+
+namespace dmtcp
+{
+
+static int roundingMode = -1;
+static fenv_t envp;
+static rlim_t rlim_cur_nofile = 0;
+static rlim_t rlim_cur_stack = 0;
+
+static void
+save_rlimit_float_settings()
+{
+  roundingMode = fegetround();
+  fegetenv(&envp);
+
+  struct rlimit rlim = {0, 0};
+  getrlimit(RLIMIT_NOFILE, &rlim);
+  rlim_cur_nofile = rlim.rlim_cur;
+
+  getrlimit(RLIMIT_STACK, &rlim);
+  rlim_cur_stack = rlim.rlim_cur;
+}
+
+static void
+restore_rlimit_float_settings()
+{
+  fesetenv(&envp);
+  fesetround(roundingMode);
+
+  struct rlimit rlim = {0, 0};
+  getrlimit(RLIMIT_NOFILE, &rlim);
+  JWARNING(rlim_cur_nofile <= rlim.rlim_max)
+    (rlim_cur_nofile) (rlim.rlim_max)
+    .Text("Previous soft limit of RLIMIT_NOFILE lowered to new hard limit");
+  rlim.rlim_cur = MIN(rlim_cur_nofile, rlim.rlim_max);
+  JASSERT(setrlimit(RLIMIT_NOFILE, &rlim) == 0);
+
+  getrlimit(RLIMIT_STACK, &rlim);
+  JWARNING(rlim_cur_stack <= rlim.rlim_max)
+    (rlim_cur_stack) (rlim.rlim_max)
+    .Text("Previous soft limit of RLIMIT_STACK lowered to new hard limit");
+  rlim.rlim_cur = MIN(rlim_cur_stack, rlim.rlim_max);
+  JASSERT(setrlimit(RLIMIT_STACK, &rlim) == 0);
+}
+
+static void
+checkpoint()
+{
+  save_rlimit_float_settings();
+}
+
+static void
+restart()
+{
+  restore_rlimit_float_settings();
+}
+
+static DmtcpBarrier rlimitFloatBarriers[] = {
+  { DMTCP_PRIVATE_BARRIER_PRE_CKPT, checkpoint, "checkpoint" },
+  { DMTCP_PRIVATE_BARRIER_RESTART, restart, "restart" }
+};
+
+static DmtcpPluginDescriptor_t rlimitFloatPlugin = {
+  DMTCP_PLUGIN_API_VERSION,
+  PACKAGE_VERSION,
+  "rlimit_float",
+  "DMTCP",
+  "dmtcp@ccs.neu.edu",
+  "Rlimit/floating point plugin",
+  DMTCP_DECL_BARRIERS(rlimitFloatBarriers),
+  NULL
+};
+
+
+DmtcpPluginDescriptor_t
+dmtcp_Rlimit_Float_PluginDescr()
+{
+  return rlimitFloatPlugin;
+}
+}

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -446,11 +446,40 @@ writememoryarea(int fd, Area *area, int stack_was_seen)
     /* Kernel won't let us munmap this.  But we don't need to restore it. */
     JTRACE("skipping over [stack] segment (not the orig stack)")
       (addr) (area->size);
-  } else if (0 == strcmp(area->name, "[vsyscall]") ||
-             0 == strcmp(area->name, "[vectors]") ||
-             0 == strcmp(area->name, "[vvar]") ||
-             0 == strcmp(area->name, "[vdso]")) {
+  } else if (0 == strcmp(area -> name, "[vsyscall]") ||
+             0 == strcmp(area -> name, "[vectors]") ||
+             0 == strcmp(area -> name, "[vvar]"))
+             // NOTE: We can't trust kernel's "[vdso]" label here.  See below.
+  {
     JTRACE("skipping over memory special section")
+      (area->name) (addr) (area->size);
+  } else if ( area->__addr == ProcessInfo::instance().vdsoStart() ) {
+    //vDSO issue:
+    //    As always, we never want to save the vdso section.  We will use
+    //  the vdso section code provided by the kernel on restart.  Further,
+    //  the user code on restart has already been initialized and so it
+    //  will continue to use the original vdso section determined during
+    //  program launch.  Luckily, during the DMTCP_INIT event, DMTCP recorded
+    //  this vdso address when it called ProcessInfo::instance().init().
+    //    Now, here's the bad news.  During the first restart, the kernel
+    //  may choose to locate the vdso at a new address.  So, in
+    //  src/mtcp/mtcp_restart, DMTCP will mremap the kernel's vdso back
+    //  to the original address known during program launch.  This is as
+    //  it should be.  But when DMTCP does an mremap of vdso, the kernel
+    //  fails to update its own "[vds0]" label.  So, during the second
+    //  checkpoint (after the first restart), we can't trust the "[vdso]"
+    //  label to tell us where the vdso section really is.  And it's even
+    //  worse.  During mtcp_restart, we may have done the mremap, and there
+    //  may even now be some user data that was restored to the address
+    //  where the kernel thinks the "[vdso]" label belongs.  So, we would
+    //  be saving the original vdso section (which is wrong), and we would
+    //  be failing to save the user's memory that was restored into the
+    //  location labelled by the kernel's "[vdso]" label.  This last
+    //  case is even worse, since we have now failed to restore some user data. 
+    //    This was observed to happen in RHEL 6.6.  The solution is to
+    //  trust DMTCP for the vdso location (as in the if condition above),
+    //  and not to trust the kernel's "[vdso]" label.
+    JTRACE("skipping vDSO special section")
       (area->name) (addr) (area->size);
   } else if (area->prot == 0 ||
              (area->name[0] == '\0' &&

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -756,6 +756,8 @@ S=DEFAULT_S
 # Test for normal file, /dev/tty, proc file, and illegal pathname
 runTest("stat",         1, ["./test/stat"])
 
+runTest("rlimit-restore",         1, ["./test/rlimit-restore"])
+
 PWD=os.getcwd()
 runTest("plugin-sleep2", 1, ["--with-plugin "+
                              PWD+"/test/plugin/sleep1/dmtcp_sleep1hijack.so:"+

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -15,6 +15,19 @@ import pwd
 import stat
 import re
 
+
+# FIX for bad path for Java:  Travis prepended
+#     "/usr/bin:/opt/pyenv/libexec:/opt/pyenv/plugins/python-build/bin:/"
+# to os.environ['PATH'] on July 31, 2019.  It does this, even though
+# "/usr/bin" occurs later in the path.  /usr/bin/java exists as Java-8.
+# So, it never finds java (version Java-11) in
+#   "/usr/local/lib/jvm/openjdk11/bin", which occurs later in path.
+# Unfortunately, 'Makefile' finds javac as verion Javac-11,
+# and so the 'java1' test fails, using java (Java-8).
+if os.environ.has_key('PATH') and os.environ['PATH'].startswith('/usr/bin:') \
+     and ':/usr/bin:' in os.environ['PATH']:
+  os.environ['PATH'] = os.environ['PATH'][len('/usr/bin:'):]
+
 parser = argparse.ArgumentParser()
 parser.add_argument('-v', '--verbose',
                     action='store_true',

--- a/test/rlimit-restore.c
+++ b/test/rlimit-restore.c
@@ -1,0 +1,47 @@
+#define _POSIX_C_SOURCE 199309L
+
+#include <stdio.h>
+#include <time.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+
+int main() {
+  struct rlimit rlim_nofile = {0, 0};
+  struct rlimit rlim_stack = {0, 0};
+  rlim_t rlim_cur_nofile = 0;
+  rlim_t rlim_cur_stack = 0;
+
+  getrlimit(RLIMIT_NOFILE, &rlim_nofile);
+  getrlimit(RLIMIT_STACK, &rlim_stack);
+  rlim_cur_nofile = rlim_nofile.rlim_cur;
+  rlim_cur_stack = rlim_stack.rlim_cur;
+  // Reduce resource limits by a small amount.
+  // rlim_nofile.rlim_cur -= 10;
+  rlim_nofile.rlim_cur = rlim_nofile.rlim_max - 10;
+  rlim_stack.rlim_cur += (2 << 20);
+  setrlimit(RLIMIT_NOFILE, &rlim_nofile);
+  setrlimit(RLIMIT_STACK, &rlim_stack);
+
+  struct timespec eighth_second = {0, 2<<26};
+  int i;
+  for (i = 0; ; i++) {
+    getrlimit(RLIMIT_NOFILE, &rlim_nofile);
+    getrlimit(RLIMIT_STACK, &rlim_stack);
+    // Were the current values restored to the original values after restart?
+    if ((rlim_nofile.rlim_cur == rlim_cur_nofile) ||
+        (rlim_stack.rlim_cur == rlim_cur_stack)) {
+      // Yes!  They were.
+      printf("Some resource limits were reset back to the original values!\n"
+             "  original( nofile, stack ): %d, %d\n"
+             "  latest( nofile, stack ):   %d, %d\n",
+             (int)rlim_cur_nofile, (int)rlim_cur_stack,
+             (int)rlim_nofile.rlim_cur, (int)rlim_stack.rlim_cur);
+      return 1; // error 1
+    }
+    nanosleep(& eighth_second, NULL);
+    if (i%8 == 0) {
+      printf("."); fflush(stdout);
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
Continuation of PR #746.  Stupid github has Travis using an incompatible 'java' and 'javac' versions for an obscure reason.  It one does a sanity test to see if an earlier version would pass the Travis test, then github decides to close the pull request because it sees that the most recent push has 0 new commits -- even though no one told it to close the PR.

Let's continue the discussion here, that was started in PR #746.

This version of the PR now adds a third commit to fix Travis's incompatible java vs. javac versions in the presence of Python (see below).