### PR TITLE
Added DmtcpMutex and DmtcpRWLock functions.

### DIFF
--- a/configure
+++ b/configure
@@ -7764,10 +7764,12 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $gccAtomicBuiltins" >&5
 $as_echo "$gccAtomicBuiltins" >&6; }
 
-if test "$gccAtomicBuiltins" = "yes"; then
-
-$as_echo "#define HAS_ATOMIC_BUILTINS 1" >>confdefs.h
-
+if test "$gccAtomicBuiltins" = "no"; then
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "Support for atomic built-ins is required to build DMTCP.
+                  Consider using GCC 4.1 or newer.
+See \`config.log' for more details" "$LINENO" 5; }
 fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for __WAIT_STATUS type" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -670,9 +670,9 @@ AC_LINK_IFELSE(
 AC_LANG_POP([C++])
 AC_MSG_RESULT([$gccAtomicBuiltins])
 
-if test "$gccAtomicBuiltins" = "yes"; then
-  AC_DEFINE([HAS_ATOMIC_BUILTINS],[1],
-            [Can use __sync_bool_compare_and_swap(), etc.])
+if test "$gccAtomicBuiltins" = "no"; then
+  AC_MSG_FAILURE([Support for atomic built-ins is required to build DMTCP.
+                  Consider using GCC 4.1 or newer.])
 fi
 dnl Else will use mutex implementation; see jalib/jalloc.cpp
 

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -18,9 +18,6 @@
 /* Child process does checkpointing */
 #undef FORKED_CHECKPOINTING
 
-/* Can use __sync_bool_compare_and_swap(), etc. */
-#undef HAS_ATOMIC_BUILTINS
-
 /* Define to 1 if you have process_vm_readv and process_vm_writev. */
 #undef HAS_CMA
 

--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -133,6 +133,46 @@ typedef enum eDmtcpGetRestartEnvErr {
   RESTART_ENV_NULL_PTR = -5,
 } DmtcpGetRestartEnvErr_t;
 
+typedef enum eDmtcpMutexType
+{
+  DMTCP_MUTEX_NORMAL,
+  DMTCP_MUTEX_RECURSIVE
+} DmtcpMutexType;
+
+typedef struct
+{
+  DmtcpMutexType type;
+  int32_t owner;
+  uint32_t count;
+} DmtcpMutex;
+
+#define DMTCP_MUTEX_INITIALIZER {DMTCP_MUTEX_NORMAL, 0, 0}
+#define DMTCP_MUTEX_INITIALIZER_RECURSIVE {DMTCP_MUTEX_RECURSIVE, 0, 0}
+
+typedef struct
+{
+  int32_t writer;
+  uint32_t nReaders;
+  uint32_t nWritersQueued;
+  uint32_t nReadersQueued;
+  uint32_t writersFutex;
+  uint32_t readersFutex;
+
+  DmtcpMutex xLock;
+} DmtcpRWLock;
+
+void DmtcpMutexInit(DmtcpMutex *mutex, DmtcpMutexType type);
+int DmtcpMutexLock(DmtcpMutex *mutex);
+int DmtcpMutexTryLock(DmtcpMutex *mutex);
+int DmtcpMutexUnlock(DmtcpMutex *mutex);
+
+void DmtcpRWLockInit(DmtcpRWLock *rwlock);
+int DmtcpRWLockRdLock(DmtcpRWLock *rwlock);
+int DmtcpRWLockTryRdLock(DmtcpRWLock *rwlock);
+int DmtcpRWLockWrLock(DmtcpRWLock *rwlock);
+int DmtcpRWLockUnlock(DmtcpRWLock *rwlock);
+
+
 #define   RESTART_ENV_MAXSIZE               12288*10
 
 #define DMTCP_NO_PLUGIN_BARRIERS 0, NULL

--- a/include/futex.h
+++ b/include/futex.h
@@ -1,0 +1,29 @@
+#include <unistd.h>
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+
+static inline int
+futex(uint32_t *uaddr,
+      int futex_op,
+      uint32_t val,
+      const struct timespec *timeout,
+      int *uaddr2,
+      int val3)
+{
+  return syscall(SYS_futex, uaddr, futex_op, val, timeout, uaddr, val3);
+}
+
+
+static inline int
+futex_wait(uint32_t *uaddr, uint32_t old_val)
+{
+  return futex(uaddr, FUTEX_WAIT, old_val, NULL, NULL, 0);
+}
+
+
+static inline int
+futex_wake(uint32_t *uaddr, uint32_t num)
+{
+  return futex(uaddr, FUTEX_WAKE, num, NULL, NULL, 0);
+}

--- a/include/virtualidtable.h
+++ b/include/virtualidtable.h
@@ -30,6 +30,7 @@
 #include "../jalib/jfilesystem.h"
 #include "../jalib/jserialize.h"
 
+#include "dmtcp.h"
 #include "dmtcpalloc.h"
 #include "util.h"
 
@@ -43,12 +44,12 @@ class VirtualIdTable
   protected:
     void _do_lock_tbl()
     {
-      JASSERT(pthread_mutex_lock(&tblLock) == 0) (JASSERT_ERRNO);
+      JASSERT(DmtcpMutexLock(&tblLock) == 0) (JASSERT_ERRNO);
     }
 
     void _do_unlock_tbl()
     {
-      JASSERT(pthread_mutex_unlock(&tblLock) == 0) (JASSERT_ERRNO);
+      JASSERT(DmtcpMutexUnlock(&tblLock) == 0) (JASSERT_ERRNO);
     }
 
   public:
@@ -61,9 +62,7 @@ class VirtualIdTable
 #endif // ifdef JALIB_ALLOCATOR
     VirtualIdTable(string typeStr, IdType base, size_t max = MAX_VIRTUAL_ID)
     {
-      pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
-
-      tblLock = lock;
+      DmtcpMutexInit(&tblLock, DMTCP_MUTEX_NORMAL);
       _do_lock_tbl();
       _idMapTable.clear();
       _do_unlock_tbl();
@@ -116,8 +115,7 @@ class VirtualIdTable
     void resetOnFork(IdType newBase)
     {
       _base = newBase;
-      pthread_mutex_t newlock = PTHREAD_MUTEX_INITIALIZER;
-      tblLock = newlock;
+      DmtcpMutexInit(&tblLock, DMTCP_MUTEX_NORMAL);
       resetNextVirtualId();
     }
 
@@ -310,7 +308,7 @@ class VirtualIdTable
 
   private:
     string _typeStr;
-    pthread_mutex_t tblLock;
+    DmtcpMutex tblLock;
 
   protected:
     typedef typename map<IdType, IdType>::iterator id_iterator;

--- a/jalib/jalib.cpp
+++ b/jalib/jalib.cpp
@@ -171,18 +171,6 @@ syscall(long sys_num, ...)
                                         arg[3], arg[4], arg[5], arg[6]);
 }
 
-void *
-mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
-{
-  REAL_FUNC_PASSTHROUGH(void *, mmap) (addr, length, prot, flags, fd, offset);
-}
-
-int
-munmap(void *addr, size_t length)
-{
-  REAL_FUNC_PASSTHROUGH(int, munmap) (addr, length);
-}
-
 ssize_t
 read(int fd, void *buf, size_t count)
 {

--- a/jalib/jalib.cpp
+++ b/jalib/jalib.cpp
@@ -248,24 +248,6 @@ setsockopt(int s, int level, int optname, const void *optval, socklen_t optlen)
   REAL_FUNC_PASSTHROUGH(int, setsockopt) (s, level, optname, optval, optlen);
 }
 
-int
-pthread_mutex_lock(pthread_mutex_t *mutex)
-{
-  REAL_FUNC_PASSTHROUGH(int, pthread_mutex_lock) (mutex);
-}
-
-int
-pthread_mutex_trylock(pthread_mutex_t *mutex)
-{
-  REAL_FUNC_PASSTHROUGH(int, pthread_mutex_trylock) (mutex);
-}
-
-int
-pthread_mutex_unlock(pthread_mutex_t *mutex)
-{
-  REAL_FUNC_PASSTHROUGH(int, pthread_mutex_unlock) (mutex);
-}
-
 ssize_t
 writeAll(int fd, const void *buf, size_t count)
 {

--- a/jalib/jalib.h
+++ b/jalib/jalib.h
@@ -41,9 +41,6 @@ typedef struct JalibFuncPtrs {
   ssize_t (*readlink)(const char *path, char *buf, size_t bufsiz);
 
   long (*syscall)(long sys_num, ...);
-  void *    (*mmap)(void *addr, size_t length, int prot, int flags, int fd,
-                    off_t offset);
-  int (*munmap)(void *addr, size_t length);
 
   ssize_t (*read)(int fd, void *buf, size_t count);
   ssize_t (*write)(int fd, const void *buf, size_t count);
@@ -78,9 +75,6 @@ int dup2(int oldfd, int newfd);
 ssize_t readlink(const char *path, char *buf, size_t bufsiz);
 
 long syscall(long sys_num, ...);
-void *mmap(void *addr, size_t length, int prot, int flags, int fd,
-           off_t offset);
-int munmap(void *addr, size_t length);
 
 ssize_t read(int fd, void *buf, size_t count);
 ssize_t write(int fd, const void *buf, size_t count);

--- a/jalib/jalib.h
+++ b/jalib/jalib.h
@@ -58,10 +58,6 @@ typedef struct JalibFuncPtrs {
   int (*accept)(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
   int (*setsockopt)(int s, int level, int optname, const void *optval,
                     socklen_t optlen);
-  int (*pthread_mutex_lock)(pthread_mutex_t *mutex);
-  int (*pthread_mutex_trylock)(pthread_mutex_t *mutex);
-  int (*pthread_mutex_unlock)(pthread_mutex_t *mutex);
-
   ssize_t (*writeAll)(int fd, const void *buf, size_t count);
   ssize_t (*readAll)(int fd, void *buf, size_t count);
 } JalibFuncPtrs;
@@ -105,9 +101,6 @@ int setsockopt(int s,
                int optname,
                const void *optval,
                socklen_t optlen);
-int pthread_mutex_lock(pthread_mutex_t *mutex);
-int pthread_mutex_trylock(pthread_mutex_t *mutex);
-int pthread_mutex_unlock(pthread_mutex_t *mutex);
 
 ssize_t writeAll(int fd, const void *buf, size_t count);
 ssize_t readAll(int fd, void *buf, size_t count);

--- a/jalib/jalloc.cpp
+++ b/jalib/jalloc.cpp
@@ -19,7 +19,6 @@
  *  <http://www.gnu.org/licenses/>.                                         *
  ****************************************************************************/
 
-#include "config.h" /* For HAS_ATOMIC_BUILTINS */
 #include "jalib.h"
 #include "jalloc.h"
 #include <pthread.h>
@@ -43,29 +42,6 @@ static bool _initialized = false;
 
 namespace jalib
 {
-# ifndef HAS_ATOMIC_BUILTINS
-
-// We'll use critical section instead of atomic builtins.
-// Hopefully, all changes to the variables go through this critical section
-
-static pthread_mutex_t sync_mutex = PTHREAD_MUTEX_INITIALIZER;
-
-template<typename T>
-static bool
-__sync_bool_compare_and_swap(
-  T volatile *ptr, T oldval, T newval)
-{
-  bool retval = false;
-  jalib::pthread_mutex_lock(&sync_mutex);
-
-  if (*ptr == oldval) {
-    *ptr = newval;
-    retval = true;
-  }
-  jalib::pthread_mutex_unlock(&sync_mutex);
-  return retval;
-}
-# endif // ifndef HAS_ATOMIC_BUILTINS
 
 inline void *
 _alloc_raw(size_t n)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -148,7 +148,7 @@ __d_libdir__libdmtcp_so_SOURCES = alarm.cpp			\
 				  plugininfo.cpp 		\
 				  pluginmanager.cpp		\
 				  popen.cpp 			\
-				  rlimitfloat.cpp 		\
+				  rlimitfloatenv.cpp 		\
 				  signalwrappers.cpp 		\
 				  siginfo.cpp 			\
 				  syslogwrappers.cpp 		\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -95,6 +95,7 @@ nobase_noinst_HEADERS += $(jalibdir)/jalib.h			\
 
 nobase_noinst_HEADERS += $(dmtcpincludedir)/dmtcp.h		\
 			 $(dmtcpincludedir)/dmtcpalloc.h	\
+			 $(dmtcpincludedir)/futex.h		\
 			 $(dmtcpincludedir)/procmapsarea.h	\
 			 $(dmtcpincludedir)/procselfmaps.h	\
 			 $(dmtcpincludedir)/protectedfds.h	\
@@ -111,8 +112,10 @@ libdmtcpinternal_a_SOURCES = coordinatorapi.cpp 		\
 			     dmtcpmessagetypes.cpp		\
 			     dmtcp_dlsym.cpp 			\
 			     jalibinterface.cpp			\
+			     mutex.cpp 				\
 			     processinfo.cpp 			\
 			     procselfmaps.cpp			\
+			     rwlock.cpp 			\
 			     shareddata.cpp 			\
 			     tokenize.cpp			\
 			     uniquepid.cpp			\

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -185,9 +185,8 @@ am___d_libdir__libdmtcp_so_OBJECTS = alarm.$(OBJEXT) \
 	dmtcpworker.$(OBJEXT) execwrappers.$(OBJEXT) \
 	glibcsystem.$(OBJEXT) miscwrappers.$(OBJEXT) \
 	plugininfo.$(OBJEXT) pluginmanager.$(OBJEXT) popen.$(OBJEXT) \
-	rlimitfloatenv.$(OBJEXT) \
-	signalwrappers.$(OBJEXT) siginfo.$(OBJEXT) \
-	syslogwrappers.$(OBJEXT) terminal.$(OBJEXT) \
+	rlimitfloatenv.$(OBJEXT) signalwrappers.$(OBJEXT) \
+	siginfo.$(OBJEXT) syslogwrappers.$(OBJEXT) terminal.$(OBJEXT) \
 	threadlist.$(OBJEXT) threadsync.$(OBJEXT) \
 	threadwrappers.$(OBJEXT) writeckpt.$(OBJEXT)
 __d_libdir__libdmtcp_so_OBJECTS =  \
@@ -228,16 +227,16 @@ am__depfiles_remade = ./$(DEPDIR)/alarm.Po \
 	./$(DEPDIR)/nosyscallsreal.Po ./$(DEPDIR)/plugininfo.Po \
 	./$(DEPDIR)/pluginmanager.Po ./$(DEPDIR)/popen.Po \
 	./$(DEPDIR)/processinfo.Po ./$(DEPDIR)/procselfmaps.Po \
-	./$(DEPDIR)/restartscript.Po \
-	./$(DEPDIR)/rlimitfloatenv.Po ./$(DEPDIR)/shareddata.Po \
-	./$(DEPDIR)/siginfo.Po ./$(DEPDIR)/signalwrappers.Po \
-	./$(DEPDIR)/syscallsreal.Po ./$(DEPDIR)/syslogwrappers.Po \
-	./$(DEPDIR)/terminal.Po ./$(DEPDIR)/threadlist.Po \
-	./$(DEPDIR)/threadsync.Po ./$(DEPDIR)/threadwrappers.Po \
-	./$(DEPDIR)/tokenize.Po ./$(DEPDIR)/trampolines.Po \
-	./$(DEPDIR)/uniquepid.Po ./$(DEPDIR)/util_exec.Po \
-	./$(DEPDIR)/util_init.Po ./$(DEPDIR)/util_misc.Po \
-	./$(DEPDIR)/workerstate.Po ./$(DEPDIR)/writeckpt.Po
+	./$(DEPDIR)/restartscript.Po ./$(DEPDIR)/rlimitfloatenv.Po \
+	./$(DEPDIR)/shareddata.Po ./$(DEPDIR)/siginfo.Po \
+	./$(DEPDIR)/signalwrappers.Po ./$(DEPDIR)/syscallsreal.Po \
+	./$(DEPDIR)/syslogwrappers.Po ./$(DEPDIR)/terminal.Po \
+	./$(DEPDIR)/threadlist.Po ./$(DEPDIR)/threadsync.Po \
+	./$(DEPDIR)/threadwrappers.Po ./$(DEPDIR)/tokenize.Po \
+	./$(DEPDIR)/trampolines.Po ./$(DEPDIR)/uniquepid.Po \
+	./$(DEPDIR)/util_exec.Po ./$(DEPDIR)/util_init.Po \
+	./$(DEPDIR)/util_misc.Po ./$(DEPDIR)/workerstate.Po \
+	./$(DEPDIR)/writeckpt.Po
 am__mv = mv -f
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
@@ -630,7 +629,7 @@ __d_libdir__libdmtcp_so_SOURCES = alarm.cpp			\
 				  plugininfo.cpp 		\
 				  pluginmanager.cpp		\
 				  popen.cpp 			\
-				  rlimitfloatenv.cpp 			\
+				  rlimitfloatenv.cpp 		\
 				  signalwrappers.cpp 		\
 				  siginfo.cpp 			\
 				  syslogwrappers.cpp 		\

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -131,10 +131,10 @@ libdmtcpinternal_a_AR = $(AR) $(ARFLAGS)
 libdmtcpinternal_a_LIBADD =
 am_libdmtcpinternal_a_OBJECTS = coordinatorapi.$(OBJEXT) \
 	dmtcpmessagetypes.$(OBJEXT) dmtcp_dlsym.$(OBJEXT) \
-	jalibinterface.$(OBJEXT) processinfo.$(OBJEXT) \
-	procselfmaps.$(OBJEXT) shareddata.$(OBJEXT) tokenize.$(OBJEXT) \
-	uniquepid.$(OBJEXT) util_exec.$(OBJEXT) util_init.$(OBJEXT) \
-	util_misc.$(OBJEXT) workerstate.$(OBJEXT)
+	jalibinterface.$(OBJEXT) mutex.$(OBJEXT) processinfo.$(OBJEXT) \
+	procselfmaps.$(OBJEXT) rwlock.$(OBJEXT) shareddata.$(OBJEXT) \
+	tokenize.$(OBJEXT) uniquepid.$(OBJEXT) util_exec.$(OBJEXT) \
+	util_init.$(OBJEXT) util_misc.$(OBJEXT) workerstate.$(OBJEXT)
 libdmtcpinternal_a_OBJECTS = $(am_libdmtcpinternal_a_OBJECTS)
 libjalib_a_AR = $(AR) $(ARFLAGS)
 libjalib_a_LIBADD =
@@ -224,10 +224,11 @@ am__depfiles_remade = ./$(DEPDIR)/alarm.Po \
 	./$(DEPDIR)/jfilesystem.Po ./$(DEPDIR)/jserialize.Po \
 	./$(DEPDIR)/jsocket.Po ./$(DEPDIR)/jtimer.Po \
 	./$(DEPDIR)/lookup_service.Po ./$(DEPDIR)/miscwrappers.Po \
-	./$(DEPDIR)/nosyscallsreal.Po ./$(DEPDIR)/plugininfo.Po \
-	./$(DEPDIR)/pluginmanager.Po ./$(DEPDIR)/popen.Po \
-	./$(DEPDIR)/processinfo.Po ./$(DEPDIR)/procselfmaps.Po \
-	./$(DEPDIR)/restartscript.Po ./$(DEPDIR)/rlimitfloatenv.Po \
+	./$(DEPDIR)/mutex.Po ./$(DEPDIR)/nosyscallsreal.Po \
+	./$(DEPDIR)/plugininfo.Po ./$(DEPDIR)/pluginmanager.Po \
+	./$(DEPDIR)/popen.Po ./$(DEPDIR)/processinfo.Po \
+	./$(DEPDIR)/procselfmaps.Po ./$(DEPDIR)/restartscript.Po \
+	./$(DEPDIR)/rlimitfloatenv.Po ./$(DEPDIR)/rwlock.Po \
 	./$(DEPDIR)/shareddata.Po ./$(DEPDIR)/siginfo.Po \
 	./$(DEPDIR)/signalwrappers.Po ./$(DEPDIR)/syscallsreal.Po \
 	./$(DEPDIR)/syslogwrappers.Po ./$(DEPDIR)/terminal.Po \
@@ -576,7 +577,7 @@ nobase_noinst_HEADERS = barrierinfo.h ckptserializer.h constants.h \
 	$(jalibdir)/jfilesystem.h $(jalibdir)/jserialize.h \
 	$(jalibdir)/jsocket.h $(jalibdir)/jtimer.h \
 	$(dmtcpincludedir)/dmtcp.h $(dmtcpincludedir)/dmtcpalloc.h \
-	$(dmtcpincludedir)/procmapsarea.h \
+	$(dmtcpincludedir)/futex.h $(dmtcpincludedir)/procmapsarea.h \
 	$(dmtcpincludedir)/procselfmaps.h \
 	$(dmtcpincludedir)/protectedfds.h \
 	$(dmtcpincludedir)/shareddata.h \
@@ -591,8 +592,10 @@ libdmtcpinternal_a_SOURCES = coordinatorapi.cpp 		\
 			     dmtcpmessagetypes.cpp		\
 			     dmtcp_dlsym.cpp 			\
 			     jalibinterface.cpp			\
+			     mutex.cpp 				\
 			     processinfo.cpp 			\
 			     procselfmaps.cpp			\
+			     rwlock.cpp 			\
 			     shareddata.cpp 			\
 			     tokenize.cpp			\
 			     uniquepid.cpp			\
@@ -880,6 +883,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/jtimer.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/lookup_service.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/miscwrappers.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/mutex.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/nosyscallsreal.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/plugininfo.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/pluginmanager.Po@am__quote@ # am--include-marker
@@ -888,6 +892,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/procselfmaps.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/restartscript.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/rlimitfloatenv.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/rwlock.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/shareddata.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/siginfo.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/signalwrappers.Po@am__quote@ # am--include-marker
@@ -1302,6 +1307,7 @@ distclean: distclean-recursive
 	-rm -f ./$(DEPDIR)/jtimer.Po
 	-rm -f ./$(DEPDIR)/lookup_service.Po
 	-rm -f ./$(DEPDIR)/miscwrappers.Po
+	-rm -f ./$(DEPDIR)/mutex.Po
 	-rm -f ./$(DEPDIR)/nosyscallsreal.Po
 	-rm -f ./$(DEPDIR)/plugininfo.Po
 	-rm -f ./$(DEPDIR)/pluginmanager.Po
@@ -1310,6 +1316,7 @@ distclean: distclean-recursive
 	-rm -f ./$(DEPDIR)/procselfmaps.Po
 	-rm -f ./$(DEPDIR)/restartscript.Po
 	-rm -f ./$(DEPDIR)/rlimitfloatenv.Po
+	-rm -f ./$(DEPDIR)/rwlock.Po
 	-rm -f ./$(DEPDIR)/shareddata.Po
 	-rm -f ./$(DEPDIR)/siginfo.Po
 	-rm -f ./$(DEPDIR)/signalwrappers.Po
@@ -1398,6 +1405,7 @@ maintainer-clean: maintainer-clean-recursive
 	-rm -f ./$(DEPDIR)/jtimer.Po
 	-rm -f ./$(DEPDIR)/lookup_service.Po
 	-rm -f ./$(DEPDIR)/miscwrappers.Po
+	-rm -f ./$(DEPDIR)/mutex.Po
 	-rm -f ./$(DEPDIR)/nosyscallsreal.Po
 	-rm -f ./$(DEPDIR)/plugininfo.Po
 	-rm -f ./$(DEPDIR)/pluginmanager.Po
@@ -1406,6 +1414,7 @@ maintainer-clean: maintainer-clean-recursive
 	-rm -f ./$(DEPDIR)/procselfmaps.Po
 	-rm -f ./$(DEPDIR)/restartscript.Po
 	-rm -f ./$(DEPDIR)/rlimitfloatenv.Po
+	-rm -f ./$(DEPDIR)/rwlock.Po
 	-rm -f ./$(DEPDIR)/shareddata.Po
 	-rm -f ./$(DEPDIR)/siginfo.Po
 	-rm -f ./$(DEPDIR)/signalwrappers.Po

--- a/src/execwrappers.cpp
+++ b/src/execwrappers.cpp
@@ -152,7 +152,6 @@ pthread_atfork_child()
   UniquePid parent = UniquePid::ThisProcess();
   UniquePid child = UniquePid(host, getpid(), child_time);
   string child_name = jalib::Filesystem::GetProgramName() + "_(forked)";
-  _dmtcp_remutex_on_fork();
   ThreadSync::resetLocks();
 
   UniquePid::resetOnFork(child);

--- a/src/jalibinterface.cpp
+++ b/src/jalibinterface.cpp
@@ -47,8 +47,6 @@ initializeJalib()
   INIT_JALIB_FPTR(readlink);
 
   INIT_JALIB_FPTR(syscall);
-  INIT_JALIB_FPTR(mmap);
-  INIT_JALIB_FPTR(munmap);
 
   INIT_JALIB_FPTR(read);
   INIT_JALIB_FPTR(write);

--- a/src/jalibinterface.cpp
+++ b/src/jalibinterface.cpp
@@ -62,10 +62,6 @@ initializeJalib()
   INIT_JALIB_FPTR(accept);
   INIT_JALIB_FPTR(setsockopt);
 
-  INIT_JALIB_FPTR(pthread_mutex_lock);
-  INIT_JALIB_FPTR(pthread_mutex_trylock);
-  INIT_JALIB_FPTR(pthread_mutex_unlock);
-
   jalib_init(jalibFuncPtrs,
              ELF_INTERPRETER,
              PROTECTED_STDERR_FD,

--- a/src/miscwrappers.cpp
+++ b/src/miscwrappers.cpp
@@ -655,59 +655,6 @@ syscall(long sys_num, ...)
   return ret;
 }
 
-#ifdef ENABLE_PTHREAD_COND_WRAPPERS
-// TODO: Move these to a separate pthreadwrappers.cpp file.
-extern "C" int
-pthread_cond_broadcast(pthread_cond_t *cond)
-{
-  return _real_pthread_cond_broadcast(cond);
-}
-
-extern "C" int
-pthread_cond_destroy(pthread_cond_t *cond)
-{
-  return _real_pthread_cond_destroy(cond);
-}
-
-extern "C" int
-pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr)
-{
-  return _real_pthread_cond_init(cond, attr);
-}
-
-extern "C" int
-pthread_cond_signal(pthread_cond_t *cond)
-{
-  return _real_pthread_cond_signal(cond);
-}
-
-extern "C" int
-pthread_cond_timedwait(pthread_cond_t *cond,
-                       pthread_mutex_t *mutex,
-                       const struct timespec *abstime)
-{
-  return _real_pthread_cond_timedwait(cond, mutex, abstime);
-}
-
-extern "C" int
-pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
-{
-  return _real_pthread_cond_wait(cond, mutex);
-}
-
-extern "C" int
-pthread_mutex_lock(pthread_mutex_t *mutex)
-{
-  return _real_pthread_mutex_lock(mutex);
-}
-
-extern "C" int
-pthread_mutex_unlock(pthread_mutex_t *mutex)
-{
-  return _real_pthread_mutex_unlock(mutex);
-}
-#endif // #ifdef ENABLE_PTHREAD_COND_WRAPPERS
-
 /*
 extern "C" int
 printf (const char *format, ...)

--- a/src/mutex.cpp
+++ b/src/mutex.cpp
@@ -1,0 +1,93 @@
+#include "dmtcp.h"
+#include "futex.h"
+#include "jassert.h"
+#include "syscallwrappers.h"
+
+
+static const int zero = 0;
+
+/*
+ * Mutex
+ */
+
+extern "C"
+void DmtcpMutexInit(DmtcpMutex *mutex, DmtcpMutexType type)
+{
+  mutex->type = type;
+  mutex->owner = 0;
+  mutex->count = 0;
+}
+
+
+extern "C"
+int DmtcpMutexLock(DmtcpMutex *mutex)
+{
+  if (mutex->owner == dmtcp_gettid()) {
+    if (mutex->type == DMTCP_MUTEX_RECURSIVE) {
+      JASSERT(mutex->count + 1 != 0);
+      mutex->count++;
+      return 0;
+    }
+    return EDEADLK;
+  }
+
+  while (1) {
+    uint32_t waitVal = __sync_val_compare_and_swap((uint32_t*) &mutex->owner,
+                                                   0,
+                                                   dmtcp_gettid());
+    if (waitVal == 0) {
+      // We successfully acquired the lock.
+      break;
+    }
+
+    int s = futex_wait((uint32_t*) &mutex->owner, waitVal);
+    JASSERT (s != -1 || errno == EAGAIN) (JASSERT_ERRNO);
+  }
+
+  JASSERT(mutex->owner == dmtcp_gettid());
+  mutex->count = 1;
+
+  return 0;
+}
+
+
+extern "C"
+int DmtcpMutexTryLock(DmtcpMutex *mutex)
+{
+  if (mutex->owner == dmtcp_gettid()) {
+    if (mutex->type == DMTCP_MUTEX_RECURSIVE) {
+      JASSERT(mutex->count + 1 != 0);
+      mutex->count++;
+      return 0;
+    }
+    return EDEADLK;
+  }
+
+  if (__sync_bool_compare_and_swap((uint32_t*) &mutex->owner,
+                                   0,
+                                   dmtcp_gettid())) {
+    JASSERT(mutex->owner == dmtcp_gettid());
+    mutex->count = 1;
+    return 0;
+  }
+
+  return EAGAIN;
+}
+
+
+extern "C"
+int DmtcpMutexUnlock(DmtcpMutex *mutex)
+{
+  JASSERT(mutex->owner == dmtcp_gettid());
+
+  mutex->count--;
+
+  if (mutex->count == 0) {
+    mutex->owner = 0;
+
+    // TODO(Kapil): Call futex_wake only if there are futex waiters.
+    JASSERT(futex_wake((uint32_t*) &mutex->owner, 1) != -1) (JASSERT_ERRNO);
+  }
+
+  return 0;
+}

--- a/src/nosyscallsreal.c
+++ b/src/nosyscallsreal.c
@@ -392,21 +392,6 @@ _real_ioctl(int d, unsigned long int request, ...)
   REAL_FUNC_PASSTHROUGH_TYPED(int, ioctl) (d, request, arg);
 }
 
-LIB_PRIVATE
-void *
-_real_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(void *, mmap) (addr, length, prot, flags, fd,
-                                             offset);
-}
-
-LIB_PRIVATE
-int
-_real_munmap(void *addr, size_t length)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, munmap) (addr, length);
-}
-
 // Needed for _real_gettid, etc.
 long
 _real_syscall(long sys_num, ...)

--- a/src/nosyscallsreal.c
+++ b/src/nosyscallsreal.c
@@ -30,8 +30,6 @@
 // this extra declaration.
 #define FOR_SYSCALLSREAL_C
 
-#include <pthread.h>
-
 // We should not need dlopen/dlsym
 // #include <dlfcn.h>
 #include <ctype.h>
@@ -98,42 +96,6 @@
 
 void
 initialize_wrappers() {}
-
-int
-_real_pthread_mutex_lock(pthread_mutex_t *mutex)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_mutex_lock) (mutex);
-}
-
-int
-_real_pthread_mutex_trylock(pthread_mutex_t *mutex)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_mutex_trylock) (mutex);
-}
-
-int
-_real_pthread_mutex_unlock(pthread_mutex_t *mutex)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_mutex_unlock) (mutex);
-}
-
-int
-_real_pthread_rwlock_unlock(pthread_rwlock_t *rwlock)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_rwlock_unlock) (rwlock);
-}
-
-int
-_real_pthread_rwlock_rdlock(pthread_rwlock_t *rwlock)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_rwlock_rdlock) (rwlock);
-}
-
-int
-_real_pthread_rwlock_wrlock(pthread_rwlock_t *rwlock)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_rwlock_wrlock) (rwlock);
-}
 
 ssize_t
 _real_read(int fd, void *buf, size_t count)

--- a/src/nosyscallsreal.c
+++ b/src/nosyscallsreal.c
@@ -77,8 +77,6 @@
 //// DEFINE REAL VERSIONS OF NEEDED FUNCTIONS (based on syscallsreal.cpp)
 //// (Define only functions needed for dmtcp_launch, dmtcp_restart, etc.
 
-static pthread_mutex_t theMutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
-
 #define REAL_FUNC_PASSTHROUGH(name)       return name
 
 #define REAL_FUNC_PASSTHROUGH_TYPED(type, \
@@ -97,12 +95,6 @@ static pthread_mutex_t theMutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
                   "  Symbol %s not found!\n", # name); \
   abort();                                             \
   return -1;
-
-void
-_dmtcp_lock() { pthread_mutex_lock(&theMutex); }
-
-void
-_dmtcp_unlock() { pthread_mutex_unlock(&theMutex); }
 
 void
 initialize_wrappers() {}

--- a/src/plugin/ipc/connectionlist.cpp
+++ b/src/plugin/ipc/connectionlist.cpp
@@ -140,8 +140,7 @@ _isBadFd(int fd)
 void
 ConnectionList::resetOnFork()
 {
-  JASSERT(pthread_mutex_destroy(&_lock) == 0) (JASSERT_ERRNO);
-  JASSERT(pthread_mutex_init(&_lock, NULL) == 0) (JASSERT_ERRNO);
+  DmtcpMutexInit(&_lock, DMTCP_MUTEX_NORMAL);
 }
 
 void

--- a/src/plugin/ipc/connectionlist.h
+++ b/src/plugin/ipc/connectionlist.h
@@ -23,7 +23,6 @@
 #ifndef CONNECTIONLIST_H
 # define CONNECTIONLIST_H
 
-#include <pthread.h>
 #include "jalloc.h"
 #include "jserialize.h"
 #include "connection.h"
@@ -47,7 +46,7 @@ class ConnectionList
     ConnectionList()
     {
       numIncomingCons = 0;
-      JASSERT(pthread_mutex_init(&_lock, NULL) == 0);
+      DmtcpMutexInit(&_lock, DMTCP_MUTEX_NORMAL);
     }
 
     virtual ~ConnectionList();
@@ -103,15 +102,15 @@ class ConnectionList
     void processCloseWork(int fd);
     void _lock_tbl()
     {
-      JASSERT(_real_pthread_mutex_lock(&_lock) == 0) (JASSERT_ERRNO);
+      JASSERT(DmtcpMutexLock(&_lock) == 0);
     }
 
     void _unlock_tbl()
     {
-      JASSERT(_real_pthread_mutex_unlock(&_lock) == 0) (JASSERT_ERRNO);
+      JASSERT(DmtcpMutexUnlock(&_lock) == 0);
     }
 
-    pthread_mutex_t _lock;
+    DmtcpMutex _lock;
     typedef map<ConnectionIdentifier, Connection *>ConnectionMapT;
     ConnectionMapT _connections;
 

--- a/src/plugin/ipc/file/fileconnlist.cpp
+++ b/src/plugin/ipc/file/fileconnlist.cpp
@@ -330,9 +330,9 @@ FileConnList::prepareShmList()
            * the second checkpoint cycle, the area was again unmapped and later
            * JALLOC tried to access it, causing a SIGSEGV.
            */
-          JASSERT(_real_mmap(area.addr, area.size, PROT_NONE,
-                             MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED,
-                             -1, 0) != MAP_FAILED) (JASSERT_ERRNO);
+          JASSERT(mmap(area.addr, area.size, PROT_NONE,
+                       MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED,
+                       -1, 0) != MAP_FAILED) (JASSERT_ERRNO);
         } else {
           JTRACE("Will not checkpoint shared memory area") (area.name);
         }
@@ -411,8 +411,8 @@ FileConnList::restoreShmArea(const ProcMapsArea &area, int fd)
   JASSERT(fd != -1) (area.name) (JASSERT_ERRNO);
 
   JTRACE("Restoring shared memory area") (area.name) ((void *)area.addr);
-  void *addr = _real_mmap(area.addr, area.size, area.prot,
-                          MAP_FIXED | area.flags, fd, area.offset);
+  void *addr = mmap(area.addr, area.size, area.prot,
+                    MAP_FIXED | area.flags, fd, area.offset);
   JASSERT(addr != MAP_FAILED) (area.flags) (area.prot) (JASSERT_ERRNO)
   .Text("mmap failed");
   _real_close(fd);
@@ -426,9 +426,8 @@ FileConnList::remapShmMaps()
     FileConnection *fileCon = shmAreaConn[i];
     int fd = fileCon->getFds()[0];
     JTRACE("Restoring shared memory area") (area->name) ((void *)area->addr);
-    void *addr = _real_mmap(area->addr, area->size, area->prot,
-                            MAP_FIXED | area->flags,
-                            fd, area->offset);
+    void *addr = mmap(area->addr, area->size, area->prot,
+                      MAP_FIXED | area->flags, fd, area->offset);
     JASSERT(addr != MAP_FAILED) (area->flags) (area->prot) (JASSERT_ERRNO).Text(
       "mmap failed");
     _real_close(fd);

--- a/src/plugin/ipc/file/filewrappers.h
+++ b/src/plugin/ipc/file/filewrappers.h
@@ -60,6 +60,4 @@
 # define _real_fcntl           NEXT_FNC(fcntl)
 
 # define _real_system          NEXT_FNC(system)
-# define _real_mmap            NEXT_FNC(mmap)
-# define _real_munmap          NEXT_FNC(munmap)
 #endif // FILE_WRAPPERS_H

--- a/src/plugin/ipc/ipc.h
+++ b/src/plugin/ipc/ipc.h
@@ -53,6 +53,4 @@
 # define _real_fcntl                NEXT_FNC(fcntl)
 # define _real_select               NEXT_FNC(select)
 # define _real_poll                 NEXT_FNC(poll)
-# define _real_pthread_mutex_lock   NEXT_FNC(pthread_mutex_lock)
-# define _real_pthread_mutex_unlock NEXT_FNC(pthread_mutex_unlock)
 #endif // ifndef DMTCP_IPC_H

--- a/src/plugin/svipc/sysvipc.cpp
+++ b/src/plugin/svipc/sysvipc.cpp
@@ -89,7 +89,7 @@ using namespace dmtcp;
 /* TODO: Handle the case when the segment is marked for removal at ckpt time.
  */
 
-static pthread_mutex_t tblLock = PTHREAD_MUTEX_INITIALIZER;
+static DmtcpMutex tblLock = DMTCP_MUTEX_INITIALIZER;
 
 static void
 preCheckpoint()
@@ -218,13 +218,13 @@ DMTCP_DECL_PLUGIN(sysvipcPlugin);
 static void
 _do_lock_tbl()
 {
-  JASSERT(_real_pthread_mutex_lock(&tblLock) == 0) (JASSERT_ERRNO);
+  JASSERT(DmtcpMutexLock(&tblLock) == 0) (JASSERT_ERRNO);
 }
 
 static void
 _do_unlock_tbl()
 {
-  JASSERT(_real_pthread_mutex_unlock(&tblLock) == 0) (JASSERT_ERRNO);
+  JASSERT(DmtcpMutexUnlock(&tblLock) == 0) (JASSERT_ERRNO);
 }
 
 static void

--- a/src/plugin/svipc/sysvipcwrappers.h
+++ b/src/plugin/svipc/sysvipcwrappers.h
@@ -40,8 +40,5 @@
 # define _real_msgsnd               NEXT_FNC(msgsnd)
 # define _real_msgrcv               NEXT_FNC(msgrcv)
 
-# define _real_pthread_mutex_lock   NEXT_FNC(pthread_mutex_lock)
-# define _real_pthread_mutex_unlock NEXT_FNC(pthread_mutex_unlock)
-
 # define _real_dlsym                NEXT_FNC(dlsym)
 #endif // ifndef SYSVIPC_WRAPPERS_H

--- a/src/plugin/timer/timerlist.cpp
+++ b/src/plugin/timer/timerlist.cpp
@@ -29,17 +29,17 @@ using namespace dmtcp;
 
 static TimerList *_timerlist = NULL;
 
-static pthread_mutex_t timerLock = PTHREAD_MUTEX_INITIALIZER;
+static DmtcpMutex timerLock = DMTCP_MUTEX_INITIALIZER;
 static void
 _do_lock_tbl()
 {
-  JASSERT(_real_pthread_mutex_lock(&timerLock) == 0) (JASSERT_ERRNO);
+  JASSERT(DmtcpMutexLock(&timerLock) == 0) (JASSERT_ERRNO);
 }
 
 static void
 _do_unlock_tbl()
 {
-  JASSERT(_real_pthread_mutex_unlock(&timerLock) == 0) (JASSERT_ERRNO);
+  JASSERT(DmtcpMutexUnlock(&timerLock) == 0) (JASSERT_ERRNO);
 }
 
 static void
@@ -147,8 +147,7 @@ TimerList::resetOnFork()
   // _clockPidList.clear();
   // _clockPthreadList.clear();
   _timerVirtIdTable.clear();
-  pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
-  timerLock = lock;
+  DmtcpMutexInit(&timerLock, DMTCP_MUTEX_NORMAL);
   _clockVirtIdTable.resetOnFork((clockid_t)(unsigned)getpid());
 }
 

--- a/src/plugin/timer/timerwrappers.h
+++ b/src/plugin/timer/timerwrappers.h
@@ -39,9 +39,6 @@
 # define _real_clock_gettime         NEXT_FNC(clock_gettime)
 # define _real_clock_settime         NEXT_FNC(clock_settime)
 
-# define _real_pthread_mutex_lock    NEXT_FNC(pthread_mutex_lock)
-# define _real_pthread_mutex_unlock  NEXT_FNC(pthread_mutex_unlock)
-
 int timer_create_sigev_thread(clockid_t clock_id,
                               struct sigevent *evp,
                               timer_t *timerid,

--- a/src/popen.cpp
+++ b/src/popen.cpp
@@ -19,6 +19,7 @@
  *  <http://www.gnu.org/licenses/>.                                         *
  ****************************************************************************/
 
+#include "dmtcp.h"
 #include "../jalib/jassert.h"
 #include "syscallwrappers.h"
 #include "threadsync.h"
@@ -28,18 +29,18 @@ using namespace dmtcp;
 static map<FILE *, pid_t>_dmtcpPopenPidMap;
 typedef map<FILE *, pid_t>::iterator _dmtcpPopenPidMapIterator;
 
-static pthread_mutex_t popen_map_lock = PTHREAD_MUTEX_INITIALIZER;
+static DmtcpMutex popen_map_lock = DMTCP_MUTEX_INITIALIZER;
 
 static void
 _lock_popen_map()
 {
-  JASSERT(_real_pthread_mutex_lock(&popen_map_lock) == 0) (JASSERT_ERRNO);
+  JASSERT(DmtcpMutexLock(&popen_map_lock) == 0) (JASSERT_ERRNO);
 }
 
 static void
 _unlock_popen_map()
 {
-  JASSERT(_real_pthread_mutex_unlock(&popen_map_lock) == 0) (JASSERT_ERRNO);
+  JASSERT(DmtcpMutexUnlock(&popen_map_lock) == 0) (JASSERT_ERRNO);
 }
 
 extern "C"

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -36,18 +36,18 @@
 
 namespace dmtcp
 {
-static pthread_mutex_t tblLock = PTHREAD_MUTEX_INITIALIZER;
+static DmtcpMutex tblLock = DMTCP_MUTEX_INITIALIZER;
 
 static void
 _do_lock_tbl()
 {
-  JASSERT(_real_pthread_mutex_lock(&tblLock) == 0) (JASSERT_ERRNO);
+  JASSERT(DmtcpMutexLock(&tblLock) == 0);
 }
 
 static void
 _do_unlock_tbl()
 {
-  JASSERT(_real_pthread_mutex_unlock(&tblLock) == 0) (JASSERT_ERRNO);
+  JASSERT(DmtcpMutexUnlock(&tblLock) == 0);
 }
 
 static void
@@ -459,9 +459,7 @@ ProcessInfo::postExec()
 void
 ProcessInfo::resetOnFork()
 {
-  pthread_mutex_t newlock = PTHREAD_MUTEX_INITIALIZER;
-
-  tblLock = newlock;
+  DmtcpMutexInit(&tblLock, DMTCP_MUTEX_NORMAL);
   _ppid = _pid;
   _pid = getpid();
   _isRootOfProcessTree = false;

--- a/src/rwlock.cpp
+++ b/src/rwlock.cpp
@@ -1,0 +1,167 @@
+#include <limits.h>
+
+#include "dmtcp.h"
+#include "futex.h"
+#include "jassert.h"
+#include "syscallwrappers.h"
+
+
+extern "C"
+void DmtcpRWLockInit(DmtcpRWLock *rwlock)
+{
+  memset(rwlock, 0, sizeof(*rwlock));
+  DmtcpMutexInit(&rwlock->xLock, DMTCP_MUTEX_NORMAL);
+}
+
+
+extern "C"
+int DmtcpRWLockTryRdLock(DmtcpRWLock *rwlock)
+{
+  int result = EBUSY;
+
+  if (DmtcpMutexTryLock(&rwlock->xLock) != 0) {
+    return result;
+  }
+
+  // Detect deadlock.
+  if (rwlock->writer == dmtcp_gettid()) {
+    result = EDEADLK;
+  }
+
+  // See if we can acquire the lock.
+  if (rwlock->writer == 0 && !rwlock->nWritersQueued) {
+    ++rwlock->nReaders;
+    JASSERT(rwlock->nReaders != 0); // Overflow
+    result = 0;
+  }
+
+  JASSERT(DmtcpMutexUnlock(&rwlock->xLock) == 0);
+
+  return result;
+}
+
+
+extern "C"
+int DmtcpRWLockRdLock(DmtcpRWLock *rwlock)
+{
+  int result = 0;
+
+  JASSERT(DmtcpMutexLock(&rwlock->xLock) == 0);
+
+  while (1) {
+    // Detect deadlock.
+    if (rwlock->writer == dmtcp_gettid()) {
+      result = EDEADLK;
+    }
+
+    // See if we can acquire the lock.
+    if (rwlock->writer == 0 && !rwlock->nWritersQueued) {
+      ++rwlock->nReaders;
+      JASSERT(rwlock->nReaders != 0); // Overflow
+      break;
+    }
+
+    // Lock was not available. Let's queue ourselves.
+    ++rwlock->nReadersQueued;
+    JASSERT(rwlock->nReadersQueued != 0); // Overflow
+
+    // Record writer TID.
+    uint64_t waitVal = rwlock->readersFutex;
+
+    // Unlock exclusive lock and wait for writer to finish.
+    JASSERT(DmtcpMutexUnlock(&rwlock->xLock) == 0);
+
+    // Wait for futex.
+    int s = futex_wait(&rwlock->readersFutex, waitVal);
+    JASSERT (s != -1 || errno == EAGAIN) (JASSERT_ERRNO);
+
+    // Reacquire the exclusive lock.
+    JASSERT(DmtcpMutexLock(&rwlock->xLock) == 0);
+    --rwlock->nReadersQueued;
+  }
+
+  JASSERT(DmtcpMutexUnlock(&rwlock->xLock) == 0);
+
+  return result;
+}
+
+
+extern "C"
+int DmtcpRWLockWrLock(DmtcpRWLock *rwlock)
+{
+  int result = 0;
+
+  JASSERT(DmtcpMutexLock(&rwlock->xLock) == 0);
+
+  while (1) {
+    // Detect deadlock.
+    if (rwlock->writer == dmtcp_gettid()) {
+      result = EDEADLK;
+    }
+
+    // See if we can acquire the lock.
+    if (rwlock->writer == 0 && rwlock->nReaders == 0) {
+      rwlock->writer = dmtcp_gettid();
+      break;
+    }
+
+    // Lock was not available. Let's queue ourselves.
+    ++rwlock->nWritersQueued;
+    JASSERT(rwlock->nWritersQueued != 0); // Overflow
+
+    // Record writer TID.
+    uint64_t waitVal = rwlock->writersFutex;
+
+    // Unlock exclusive lock and wait for writer to finish.
+    JASSERT(DmtcpMutexUnlock(&rwlock->xLock) == 0);
+
+    // Wait for futex.
+    int s = futex_wait(&rwlock->writersFutex, waitVal);
+    JASSERT (s != -1 || errno == EAGAIN) (JASSERT_ERRNO);
+
+    // Reacquire the exclusive lock.
+    JASSERT(DmtcpMutexLock(&rwlock->xLock) == 0);
+    --rwlock->nWritersQueued;
+  }
+
+  JASSERT(DmtcpMutexUnlock(&rwlock->xLock) == 0);
+
+  return result;
+}
+
+
+extern "C"
+int DmtcpRWLockUnlock(DmtcpRWLock *rwlock)
+{
+  JASSERT(DmtcpMutexLock(&rwlock->xLock) == 0);
+
+  if (rwlock->writer == dmtcp_gettid()) {
+    rwlock->writer = 0;
+  } else {
+    JASSERT(rwlock->writer == 0) (rwlock->writer);
+    --rwlock->nReaders;
+  }
+
+  // If we are the last reader or the writer, wake a waiting writer.
+  if (rwlock->nReaders == 0) {
+    if (rwlock->nWritersQueued > 0) {
+      // If writers are queued, wakeup one of them.
+      ++rwlock->writersFutex;
+      JASSERT(DmtcpMutexUnlock(&rwlock->xLock) == 0);
+      JASSERT(futex_wake(&rwlock->writersFutex, 1) != -1) (JASSERT_ERRNO);
+      return 0;
+    }
+
+    if (rwlock->nReadersQueued > 0) {
+      // Wakeup all queued Readers.
+      ++rwlock->readersFutex;
+      JASSERT(DmtcpMutexUnlock(&rwlock->xLock) == 0);
+      JASSERT(futex_wake(&rwlock->readersFutex, INT_MAX) != -1) (JASSERT_ERRNO);
+      return 0;
+    }
+  }
+
+  JASSERT(DmtcpMutexUnlock(&rwlock->xLock) == 0);
+  return 0;
+}
+

--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -165,9 +165,9 @@ SharedData::initialize(const char *tmpDir = NULL,
   }
 
   size_t size = CEIL(SHM_MAX_SIZE, Util::pageSize());
-  void *addr = _real_mmap((void *)sharedDataHeader, size,
-                          PROT_READ | PROT_WRITE, MAP_SHARED,
-                          PROTECTED_SHM_FD, 0);
+  void *addr = mmap((void *)sharedDataHeader, size,
+                    PROT_READ | PROT_WRITE, MAP_SHARED,
+                    PROTECTED_SHM_FD, 0);
   JASSERT(addr != MAP_FAILED) (JASSERT_ERRNO)
   .Text("Unable to find shared area.");
 

--- a/src/syscallsreal.c
+++ b/src/syscallsreal.c
@@ -1097,63 +1097,6 @@ _real_mq_timedsend(mqd_t mqdes,
 }
 
 LIB_PRIVATE
-void *
-_real_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(void *, mmap) (addr, length, prot, flags, fd,
-                                             offset);
-}
-
-LIB_PRIVATE
-void *
-_real_mmap64(void *addr,
-             size_t length,
-             int prot,
-             int flags,
-             int fd,
-             __off64_t offset)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(void *, mmap64) (addr, length, prot, flags, fd,
-                                               offset);
-}
-
-#if __GLIBC_PREREQ(2, 4)
-LIB_PRIVATE
-void *
-_real_mremap(void *old_address, size_t old_size, size_t new_size, int flags,
-             ... /* void *new_address*/)
-{
-  if (flags == MREMAP_FIXED) {
-    va_list ap;
-    va_start(ap, flags);
-    void *new_address = va_arg(ap, void *);
-    va_end(ap);
-    REAL_FUNC_PASSTHROUGH_TYPED(void *, mremap)
-      (old_address, old_size, new_size, flags, new_address);
-  } else {
-    REAL_FUNC_PASSTHROUGH_TYPED(void *, mremap)
-      (old_address, old_size, new_size, flags);
-  }
-}
-
-#else /* if __GLIBC_PREREQ(2, 4) */
-LIB_PRIVATE
-void *
-_real_mremap(void *old_address, size_t old_size, size_t new_size, int flags)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(void *, mremap)
-    (old_address, old_size, new_size, flags);
-}
-#endif /* if __GLIBC_PREREQ(2, 4) */
-
-LIB_PRIVATE
-int
-_real_munmap(void *addr, size_t length)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, munmap) (addr, length);
-}
-
-LIB_PRIVATE
 int
 _real_poll(struct pollfd *fds, nfds_t nfds, int timeout)
 {

--- a/src/syscallsreal.c
+++ b/src/syscallsreal.c
@@ -54,8 +54,6 @@ typedef int (*funcptr_t) ();
 typedef pid_t (*funcptr_pid_t) ();
 typedef funcptr_t (*signal_funcptr_t) ();
 
-static pthread_mutex_t theMutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
-
 // gettid / tkill / tgkill are not defined in libc.
 LIB_PRIVATE pid_t
 dmtcp_gettid()
@@ -73,24 +71,6 @@ LIB_PRIVATE int
 dmtcp_tgkill(int tgid, int tid, int sig)
 {
   return _real_syscall(SYS_tgkill, tgid, tid, sig);
-}
-
-// FIXME: Are these primitives (_dmtcp_lock, _dmtcp_unlock) required anymore?
-void
-_dmtcp_lock() { _real_pthread_mutex_lock(&theMutex); }
-
-void
-_dmtcp_unlock() { _real_pthread_mutex_unlock(&theMutex); }
-
-void
-_dmtcp_remutex_on_fork()
-{
-  pthread_mutexattr_t attr;
-
-  pthread_mutexattr_init(&attr);
-  pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP);
-  pthread_mutex_init(&theMutex, &attr);
-  pthread_mutexattr_destroy(&attr);
 }
 
 /*

--- a/src/syscallsreal.c
+++ b/src/syscallsreal.c
@@ -245,46 +245,12 @@ initialize_libc_wrappers()
   }
 }
 
-#ifdef ENABLE_PTHREAD_COND_WRAPPERS
-#define GET_LIBPTHREAD_FUNC_ADDR(name) \
-  _real_func_addr[ENUM(name)] = dmtcp_dlvsym(RTLD_NEXT, # name,\
-                                             pthread_sym_ver);
-
-/*
- * WARNING: By using this method to initialize libpthread wrappers (direct
- * dlopen()/dlsym()) we are are overriding any user wrappers for these
- * functions. If this is a problem in the future we need to think of a new way
- * to do this.
- * EDIT: On some ARM machines, the symbol version is 2.4. Try that first and
- *       fallback to 2.3.4 on failure.
- */
-static void
-initialize_libpthread_wrappers()
-{
-  const char *ver_2_4 = "GLIBC_2.4";
-  const char *ver_2_3_2 = "GLIBC_2.3.2";
-  const char *pthread_sym_ver = NULL;
-
-  void *addr = dmtcp_dlvsym(RTLD_NEXT, "pthread_cond_signal", (char*)ver_2_4);
-  if (addr != NULL) {
-    pthread_sym_ver = ver_2_4;
-  } else {
-    pthread_sym_ver = ver_2_3_2;
-  }
-
-  FOREACH_LIBPTHREAD_WRAPPERS(GET_LIBPTHREAD_FUNC_ADDR);
-}
-#endif // #ifdef ENABLE_PTHREAD_COND_WRAPPERS
-
 void
 dmtcp_prepare_wrappers(void)
 {
   if (!dmtcp_wrappers_initialized) {
     initialize_libc_wrappers();
     dmtcp_wrappers_initialized = 1;
-#ifdef ENABLE_PTHREAD_COND_WRAPPERS
-    initialize_libpthread_wrappers();
-#endif // #ifdef ENABLE_PTHREAD_COND_WRAPPERS
   }
 }
 
@@ -384,145 +350,6 @@ _real_dlclose(void *handle)
 {
   REAL_FUNC_PASSTHROUGH_TYPED(int, dlclose) (handle);
 }
-
-LIB_PRIVATE
-int
-_real_pthread_mutex_lock(pthread_mutex_t *mutex)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_mutex_lock) (mutex);
-}
-
-LIB_PRIVATE
-int
-_real_pthread_mutex_trylock(pthread_mutex_t *mutex)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_mutex_trylock) (mutex);
-}
-
-LIB_PRIVATE
-int
-_real_pthread_mutex_unlock(pthread_mutex_t *mutex)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_mutex_unlock) (mutex);
-}
-
-LIB_PRIVATE
-int
-_real_pthread_rwlock_unlock(pthread_rwlock_t *rwlock)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_rwlock_unlock) (rwlock);
-}
-
-LIB_PRIVATE
-int
-_real_pthread_rwlock_rdlock(pthread_rwlock_t *rwlock)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_rwlock_rdlock) (rwlock);
-}
-
-LIB_PRIVATE
-int
-_real_pthread_rwlock_tryrdlock(pthread_rwlock_t *rwlock)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_rwlock_tryrdlock) (rwlock);
-}
-
-LIB_PRIVATE
-int
-_real_pthread_rwlock_wrlock(pthread_rwlock_t *rwlock)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_rwlock_wrlock) (rwlock);
-}
-
-LIB_PRIVATE
-int
-_real_pthread_rwlock_trywrlock(pthread_rwlock_t *rwlock)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_rwlock_trywrlock) (rwlock);
-}
-
-#ifdef ENABLE_PTHREAD_COND_WRAPPERS
-LIB_PRIVATE
-int
-_real_pthread_cond_broadcast(pthread_cond_t *cond)
-{
-#if __aarch64__
-  int result = NEXT_FNC(pthread_cond_broadcast)(cond);
-  return result;
-
-#else /* if __aarch64__ */
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_cond_broadcast) (cond);
-#endif /* if __aarch64__ */
-}
-
-LIB_PRIVATE
-int
-_real_pthread_cond_destroy(pthread_cond_t *cond)
-{
-#if __aarch64__
-  int result = NEXT_FNC(pthread_cond_destroy)(cond);
-  return result;
-
-#else /* if __aarch64__ */
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_cond_destroy) (cond);
-#endif /* if __aarch64__ */
-}
-
-LIB_PRIVATE
-int
-_real_pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr)
-{
-#if __aarch64__
-  int result = NEXT_FNC(pthread_cond_init)(cond, attr);
-  return result;
-
-#else /* if __aarch64__ */
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_cond_init) (cond, attr);
-#endif /* if __aarch64__ */
-}
-
-LIB_PRIVATE
-int
-_real_pthread_cond_signal(pthread_cond_t *cond)
-{
-#if __aarch64__
-  int result = NEXT_FNC(pthread_cond_signal)(cond);
-  return result;
-
-#else /* if __aarch64__ */
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_cond_signal) (cond);
-#endif /* if __aarch64__ */
-}
-
-LIB_PRIVATE
-int
-_real_pthread_cond_timedwait(pthread_cond_t *cond,
-                             pthread_mutex_t *mutex,
-                             const struct timespec *abstime)
-{
-#if __aarch64__
-  int result = NEXT_FNC(pthread_cond_timedwait)(cond, mutex, abstime);
-  return result;
-
-#else /* if __aarch64__ */
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_cond_timedwait) (cond, mutex,
-                                                            abstime);
-#endif /* if __aarch64__ */
-}
-
-LIB_PRIVATE
-int
-_real_pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
-{
-#if __aarch64__
-  int result = NEXT_FNC(pthread_cond_wait)(cond, mutex);
-  return result;
-
-#else /* if __aarch64__ */
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_cond_wait) (cond, mutex);
-#endif /* if __aarch64__ */
-}
-#endif // #ifdef ENABLE_PTHREAD_COND_WRAPPERS
 
 LIB_PRIVATE
 ssize_t

--- a/src/syscallwrappers.h
+++ b/src/syscallwrappers.h
@@ -110,18 +110,7 @@ extern int dmtcp_wrappers_initializing;
 
 LIB_PRIVATE extern __thread int thread_performing_dlopen_dlsym;
 
-#define FOREACH_GLIBC_MALLOC_FAMILY_WRAPPERS(MACRO) \
-  MACRO(calloc)                                     \
-  MACRO(malloc)                                     \
-  MACRO(free)                                       \
-  MACRO(__libc_memalign)                            \
-  MACRO(realloc)                                    \
-  MACRO(mmap)                                       \
-  MACRO(mmap64)                                     \
-  MACRO(mremap)                                     \
-  MACRO(munmap)
-
-#define FOREACH_GLIBC_WRAPPERS(MACRO) \
+#define FOREACH_DMTCP_WRAPPER(MACRO)  \
   MACRO(dlopen)                       \
   MACRO(dlclose)                      \
   MACRO(getpid)                       \
@@ -256,10 +245,6 @@ LIB_PRIVATE extern __thread int thread_performing_dlopen_dlsym;
   MACRO(pthread_timedjoin_np)         \
   MACRO(pthread_sigmask)              \
   MACRO(pthread_getspecific)
-
-#define FOREACH_DMTCP_WRAPPER(MACRO) \
-  FOREACH_GLIBC_WRAPPERS(MACRO)      \
-  FOREACH_GLIBC_MALLOC_FAMILY_WRAPPERS(MACRO)
 
 #define ENUM(x)     enum_ ## x
 #define GEN_ENUM(x) ENUM(x),
@@ -414,37 +399,6 @@ void *_real_dlsym(void *handle, const char *symbol);
 
 void *_real_dlopen(const char *filename, int flag);
 int _real_dlclose(void *handle);
-
-void *_real_calloc(size_t nmemb, size_t size);
-void *_real_malloc(size_t size);
-void _real_free(void *ptr);
-void *_real_realloc(void *ptr, size_t size);
-void *_real_libc_memalign(size_t boundary, size_t size);
-void *_real_mmap(void *addr,
-                 size_t length,
-                 int prot,
-                 int flags,
-                 int fd,
-                 off_t offset);
-void *_real_mmap64(void *addr,
-                   size_t length,
-                   int prot,
-                   int flags,
-                   int fd,
-                   __off64_t offset);
-#if __GLIBC_PREREQ(2, 4)
-void *_real_mremap(void *old_address,
-                   size_t old_size,
-                   size_t new_size,
-                   int flags,
-                   ... /* void *new_address */);
-#else // if __GLIBC_PREREQ(2, 4)
-void *_real_mremap(void *old_address,
-                   size_t old_size,
-                   size_t new_size,
-                   int flags);
-#endif // if __GLIBC_PREREQ(2, 4)
-int _real_munmap(void *addr, size_t length);
 
 ssize_t _real_read(int fd, void *buf, size_t count);
 ssize_t _real_write(int fd, const void *buf, size_t count);

--- a/src/syscallwrappers.h
+++ b/src/syscallwrappers.h
@@ -255,23 +255,7 @@ LIB_PRIVATE extern __thread int thread_performing_dlopen_dlsym;
   MACRO(pthread_tryjoin_np)           \
   MACRO(pthread_timedjoin_np)         \
   MACRO(pthread_sigmask)              \
-  MACRO(pthread_getspecific)          \
-  MACRO(pthread_mutex_lock)           \
-  MACRO(pthread_mutex_trylock)        \
-  MACRO(pthread_mutex_unlock)         \
-  MACRO(pthread_rwlock_unlock)        \
-  MACRO(pthread_rwlock_rdlock)        \
-  MACRO(pthread_rwlock_tryrdlock)     \
-  MACRO(pthread_rwlock_wrlock)        \
-  MACRO(pthread_rwlock_trywrlock)
-
-#define FOREACH_LIBPTHREAD_WRAPPERS(MACRO) \
-  MACRO(pthread_cond_broadcast)            \
-  MACRO(pthread_cond_destroy)              \
-  MACRO(pthread_cond_init)                 \
-  MACRO(pthread_cond_signal)               \
-  MACRO(pthread_cond_timedwait)            \
-  MACRO(pthread_cond_wait)
+  MACRO(pthread_getspecific)
 
 #define FOREACH_DMTCP_WRAPPER(MACRO) \
   FOREACH_GLIBC_WRAPPERS(MACRO)      \
@@ -281,9 +265,6 @@ LIB_PRIVATE extern __thread int thread_performing_dlopen_dlsym;
 #define GEN_ENUM(x) ENUM(x),
 typedef enum {
   FOREACH_DMTCP_WRAPPER(GEN_ENUM)
-#ifdef ENABLE_PTHREAD_COND_WRAPPERS
-  FOREACH_LIBPTHREAD_WRAPPERS(GEN_ENUM)
-#endif // #ifdef ENABLE_PTHREAD_COND_WRAPPERS
   numLibcWrappers
 } LibcWrapperOffset;
 
@@ -474,27 +455,6 @@ int _real_select(int nfds,
                  struct timeval *timeout);
 off_t _real_lseek(int fd, off_t offset, int whence);
 int _real_unlink(const char *pathname);
-
-int _real_pthread_mutex_lock(pthread_mutex_t *mutex);
-int _real_pthread_mutex_trylock(pthread_mutex_t *mutex);
-int _real_pthread_mutex_unlock(pthread_mutex_t *mutex);
-int _real_pthread_rwlock_unlock(pthread_rwlock_t *rwlock);
-int _real_pthread_rwlock_rdlock(pthread_rwlock_t *rwlock);
-int _real_pthread_rwlock_tryrdlock(pthread_rwlock_t *rwlock);
-int _real_pthread_rwlock_wrlock(pthread_rwlock_t *rwlock);
-int _real_pthread_rwlock_trywrlock(pthread_rwlock_t *rwlock);
-
-#ifdef ENABLE_PTHREAD_COND_WRAPPERS
-int _real_pthread_cond_broadcast(pthread_cond_t *cond);
-int _real_pthread_cond_destroy(pthread_cond_t *cond);
-int _real_pthread_cond_init(pthread_cond_t *cond,
-                            const pthread_condattr_t *attr);
-int _real_pthread_cond_signal(pthread_cond_t *cond);
-int _real_pthread_cond_timedwait(pthread_cond_t *cond,
-                                 pthread_mutex_t *mutex,
-                                 const struct timespec *abstime);
-int _real_pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex);
-#endif // #ifdef ENABLE_PTHREAD_COND_WRAPPERS
 
 int _real_poll(struct pollfd *fds, nfds_t nfds, int timeout);
 

--- a/src/syscallwrappers.h
+++ b/src/syscallwrappers.h
@@ -294,10 +294,6 @@ union semun {
   struct seminfo *__buf;     /* Buffer for IPC_INFO (Linux-specific) */
 };
 
-void _dmtcp_lock();
-void _dmtcp_unlock();
-
-void _dmtcp_remutex_on_fork();
 LIB_PRIVATE void dmtcpResetTid(pid_t tid);
 LIB_PRIVATE void dmtcpResetPidPpid();
 

--- a/src/threadsync.cpp
+++ b/src/threadsync.cpp
@@ -61,24 +61,23 @@ using namespace dmtcp;
  */
 
 // NOTE: PTHREAD_RWLOCK_WRITER_NONRECURSIVE_INITIALIZER_NP is not POSIX.
-static pthread_rwlock_t
-  _wrapperExecutionLock = PTHREAD_RWLOCK_WRITER_NONRECURSIVE_INITIALIZER_NP;
-static pthread_rwlock_t
-  _threadCreationLock = PTHREAD_RWLOCK_WRITER_NONRECURSIVE_INITIALIZER_NP;
+static DmtcpRWLock _wrapperExecutionLock;
+static DmtcpRWLock _threadCreationLock;
+
 static bool _wrapperExecutionLockAcquiredByCkptThread = false;
 static bool _threadCreationLockAcquiredByCkptThread = false;
 
-static pthread_mutex_t theCkptCanStart = PTHREAD_MUTEX_INITIALIZER;
+static DmtcpMutex theCkptCanStart = DMTCP_MUTEX_INITIALIZER;
 static int ckptCanStartCount = 0;
 
-static pthread_mutex_t libdlLock = PTHREAD_MUTEX_INITIALIZER;
+static DmtcpMutex libdlLock = DMTCP_MUTEX_INITIALIZER;
 static pid_t libdlLockOwner = 0;
 
-static pthread_mutex_t uninitializedThreadCountLock = PTHREAD_MUTEX_INITIALIZER;
+static DmtcpMutex uninitializedThreadCountLock = DMTCP_MUTEX_INITIALIZER;
 static int _uninitializedThreadCount = 0;
 static bool _checkpointThreadInitialized = false;
 
-static pthread_mutex_t preResumeThreadCountLock = PTHREAD_MUTEX_INITIALIZER;
+static DmtcpMutex preResumeThreadCountLock = DMTCP_MUTEX_INITIALIZER;
 
 static __thread int _wrapperExecutionLockLockCount = 0;
 static __thread int _threadCreationLockLockCount = 0;
@@ -125,6 +124,9 @@ ThreadSync::initThread()
 void
 ThreadSync::initMotherOfAll()
 {
+  DmtcpRWLockInit(&_wrapperExecutionLock);
+  DmtcpRWLockInit(&_threadCreationLock);
+
   initThread();
   _hasThreadFinishedInitialization = true;
 }
@@ -139,19 +141,17 @@ ThreadSync::acquireLocks()
    */
 
   JTRACE("Waiting for lock(&theCkptCanStart)");
-  JASSERT(_real_pthread_mutex_lock(&theCkptCanStart) == 0)(JASSERT_ERRNO);
+  JASSERT(DmtcpMutexLock(&theCkptCanStart) == 0);
 
   JTRACE("Waiting for libdlLock");
-  JASSERT(_real_pthread_mutex_lock(&libdlLock) == 0) (JASSERT_ERRNO);
+  JASSERT(DmtcpMutexLock(&libdlLock) == 0);
 
   JTRACE("Waiting for threads creation lock");
-  JASSERT(_real_pthread_rwlock_wrlock(&_threadCreationLock) == 0)
-    (JASSERT_ERRNO);
+  JASSERT(DmtcpRWLockWrLock(&_threadCreationLock) == 0);
   _threadCreationLockAcquiredByCkptThread = true;
 
   JTRACE("Waiting for other threads to exit DMTCP-Wrappers");
-  JASSERT(_real_pthread_rwlock_wrlock(&_wrapperExecutionLock) == 0)
-    (JASSERT_ERRNO);
+  JASSERT(DmtcpRWLockWrLock(&_wrapperExecutionLock) == 0);
   _wrapperExecutionLockAcquiredByCkptThread = true;
 
   JTRACE("Waiting for newly created threads to finish initialization")
@@ -168,14 +168,12 @@ ThreadSync::releaseLocks()
   JASSERT(WorkerState::currentState() == WorkerState::SUSPENDED);
 
   JTRACE("Releasing ThreadSync locks");
-  JASSERT(_real_pthread_rwlock_unlock(&_wrapperExecutionLock) == 0)
-    (JASSERT_ERRNO);
+  JASSERT(DmtcpRWLockUnlock(&_wrapperExecutionLock) == 0);
   _wrapperExecutionLockAcquiredByCkptThread = false;
-  JASSERT(_real_pthread_rwlock_unlock(&_threadCreationLock) == 0)
-    (JASSERT_ERRNO);
+  JASSERT(DmtcpRWLockUnlock(&_threadCreationLock) == 0);
   _threadCreationLockAcquiredByCkptThread = false;
-  JASSERT(_real_pthread_mutex_unlock(&libdlLock) == 0) (JASSERT_ERRNO);
-  JASSERT(_real_pthread_mutex_unlock(&theCkptCanStart) == 0) (JASSERT_ERRNO);
+  JASSERT(DmtcpMutexUnlock(&libdlLock) == 0);
+  JASSERT(DmtcpMutexUnlock(&theCkptCanStart) == 0);
 
   setOkToGrabLock();
 }
@@ -183,10 +181,8 @@ ThreadSync::releaseLocks()
 void
 ThreadSync::resetLocks()
 {
-  pthread_rwlock_t newLock = PTHREAD_RWLOCK_WRITER_NONRECURSIVE_INITIALIZER_NP;
-
-  _wrapperExecutionLock = newLock;
-  _threadCreationLock = newLock;
+  DmtcpRWLockInit(&_wrapperExecutionLock);
+  DmtcpRWLockInit(&_threadCreationLock);
 
   _wrapperExecutionLockLockCount = 0;
   _threadCreationLockLockCount = 0;
@@ -196,13 +192,10 @@ ThreadSync::resetLocks()
   _isOkToGrabWrapperExecutionLock = true;
   _hasThreadFinishedInitialization = true;
 
-  pthread_mutex_t newCountLock = PTHREAD_MUTEX_INITIALIZER;
-  uninitializedThreadCountLock = newCountLock;
-  pthread_mutex_t newPreResumeThreadCountLock = PTHREAD_MUTEX_INITIALIZER;
-  preResumeThreadCountLock = newPreResumeThreadCountLock;
+  DmtcpMutexInit(&uninitializedThreadCountLock, DMTCP_MUTEX_NORMAL);
+  DmtcpMutexInit(&preResumeThreadCountLock, DMTCP_MUTEX_NORMAL);
+  DmtcpMutexInit(&libdlLock, DMTCP_MUTEX_NORMAL);
 
-  pthread_mutex_t newLibdlLock = PTHREAD_MUTEX_INITIALIZER;
-  libdlLock = newLibdlLock;
   libdlLockOwner = 0;
 
   _checkpointThreadInitialized = false;
@@ -266,7 +259,7 @@ void
 ThreadSync::delayCheckpointsLock()
 {
   if (ckptCanStartCount++ == 0) {
-    JASSERT(_real_pthread_mutex_lock(&theCkptCanStart) == 0)(JASSERT_ERRNO);
+    JASSERT(DmtcpMutexLock(&theCkptCanStart) == 0);
   }
 }
 
@@ -274,7 +267,7 @@ void
 ThreadSync::delayCheckpointsUnlock()
 {
   if (--ckptCanStartCount == 0) {
-    JASSERT(_real_pthread_mutex_unlock(&theCkptCanStart) == 0)(JASSERT_ERRNO);
+    JASSERT(DmtcpMutexUnlock(&theCkptCanStart) == 0);
   }
 }
 
@@ -315,7 +308,7 @@ ThreadSync::libdlLockLock()
   if ((WorkerState::currentState() == WorkerState::RUNNING ||
        WorkerState::currentState() == WorkerState::PRESUSPEND) &&
       libdlLockOwner != dmtcp_gettid()) {
-    JASSERT(_real_pthread_mutex_lock(&libdlLock) == 0);
+    JASSERT(DmtcpMutexLock(&libdlLock) == 0);
     libdlLockOwner = dmtcp_gettid();
     lockAcquired = true;
   }
@@ -333,7 +326,7 @@ ThreadSync::libdlLockUnlock()
   JASSERT(WorkerState::currentState() == WorkerState::RUNNING ||
           WorkerState::currentState() == WorkerState::PRESUSPEND);
   libdlLockOwner = 0;
-  JASSERT(_real_pthread_mutex_unlock(&libdlLock) == 0);
+  JASSERT(DmtcpMutexUnlock(&libdlLock) == 0);
   errno = saved_errno;
 }
 
@@ -355,7 +348,7 @@ ThreadSync::wrapperExecutionLockLock()
         isOkToGrabLock() == true &&
         _wrapperExecutionLockLockCount == 0) {
       incrementWrapperExecutionLockLockCount();
-      int retVal = _real_pthread_rwlock_tryrdlock(&_wrapperExecutionLock);
+      int retVal = DmtcpRWLockTryRdLock(&_wrapperExecutionLock);
       if (retVal != 0 && retVal == EBUSY) {
         decrementWrapperExecutionLockLockCount();
         struct timespec sleepTime = { 0, 100 * 1000 * 1000 };
@@ -424,7 +417,7 @@ ThreadSync::wrapperExecutionLockLockExcl()
   if (WorkerState::currentState() == WorkerState::RUNNING ||
       WorkerState::currentState() == WorkerState::PRESUSPEND) {
     incrementWrapperExecutionLockLockCount();
-    int retVal = _real_pthread_rwlock_wrlock(&_wrapperExecutionLock);
+    int retVal = DmtcpRWLockWrLock(&_wrapperExecutionLock);
     if (retVal != 0 && retVal != EDEADLK) {
       fprintf(stderr, "ERROR %s:%d %s: Failed to acquire lock\n",
               __FILE__, __LINE__, __PRETTY_FUNCTION__);
@@ -446,7 +439,7 @@ ThreadSync::wrapperExecutionLockUnlock()
 {
   int saved_errno = errno;
 
-  if (_real_pthread_rwlock_unlock(&_wrapperExecutionLock) != 0) {
+  if (DmtcpRWLockUnlock(&_wrapperExecutionLock) != 0) {
     fprintf(stderr, "ERROR %s:%d %s: Failed to release lock\n",
             __FILE__, __LINE__, __PRETTY_FUNCTION__);
     _exit(DMTCP_FAIL_RC);
@@ -466,7 +459,7 @@ ThreadSync::threadCreationLockLock()
     if (WorkerState::currentState() == WorkerState::RUNNING ||
         WorkerState::currentState() == WorkerState::PRESUSPEND) {
       incrementThreadCreationLockLockCount();
-      int retVal = _real_pthread_rwlock_tryrdlock(&_threadCreationLock);
+      int retVal = DmtcpRWLockTryRdLock(&_threadCreationLock);
       if (retVal != 1 && retVal == EBUSY) {
         decrementThreadCreationLockLockCount();
         struct timespec sleepTime = { 0, 100 * 1000 * 1000 };
@@ -511,7 +504,7 @@ ThreadSync::threadCreationLockUnlock()
             __PRETTY_FUNCTION__);
     _exit(DMTCP_FAIL_RC);
   }
-  if (_real_pthread_rwlock_unlock(&_threadCreationLock) != 0) {
+  if (DmtcpRWLockUnlock(&_threadCreationLock) != 0) {
     fprintf(stderr, "ERROR %s:%d %s: Failed to release lock\n",
             __FILE__, __LINE__, __PRETTY_FUNCTION__);
     _exit(DMTCP_FAIL_RC);
@@ -557,13 +550,11 @@ ThreadSync::incrementUninitializedThreadCount()
 
   if (WorkerState::currentState() == WorkerState::RUNNING ||
       WorkerState::currentState() == WorkerState::PRESUSPEND) {
-    JASSERT(_real_pthread_mutex_lock(&uninitializedThreadCountLock) == 0)
-      (JASSERT_ERRNO);
+    JASSERT(DmtcpMutexLock(&uninitializedThreadCountLock) == 0);
     _uninitializedThreadCount++;
 
     // JTRACE(":") (_uninitializedThreadCount);
-    JASSERT(_real_pthread_mutex_unlock(&uninitializedThreadCountLock) == 0)
-      (JASSERT_ERRNO);
+    JASSERT(DmtcpMutexUnlock(&uninitializedThreadCountLock) == 0);
   }
   errno = saved_errno;
 }
@@ -575,14 +566,12 @@ ThreadSync::decrementUninitializedThreadCount()
 
   if (WorkerState::currentState() == WorkerState::RUNNING ||
       WorkerState::currentState() == WorkerState::PRESUSPEND) {
-    JASSERT(_real_pthread_mutex_lock(&uninitializedThreadCountLock) == 0)
-      (JASSERT_ERRNO);
+    JASSERT(DmtcpMutexLock(&uninitializedThreadCountLock) == 0);
     JASSERT(_uninitializedThreadCount > 0) (_uninitializedThreadCount);
     _uninitializedThreadCount--;
 
     // JTRACE(":") (_uninitializedThreadCount);
-    JASSERT(_real_pthread_mutex_unlock(&uninitializedThreadCountLock) == 0)
-      (JASSERT_ERRNO);
+    JASSERT(DmtcpMutexUnlock(&uninitializedThreadCountLock) == 0);
   }
   errno = saved_errno;
 }

--- a/src/threadsync.cpp
+++ b/src/threadsync.cpp
@@ -138,10 +138,6 @@ ThreadSync::acquireLocks()
    * these locks to prevent future deadlocks due to rank violation.
    */
 
-  JTRACE("waiting for dmtcp_lock():"
-         " to get synchronized with _runCoordinatorCmd if we use DMTCP API");
-  _dmtcp_lock();
-
   JTRACE("Waiting for lock(&theCkptCanStart)");
   JASSERT(_real_pthread_mutex_lock(&theCkptCanStart) == 0)(JASSERT_ERRNO);
 
@@ -181,7 +177,6 @@ ThreadSync::releaseLocks()
   JASSERT(_real_pthread_mutex_unlock(&libdlLock) == 0) (JASSERT_ERRNO);
   JASSERT(_real_pthread_mutex_unlock(&theCkptCanStart) == 0) (JASSERT_ERRNO);
 
-  _dmtcp_unlock();
   setOkToGrabLock();
 }
 

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -823,11 +823,11 @@ runTest("forkexec",      2, ["./test/forkexec"])
 runTest("realpath",      1, ["./test/realpath"])
 runTest("pthread1",      1, ["./test/pthread1"])
 runTest("pthread2",      1, ["./test/pthread2"])
-if HAS_MUTEX_WRAPPERS == "no":
-  # This is failing under CentOS 7.5 when --enable-mutex-wrappers is configured.
-  S=10*DEFAULT_S
-  runTest("pthread3",      1, ["./test/pthread2 80"])
-  S=DEFAULT_S
+
+S=10*DEFAULT_S
+runTest("pthread3",      1, ["./test/pthread2 80"])
+S=DEFAULT_S
+
 runTest("pthread4",      1, ["./test/pthread4"])
 runTest("pthread5",      1, ["./test/pthread5"])
 


### PR DESCRIPTION
These functions replace pthread_{mutex,rwlock} functions within DMTCP, thus decoupling us from the libc implementation. This enables us to track user pthread_mutex/rwlock requests without having to worry about calls originating from DMTCP code.

The functions are a drop-in replacement for pthread_* functions and should be side-effect free.