### PR TITLE
coordinator-api: Fix caching of coordinator host info

### DIFF
--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -51,8 +51,7 @@ namespace CoordinatorAPI {
 const int coordinatorSocket = PROTECTED_COORD_FD;
 int nsSock = -1;
 
-static bool _firstTime = true;
-static string _cachedHost;
+// Shared between getCoordHostAndPort() and setCoordPort()
 static int _cachedPort = 0;
 
 void init();
@@ -129,6 +128,13 @@ restart()
 void
 getCoordHostAndPort(CoordinatorMode mode, string *host, int *port)
 {
+  static bool _firstTime = true;
+  // FIXME:  Could make _cachedHost a 'char[]'.  But then, would
+  //         "*host = _cachedHost;"  replace the string inside *host as needed?
+  //         In particular, if the _cachedHost string object gets destroyed,
+  //         e.g., by a destructor during exit, then this could be a problem.
+  static string _cachedHost;
+
   if (SharedData::initialized()) {
     *host = SharedData::coordHost();
     *port = SharedData::coordPort();
@@ -140,11 +146,19 @@ getCoordHostAndPort(CoordinatorMode mode, string *host, int *port)
     if (*host == "") {
       if (getenv(ENV_VAR_NAME_HOST)) {
         *host = getenv(ENV_VAR_NAME_HOST);
+        _cachedHost = getenv(ENV_VAR_NAME_HOST);
       } else if (getenv("DMTCP_HOST")) { // deprecated
         *host = getenv("DMTCP_HOST");
+        _cachedHost = getenv("DMTCP_HOST");
       } else {
         *host = DEFAULT_HOST;
+        _cachedHost = DEFAULT_HOST;
       }
+    } else {
+      // The caller's string object needs to be valid across
+      // multiple calls to this function, or else, the _cachedHost
+      // pointer will become a dangling pointer.
+      _cachedHost = host->c_str();
     }
 
     // Set port to cmd line (if --coord-port) or env var
@@ -161,7 +175,6 @@ getCoordHostAndPort(CoordinatorMode mode, string *host, int *port)
       }
     }
 
-    _cachedHost = *host;
     _cachedPort = *port;
     _firstTime = false;
   } else {


### PR DESCRIPTION
This is a continuation of PR #728.  See that PR for the details. Since @rohgarg was unavailable to rebase, and then push in the PR, I'm doing it here, while maintaining a commit with his signature.)