### PR TITLE
SharedData: fixed header packing and member sizes.

### DIFF
--- a/include/shareddata.h
+++ b/include/shareddata.h
@@ -113,29 +113,30 @@ typedef enum {
 } DMTCP_ARCH_MODE;
 
 struct Header {
+  uint64_t initialized;
+
   char tmpDir[PATH_MAX];
   char installDir[PATH_MAX];
 
-  uint32_t initialized;
-  struct in_addr localIPAddr;
+  struct sockaddr_storage localIPAddr;
 
-  int32_t dlsymOffset;
-  int32_t dlsymOffset_m32;
+  int64_t dlsymOffset;
+  int64_t dlsymOffset_m32;
 
-  uint32_t numPidMaps;
-  uint32_t numPtraceIdMaps;
+  uint64_t numPidMaps;
+  uint64_t numPtraceIdMaps;
 
-  uint32_t numSysVShmIdMaps;
-  uint32_t numSysVSemIdMaps;
-  uint32_t numSysVMsqIdMaps;
-  uint32_t numSysVShmKeyMaps;
+  uint64_t numSysVShmIdMaps;
+  uint64_t numSysVSemIdMaps;
+  uint64_t numSysVMsqIdMaps;
+  uint64_t numSysVShmKeyMaps;
 
-  uint32_t numPtyNameMaps;
-  uint32_t nextPtyName;
-  uint32_t nextVirtualPtyId;
+  uint64_t numPtyNameMaps;
+  uint64_t nextPtyName;
+  uint64_t nextVirtualPtyId;
 
-  uint32_t numIncomingConMaps;
-  uint32_t numInodeConnIdMaps;
+  uint64_t numIncomingConMaps;
+  uint64_t numInodeConnIdMaps;
 
   union {
     struct BarrierInfo barrierInfo;
@@ -161,7 +162,7 @@ struct Header {
     uint64_t _pad;
   };
   // char                 coordHost[NI_MAXHOST];
-} __attribute__((packed));
+};
 
 bool initialized();
 

--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -138,7 +138,8 @@ SharedData::initialize(const char *tmpDir = NULL,
     ostringstream o;
     o << tmpDir << "/dmtcpSharedArea."
       << *compId << "." << std::hex << coordInfo->timeStamp;
-    // THIS IS A DUP OF initializeHeader AND OF size, below; Pass this in as an argument to it.
+    // THIS IS A DUP OF initializeHeader AND OF size, below; Pass this in as an
+    // argument to it.
     off_t size = CEIL(SHM_MAX_SIZE, Util::pageSize());
 
     int fd = _real_open(o.str().c_str(), O_RDWR | O_CREAT | O_EXCL, 0600);
@@ -153,7 +154,8 @@ SharedData::initialize(const char *tmpDir = NULL,
         ("Internal error detected! Shared data area already exists.");
       fd = _real_open(o.str().c_str(), O_RDWR, 0600);
     } else {
-      JASSERT( truncate(o.str().c_str(), size) == 0); // extend file to size before 'mmap'
+      // extend file to size before 'mmap'
+      JASSERT( truncate(o.str().c_str(), size) == 0);
       needToInitialize = true;
     }
     JASSERT(fd != -1) (JASSERT_ERRNO);
@@ -563,7 +565,7 @@ void
 SharedData::setIPCIdMap(int type, int32_t virt, int32_t real)
 {
   size_t i;
-  uint32_t *nmaps = NULL;
+  uint64_t *nmaps = NULL;
   IPCIdMap *map = NULL;
 
   if (sharedDataHeader == NULL) {


### PR DESCRIPTION
@rohgarg observed with g++-9.1 that the attribute ` __attribute__((packed))` in shareddata.h causes many warnings and an error:  @karya0 had already developed this commit to solve the problem (as one of two commits in PR #747; but the otehr commit is unrelated to this).  PR #747 was not passing Travis anyway.  This PR isolates this comit as a separate PR.