### PR TITLE
Polishing test/plugin: README, Makefile

### DIFF
--- a/test/plugin/README
+++ b/test/plugin/README
@@ -26,7 +26,10 @@ example-db:  uses the database service of DMTCP.  At checkpoint or
 	 restart time, each process can install a key-value pair, and then
 	 optionally query a value for a given key.
 applic-initiated-ckpt:  demonstrates how an application can initiate
-         a checkpoint of itself.
+         a checkpoint of itself, using dmtcp_checkpoint().
+applic-delayed-ckpt:  demonstrates how an application can delay
+         a checkpoint during a critical section using:
+         dmtcp_disable_ckpt()/dmtcp_enable_ckpt().
 
 SELF-GUIDED TOUR:
 For a self-guided tour of plugins, try the commands below.  Be sure to stop

--- a/test/plugin/applic-delayed-ckpt/Makefile
+++ b/test/plugin/applic-delayed-ckpt/Makefile
@@ -15,8 +15,8 @@ ifndef DMTCP_ROOT
 endif
 DMTCP_INCLUDE=${DMTCP_ROOT}/include
 
-override CFLAGS += -fPIC -I${DMTCP_INCLUDE}
-override CXXFLAGS += -fPIC -I${DMTCP_INCLUDE}
+override CFLAGS += -I${DMTCP_INCLUDE}
+override CXXFLAGS += -I${DMTCP_INCLUDE}
 LINK = ${CC}
 
 DEMO_PORT=7781
@@ -26,7 +26,7 @@ default: ${LIBNAME}.so applic
 # NOTE:  ${CFLAGS} expands to invoke '-fPIC -I${DMTCP_INCLUDE}'
 #        This is required for use with DMTCP.
 applic: applic.c
-	${CC} ${CFLAGS} -o $@ $< -ldl
+	${CC} -fPIC ${CFLAGS} -o $@ $<
 
 check: ${LIBNAME}.so applic
 	@ echo ""
@@ -53,6 +53,8 @@ check: ${LIBNAME}.so applic
 ${LIBNAME}.so: ${LIBOBJS}
 	${LINK} -shared -fPIC -o $@ $^
 
+${LIBOBJS}: plugin-to-announce-events.c
+	${CC} -fPIC ${CFLAGS} -c -o $@ $<
 .c.o:
 	${CC} ${CFLAGS} -c -o $@ $<
 .cpp.o:

--- a/test/plugin/applic-initiated-ckpt/Makefile
+++ b/test/plugin/applic-initiated-ckpt/Makefile
@@ -15,8 +15,8 @@ ifndef DMTCP_ROOT
 endif
 DMTCP_INCLUDE=${DMTCP_ROOT}/include
 
-override CFLAGS += -fPIC -I${DMTCP_INCLUDE}
-override CXXFLAGS += -fPIC -I${DMTCP_INCLUDE}
+override CFLAGS += -I${DMTCP_INCLUDE}
+override CXXFLAGS += -I${DMTCP_INCLUDE}
 LINK = ${CC}
 
 DEMO_PORT=7781
@@ -26,7 +26,7 @@ default: ${LIBNAME}.so applic
 # NOTE:  ${CFLAGS} expands to invoke '-fPIC -I${DMTCP_INCLUDE}'
 #        This is required for use with DMTCP.
 applic: applic.c
-	${CC} ${CFLAGS} -o $@ $< -ldl
+	${CC} -fPIC ${CFLAGS} -o $@ $<
 
 check: ${LIBNAME}.so applic
 	@ echo ""
@@ -51,6 +51,8 @@ check: ${LIBNAME}.so applic
 ${LIBNAME}.so: ${LIBOBJS}
 	${LINK} -shared -fPIC -o $@ $^
 
+${LIBOBJS}: plugin-to-announce-events.c
+	${CC} -fPIC ${CFLAGS} -c -o $@ $<
 .c.o:
 	${CC} ${CFLAGS} -c -o $@ $<
 .cpp.o:


### PR DESCRIPTION
Easy to review.

Removing unnecessary `-ldl` in Makefile of `applic-initiated-ckpt` and `applic-delayed-ckpt`
(Now that we use our own `dmtcp_get_libc_dlsym_addr()`, we don't depend on libc `dlsym()`.)

Adding missing description in `test/plugin/README`.