### PR TITLE
Removed --text-offset from MTCP makefiles.

### DIFF
--- a/src/mtcp/Makefile.debug
+++ b/src/mtcp/Makefile.debug
@@ -59,9 +59,7 @@ mtcp_check_vdso.o: mtcp_check_vdso.ic mtcp_sys.h mtcp_util.h \
 #   available in the case of 'make check' dumping core.
 check: ../../bin/mtcp_restart ckpt_dmtcp1_test.dmtcp
 	@echo 'Expected result: "Error 99" (MTCP transfered to DMTCP correctly)'
-	../../bin/mtcp_restart \
-	  --text-offset `./text_offset.sh ../../bin/mtcp_restart` \
-	  ckpt_dmtcp1_test.dmtcp
+	../../bin/mtcp_restart ckpt_dmtcp1_test.dmtcp
 
 gdb: build_mtcp_restart_debug ../../lib/dmtcp/libdmtcp.so gdb_run
 build_mtcp_restart_debug:
@@ -69,9 +67,7 @@ build_mtcp_restart_debug:
 	${MAKE} -f ${lastword ${MAKEFILE_LIST}} MTCP_CFLAGS=-DLOGGING \
 	  mtcp_restart.o
 gdb_run: ../../bin/mtcp_restart ckpt_dmtcp1_test.dmtcp
-	gdb --args ../../bin/mtcp_restart \
-	  --use-gdb --text-offset `./text_offset.sh ../../bin/mtcp_restart` \
-	  ckpt_dmtcp1_test.dmtcp
+	gdb --args ../../bin/mtcp_restart --use-gdb ckpt_dmtcp1_test.dmtcp
 ckpt_dmtcp1_test.dmtcp: ../../test/dmtcp1 restore_libc.o
 	../../bin/dmtcp_launch -i3 ../../test/dmtcp1 &
 	sleep 8 && ../../bin/dmtcp_command --quit

--- a/src/mtcp/Makefile.debug
+++ b/src/mtcp/Makefile.debug
@@ -10,6 +10,8 @@ ifeq ($(M32),1)
   CFLAGS_M32 = -m32 -march=i386 -Wa,--32
 endif
 
+# Set gnu99 as set for the rest of DMTCP in configure.ac (AC_PROG_CC_STDC).
+CFLAGS += -std=gnu99
 
 # We need to integrate HOST_IS_ARM and HOST_IS_ARM64
 HOST_IS_ARM=${shell uname -m | grep '^arm' | sed -e 's^\(...\).*^\1^'}

--- a/src/mtcp/Makefile.in
+++ b/src/mtcp/Makefile.in
@@ -124,8 +124,7 @@ syscall-aarch64.o: syscall-aarch64.S
 #   available in the case of 'make check' dumping core.
 check: $(targetdir)/bin/$(MTCP_RESTART) ckpt_dmtcp1_test.dmtcp
         @echo 'Expected result: "Error 99" (MTCP transfered to DMTCP correctly)'
-	$(targetdir)/bin/$(MTCP_RESTART) --text-offset `./text_offset.sh \
-	  $(targetdir)/bin/$(MTCP_RESTART)` ckpt_dmtcp1_test.dmtcp
+	$(targetdir)/bin/$(MTCP_RESTART) ckpt_dmtcp1_test.dmtcp
 
 ckpt_dmtcp1_test.dmtcp: ../../test/dmtcp1 restore_libc.o
 	../../bin/dmtcp_launch -i3 ../../test/dmtcp1 &


### PR DESCRIPTION
This flag is not needed as we now mmap the mtcp_restart regions instead
of doing memcpy. The code automatically emits the proper address for the
add-symbol-file command.