### PR TITLE
Removed some unused wrappers from DMTCP.

### DIFF
--- a/jalib/jalib.cpp
+++ b/jalib/jalib.cpp
@@ -171,35 +171,6 @@ syscall(long sys_num, ...)
                                         arg[3], arg[4], arg[5], arg[6]);
 }
 
-ssize_t
-read(int fd, void *buf, size_t count)
-{
-  REAL_FUNC_PASSTHROUGH(ssize_t, read) (fd, buf, count);
-}
-
-ssize_t
-write(int fd, const void *buf, size_t count)
-{
-  REAL_FUNC_PASSTHROUGH(ssize_t, write) (fd, buf, count);
-}
-
-int
-select(int nfds,
-       fd_set *readfds,
-       fd_set *writefds,
-       fd_set *exceptfds,
-       struct timeval *timeout)
-{
-  REAL_FUNC_PASSTHROUGH(int, select) (nfds, readfds, writefds, exceptfds,
-                                      timeout);
-}
-
-int
-poll(struct pollfd fds[], nfds_t nfds, int timeout)
-{
-  REAL_FUNC_PASSTHROUGH(int, poll) (fds, nfds, timeout);
-}
-
 int
 socket(int domain, int type, int protocol)
 {

--- a/jalib/jalib.h
+++ b/jalib/jalib.h
@@ -23,7 +23,6 @@
 #define JALIB_H
 
 #include <fcntl.h>
-#include <poll.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/types.h>
@@ -41,12 +40,6 @@ typedef struct JalibFuncPtrs {
   ssize_t (*readlink)(const char *path, char *buf, size_t bufsiz);
 
   long (*syscall)(long sys_num, ...);
-
-  ssize_t (*read)(int fd, void *buf, size_t count);
-  ssize_t (*write)(int fd, const void *buf, size_t count);
-  int (*select)(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
-                struct timeval *timeout);
-  int (*poll)(struct pollfd fds[], nfds_t nfds, int timeout);
 
   int (*socket)(int domain, int type, int protocol);
   int (*connect)(int sockfd, const struct sockaddr *saddr, socklen_t addrlen);
@@ -75,15 +68,6 @@ int dup2(int oldfd, int newfd);
 ssize_t readlink(const char *path, char *buf, size_t bufsiz);
 
 long syscall(long sys_num, ...);
-
-ssize_t read(int fd, void *buf, size_t count);
-ssize_t write(int fd, const void *buf, size_t count);
-int select(int nfds,
-           fd_set *readfds,
-           fd_set *writefds,
-           fd_set *exceptfds,
-           struct timeval *timeout);
-int poll(struct pollfd fds[], nfds_t nfds, int timeout);
 
 int socket(int domain, int type, int protocol);
 int connect(int sockfd, const struct sockaddr *serv_addr, socklen_t addrlen);

--- a/jalib/jalloc.cpp
+++ b/jalib/jalloc.cpp
@@ -189,7 +189,7 @@ class JFixedAllocStack
         // TODO: why is expand being called? If you see this message, raise lvl2
         // allocation level.
         char expand_msg[] = "\n\n\n******* EXPAND IS CALLED *******\n\n\n";
-        jalib::write(2, expand_msg, sizeof(expand_msg));
+        write(2, expand_msg, sizeof(expand_msg));
 
         // jalib::fflush(stderr);
         abort();
@@ -279,7 +279,7 @@ jalib::JAllocDispatcher::deallocate(void *ptr, size_t n)
 {
   if (!_initialized) {
     char msg[] = "***DMTCP INTERNAL ERROR: Free called before init\n";
-    jalib::write(2, msg, sizeof(msg));
+    write(2, msg, sizeof(msg));
     abort();
   }
   if (n <= lvl1.N) {

--- a/jalib/jsocket.cpp
+++ b/jalib/jsocket.cpp
@@ -288,7 +288,7 @@ jalib::JSocket::close()
 ssize_t
 jalib::JSocket::read(char *buf, size_t len)
 {
-  return jalib::read(_sockfd, buf, len);
+  return ::read(_sockfd, buf, len);
 }
 
 ssize_t
@@ -595,7 +595,7 @@ jalib::JMultiSocketProgram::monitorSockets(double dblTimeout)
     uint64_t millis = timeout ? ((timeout->tv_sec * (uint64_t)1000) +
                                  (timeout->tv_usec / 1000))
       : -1;
-    int retval = jalib::poll((struct pollfd *)&fds[0], fds.size(), millis);
+    int retval = poll((struct pollfd *)&fds[0], fds.size(), millis);
 
     if (retval == -1) {
       JWARNING(retval != -1)

--- a/src/jalibinterface.cpp
+++ b/src/jalibinterface.cpp
@@ -48,11 +48,6 @@ initializeJalib()
 
   INIT_JALIB_FPTR(syscall);
 
-  INIT_JALIB_FPTR(read);
-  INIT_JALIB_FPTR(write);
-  INIT_JALIB_FPTR(select);
-  INIT_JALIB_FPTR(poll);
-
   INIT_JALIB_FPTR(socket);
   INIT_JALIB_FPTR(connect);
   INIT_JALIB_FPTR(bind);

--- a/src/miscwrappers.cpp
+++ b/src/miscwrappers.cpp
@@ -22,6 +22,7 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sys/syscall.h>
+#include <sys/poll.h>
 #include "../jalib/jassert.h"
 #include "../jalib/jconvert.h"
 #include "constants.h"

--- a/src/nosyscallsreal.c
+++ b/src/nosyscallsreal.c
@@ -97,28 +97,6 @@
 void
 initialize_wrappers() {}
 
-ssize_t
-_real_read(int fd, void *buf, size_t count)
-{
-  REAL_FUNC_PASSTHROUGH(read) (fd, buf, count);
-}
-
-ssize_t
-_real_write(int fd, const void *buf, size_t count)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(ssize_t, write) (fd, buf, count);
-}
-
-int
-_real_select(int nfds,
-             fd_set *readfds,
-             fd_set *writefds,
-             fd_set *exceptfds,
-             struct timeval *timeout)
-{
-  REAL_FUNC_PASSTHROUGH(select) (nfds, readfds, writefds, exceptfds, timeout);
-}
-
 /// call the libc version of this function via dlopen/dlsym
 int
 _real_socket(int domain, int type, int protocol)
@@ -495,13 +473,6 @@ int
 _real_shmctl(int shmid, int cmd, struct shmid_ds *buf)
 {
   REAL_FUNC_PASSTHROUGH(shmctl) (shmid, cmd, buf);
-}
-
-LIB_PRIVATE
-int
-_real_poll(struct pollfd *fds, nfds_t nfds, int timeout)
-{
-  REAL_FUNC_PASSTHROUGH(poll) (fds, nfds, timeout);
 }
 
 ssize_t

--- a/src/syscallsreal.c
+++ b/src/syscallsreal.c
@@ -35,7 +35,6 @@
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <malloc.h>
-#include <poll.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -349,31 +348,6 @@ int
 _real_dlclose(void *handle)
 {
   REAL_FUNC_PASSTHROUGH_TYPED(int, dlclose) (handle);
-}
-
-LIB_PRIVATE
-ssize_t
-_real_read(int fd, void *buf, size_t count)
-{
-  REAL_FUNC_PASSTHROUGH(read) (fd, buf, count);
-}
-
-LIB_PRIVATE
-ssize_t
-_real_write(int fd, const void *buf, size_t count)
-{
-  REAL_FUNC_PASSTHROUGH_TYPED(ssize_t, write) (fd, buf, count);
-}
-
-LIB_PRIVATE
-int
-_real_select(int nfds,
-             fd_set *readfds,
-             fd_set *writefds,
-             fd_set *exceptfds,
-             struct timeval *timeout)
-{
-  REAL_FUNC_PASSTHROUGH(select) (nfds, readfds, writefds, exceptfds, timeout);
 }
 
 LIB_PRIVATE
@@ -1094,11 +1068,4 @@ _real_mq_timedsend(mqd_t mqdes,
 {
   REAL_FUNC_PASSTHROUGH(mq_timedsend) (mqdes, msg_ptr, msg_len, msg_prio,
                                        abs_timeout);
-}
-
-LIB_PRIVATE
-int
-_real_poll(struct pollfd *fds, nfds_t nfds, int timeout)
-{
-  REAL_FUNC_PASSTHROUGH(poll) (fds, nfds, timeout);
 }

--- a/src/syscallwrappers.h
+++ b/src/syscallwrappers.h
@@ -28,7 +28,6 @@
 // among the individual *wrappers.cpp files that actually need them,
 // and not declare every possible include in one giant .h file.
 #include <features.h>
-#include <poll.h>
 #include <pthread.h>
 #include <signal.h>
 #include <stdarg.h>
@@ -233,12 +232,6 @@ LIB_PRIVATE extern __thread int thread_performing_dlopen_dlsym;
   MACRO(mq_timedreceive)              \
   MACRO(mq_notify)                    \
                                       \
-  MACRO(read)                         \
-  MACRO(write)                        \
-                                      \
-  MACRO(select)                       \
-  MACRO(poll)                         \
-                                      \
   MACRO(pthread_create)               \
   MACRO(pthread_exit)                 \
   MACRO(pthread_tryjoin_np)           \
@@ -400,17 +393,8 @@ void *_real_dlsym(void *handle, const char *symbol);
 void *_real_dlopen(const char *filename, int flag);
 int _real_dlclose(void *handle);
 
-ssize_t _real_read(int fd, void *buf, size_t count);
-ssize_t _real_write(int fd, const void *buf, size_t count);
-int _real_select(int nfds,
-                 fd_set *readfds,
-                 fd_set *writefds,
-                 fd_set *exceptfds,
-                 struct timeval *timeout);
 off_t _real_lseek(int fd, off_t offset, int whence);
 int _real_unlink(const char *pathname);
-
-int _real_poll(struct pollfd *fds, nfds_t nfds, int timeout);
 
 int _real_waitid(idtype_t idtype, id_t id, siginfo_t *infop, int options);
 pid_t _real_wait4(pid_t pid,

--- a/src/util_misc.cpp
+++ b/src/util_misc.cpp
@@ -157,7 +157,7 @@ Util::writeAll(int fd, const void *buf, size_t count)
   size_t num_written = 0;
 
   do {
-    ssize_t rc = _real_write(fd, ptr + num_written, count - num_written);
+    ssize_t rc = write(fd, ptr + num_written, count - num_written);
     if (rc == -1) {
       if (errno == EINTR || errno == EAGAIN) {
         continue;
@@ -186,7 +186,7 @@ Util::readAll(int fd, void *buf, size_t count)
   size_t num_read = 0;
 
   for (num_read = 0; num_read < count;) {
-    rc = _real_read(fd, ptr + num_read, count - num_read);
+    rc = read(fd, ptr + num_read, count - num_read);
     if (rc == -1) {
       if (errno == EINTR || errno == EAGAIN) {
         continue;
@@ -326,7 +326,7 @@ Util::readChar(int fd)
   int rc;
 
   do {
-    rc = _real_read(fd, &c, 1);
+    rc = read(fd, &c, 1);
   } while (rc == -1 && errno == EINTR);
   if (rc <= 0) {
     return 0;


### PR DESCRIPTION
This is just a cleanup of some code leftover from the FReD era. These wrappers (and the corresponding _real_ functions aren't needed anymore).