### PR TITLE
Presuspend test and bugfixes.

### DIFF
--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -219,7 +219,7 @@ int dmtcp_enable_ckpt(void) __attribute__((weak));
 
 void dmtcp_initialize_plugin(void) __attribute((weak));
 
-void dmtcp_global_barrier(const char *barrier);
+void dmtcp_global_barrier(const char *barrier) __attribute((weak));
 
 // See: test/plugin/example-db dir for an example:
 int dmtcp_send_key_val_pair_to_coordinator(const char *id,
@@ -427,7 +427,7 @@ int dmtcp_must_overwrite_file(const char *path) __attribute((weak));
 
 void dmtcp_initialize(void) __attribute((weak));
 
-void dmtcp_register_plugin(DmtcpPluginDescriptor_t);
+void dmtcp_register_plugin(DmtcpPluginDescriptor_t) __attribute((weak));
 
 // These are part of the internal implementation of DMTCP plugins
 int dmtcp_plugin_disable_ckpt(void);
@@ -439,7 +439,7 @@ void dmtcp_plugin_enable_ckpt(void);
   if (__dmtcp_plugin_ckpt_disabled) dmtcp_plugin_enable_ckpt()
 
 
-void *dmtcp_dlsym(void *handle, const char *symbol);
+void *dmtcp_dlsym(void *handle, const char *symbol) __attribute((weak));
 void *dmtcp_dlvsym(void *handle, char *symbol, const char *version);
 void *dmtcp_dlsym_lib(const char *libname, const char *symbol);
 

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -425,7 +425,7 @@ bool waitForBarrier(const string& barrier,
 
   sendMsgToCoordinator(DmtcpMessage(DMT_BARRIER), barrier);
 
-  JTRACE("waiting for DMT_BARRIER_RELEASED message");
+  JTRACE("waiting for DMT_BARRIER_RELEASED message") (barrier);
 
   char *extraData = NULL;
   DmtcpMessage msg;

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -577,7 +577,7 @@ DmtcpCoordinator::onData(CoordClient *client)
       (msg.from) (client->state()) (msg.state) (barrier);
 
     client->setState(msg.state);
-    // Warn if we have two consequtive barriers of the same name.
+    // Warn if we have two consecutive barriers of the same name.
     JWARNING(barrier != client->barrier()) (barrier) (client->barrier());
     client->setBarrier(barrier);
     processBarrier(barrier);

--- a/src/plugin/ipc/connection.cpp
+++ b/src/plugin/ipc/connection.cpp
@@ -95,8 +95,11 @@ Connection::restoreOptions()
     (_fds[0]) (_fcntlFlags) (JASSERT_ERRNO);
 
   errno = 0;
-  JASSERT(fcntl(_fds[0], F_SETOWN, (int)_fcntlOwner) == 0)
-    (_fds[0]) (_fcntlOwner) (JASSERT_ERRNO);
+  // Check to see if the owner is alive; if so, try to restore fd ownership.
+  if (kill(_fcntlOwner, 0) == 0) {
+    JASSERT(fcntl(_fds[0], F_SETOWN, (int)_fcntlOwner) == 0)
+      (_fds[0]) (_fcntlOwner) (JASSERT_ERRNO);
+  }
 
   // FIXME:  The comment below seems to be obsolete now.
   // This JASSERT will almost always trigger until we fix the above mentioned

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -771,6 +771,8 @@ runTest("stat",         1, ["./test/stat"])
 
 runTest("rlimit-restore",         1, ["./test/rlimit-restore"])
 
+runTest("presuspend",   [1, 2], ["./test/presuspend"])
+
 PWD=os.getcwd()
 runTest("plugin-sleep2", 1, ["--with-plugin "+
                              PWD+"/test/plugin/sleep1/dmtcp_sleep1hijack.so:"+

--- a/test/presuspend.c
+++ b/test/presuspend.c
@@ -1,0 +1,121 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <pthread.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "dmtcp.h"
+
+#define NUM_THREADS 10
+#define GETTID() syscall(SYS_gettid)
+
+pid_t childPid = 0;
+
+void presuspend1()
+{
+  if (childPid) {
+    printf("Parent: Presuspend1: sending SIGINT to child\n");
+    kill(childPid, SIGINT);
+    assert(waitpid(childPid, NULL, 0) == childPid);
+  } else {
+    printf("Child: Presuspend1\n");
+  }
+  fflush(stdout);
+}
+
+void presuspend2()
+{
+  printf("Parent: Presuspend2\n");
+  fflush(stdout);
+}
+
+void precheckpoint()
+{
+  printf("Parent: Precheckpoint\n");
+  fflush(stdout);
+}
+
+void resume()
+{
+  printf("Parent: Resume\n");
+  fflush(stdout);
+}
+
+static void
+presuspend_eventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
+{
+  switch (event) {
+  case DMTCP_EVENT_INIT:
+    break;
+
+  case DMTCP_EVENT_PRESUSPEND:
+    presuspend1();
+    dmtcp_global_barrier("presuspend:barrier1");
+    presuspend2();
+    break;
+
+  case DMTCP_EVENT_PRECHECKPOINT:
+    precheckpoint();
+    break;
+
+  case DMTCP_EVENT_RESUME:
+  case DMTCP_EVENT_RESTART:
+    resume();
+    childPid = 0;
+    break;
+
+  default:
+    break;
+  }
+}
+
+DmtcpPluginDescriptor_t presuspend_plugin = {
+  DMTCP_PLUGIN_API_VERSION,
+  DMTCP_PACKAGE_VERSION,
+  "presuspend",
+  "DMTCP",
+  "dmtcp@ccs.neu.edu",
+  "Presuspend test plugin",
+  presuspend_eventHook
+};
+
+int main()
+{
+  dmtcp_register_plugin(presuspend_plugin);
+
+  while (1) {
+    childPid = fork();
+    if (childPid == 0) {
+      int childCounter = 1;
+      while (1) {
+        printf("Child %d\n", childCounter++);
+        fflush(stdout);
+        sleep(1);
+      }
+    } else {
+      int parentCounter = 1;
+      while(childPid && kill(childPid, 0) == 0) {
+        printf("Parent %d\n", parentCounter++);
+        fflush(stdout);
+        sleep(1);
+      }
+      printf("Parent: Child exited; will fork another child.\n");
+      fflush(stdout);
+
+      // Wait for resume before forking another child.
+      // TODO(Kapil): Add support for creating  new processes in Presuspend
+      //              phase.
+      while (childPid != 0) {
+        sleep(1);
+      }
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds a test that exercises the `presuspend` barrier path and kills a child process. This is similar to our original use-case of killing auxiliary processes during the presuspend phase.