### PR TITLE
Windows WSL: fix 'make check'

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -151,8 +151,8 @@ static void unmap_memory_areas_and_restore_vdso(RestoreInfo *rinfo);
 
 
 #define MB                 1024 * 1024
-#define RESTORE_STACK_SIZE 5 * MB
-#define RESTORE_MEM_SIZE   5 * MB
+#define RESTORE_STACK_SIZE 16 * MB
+#define RESTORE_MEM_SIZE   16 * MB
 #define RESTORE_TOTAL_SIZE (RESTORE_STACK_SIZE + RESTORE_MEM_SIZE)
 
 // const char service_interp[] __attribute__((section(".interp"))) =
@@ -1351,6 +1351,22 @@ remapMtcpRestartToReservedArea(RestoreInfo *rinfo)
   size_t remaining_restore_area =
     rinfo->restore_addr + rinfo->restore_size - guard_page_end_addr;
 
+#ifdef WSL
+  // FIXME:  The assert below used to fail on WSL.  (Still a work in progress.)
+  //   NOTE that PR #774 raises the following also in src/processinfo.h
+  //     #define RESTORE_STACK_SIZE 16 * MB
+  //     #define RESTORE_MEM_SIZE   16 * MB
+  //   The new values seem to allow the assert below to pass now on WSL.
+  //   Maybe this must correspond between processinfo.h and mtcp_restart.c.
+  //   Maybe it must be a multiple of 2 MB to support HUGEPAGES for WSL ???
+  //   Maybe WSL needs a larger stack, since they don't support MAP_GROWSDOWN
+  // These debugging prints were to catch a failed asserg when
+  //   processinfo.h was set to only 5 MB earlier.  Let's see if the
+  //   assert fails in the future on WSL.  (work in progress)
+  // DPRINTF("remaining_restore_area: %x\na", remaining_restore_area);
+  // DPRINTF("rinfo->old_stack_size: %x\na", rinfo->old_stack_size);
+  // REMOVE ALL OF THESE COMMENTS WHEN THIS CODE IS MATURE.
+#endif
   MTCP_ASSERT(remaining_restore_area >= rinfo->old_stack_size);
 
   void *new_stack_end_addr = rinfo->restore_addr + rinfo->restore_size;

--- a/src/plugin/ipc/connection.cpp
+++ b/src/plugin/ipc/connection.cpp
@@ -121,8 +121,22 @@ Connection::doLocking()
 {
   errno = 0;
   _hasLock = false;
+#ifdef WSL
+  int rc = fcntl(_fds[0], F_SETOWN, getpid());
+  // FIXME:
+  // As of Windows build 1903, fcntl fails with EINVAL if _fds[0] is a
+  //   pipe.  We could test on _fds[1] instead, but that seems fragile.
+  //   For now, DMTCP will fail on 'make check' on tests that use
+  //   multiple processes, but at least 'make check' works now.
+  //   Later, I'll come back to this and consider something narrow for _fds[1].
+  if (rc == -1 && errno != EINVAL) {
+    JASSERT(fcntl(_fds[0], F_SETOWN, getpid()) == 0)
+      (_fds[0]) (JASSERT_ERRNO);
+  }
+#else
   JASSERT(fcntl(_fds[0], F_SETOWN, getpid()) == 0)
     (_fds[0]) (JASSERT_ERRNO);
+#endif
 }
 
 void


### PR DESCRIPTION
Windows build 1903 doesn't yet support MAP_GROWSDOWN.  Also, Windows-1903 doesn't support fcntl on pipes, and so 'make check' fails when it tries to use pipes for the test.

This is an incomplete fix that I had written about having ready a few weeks ago.  But I had wanted to do debugging including in src/mtcp_restart, before committing my PR.  Debugging in src/mtcp was made possible again only six days ago, with PR #772 .