### PR TITLE
Do not reset the NS database on checkpoint/resume (for 3.0)

### DIFF
--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -562,7 +562,9 @@ DmtcpCoordinator::recordCkptFilename(CoordClient *client, const char *extraData)
       broadcastMessage(DMT_KILL_PEER);
       exitAfterCkptOnce = false;
     } else {
-      lookupService.reset();
+      // On checkpoint/resume, we should not be resetting the lookup service.
+      //   This is absolutely required by the InfiniBand plugin.
+      // lookupService.reset();
     }
     _numRestartFilenames = 0;
     _numCkptWorkers = 0;


### PR DESCRIPTION
This is a port of PR #632 from the 2.6 branch to the master/3.0 branch.

@karya0, could you review this one-line change?  Thanks.  The intention is to avoid resetting the lookup service during a checkpoint/resume.  We do it only during a restart.  (This is what PR #632 was doing.)

The original commit was by @jiajuncao, for the sake of the InfiniBand plugin.  We are now committing his InfiniBand plugin into 3.0/master.
