### PR TITLE
Make plugin source independent of dmtcp/version.h

### DIFF
--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -31,7 +31,9 @@
 # undef __USE_GNU
 #endif // ifdef __USE_GNU_NOT_SET
 
-#include "dmtcp/version.h"
+#ifndef DMTCP_PACKAGE_VERSION
+# include "dmtcp/version.h"
+#endif
 
 #ifdef __cplusplus
 # define EXTERNC extern "C"

--- a/test/plugin/applic-delayed-ckpt/Makefile
+++ b/test/plugin/applic-delayed-ckpt/Makefile
@@ -19,6 +19,11 @@ override CFLAGS += -I${DMTCP_INCLUDE}
 override CXXFLAGS += -I${DMTCP_INCLUDE}
 LINK = ${CC}
 
+# if version.h not found:
+ifeq (,$(wildcard ${DMTCP_INCLUDE}/dmtcp/version.h))
+  override CFLAGS += -DDMTCP_PACKAGE_VERSION='"3.0.0"'
+endif
+
 DEMO_PORT=7781
 
 default: ${LIBNAME}.so applic

--- a/test/plugin/applic-initiated-ckpt/Makefile
+++ b/test/plugin/applic-initiated-ckpt/Makefile
@@ -19,6 +19,11 @@ override CFLAGS += -I${DMTCP_INCLUDE}
 override CXXFLAGS += -I${DMTCP_INCLUDE}
 LINK = ${CC}
 
+# if version.h not found:
+ifeq (,$(wildcard ${DMTCP_INCLUDE}/dmtcp/version.h))
+  override CFLAGS += -DDMTCP_PACKAGE_VERSION='"3.0.0"'
+endif
+
 DEMO_PORT=7781
 
 default: ${LIBNAME}.so applic

--- a/test/plugin/example-db/Makefile
+++ b/test/plugin/example-db/Makefile
@@ -19,6 +19,11 @@ override CFLAGS += -fPIC -I${DMTCP_INCLUDE}
 override CXXFLAGS += -fPIC -I${DMTCP_INCLUDE}
 LINK = ${CC}
 
+# if version.h not found:
+ifeq (,$(wildcard ${DMTCP_INCLUDE}/dmtcp/version.h))
+  override CFLAGS += -DDMTCP_PACKAGE_VERSION='"3.0.0"'
+endif
+
 DEMO_PORT=7781
 
 default: ${LIBNAME}.so

--- a/test/plugin/example/Makefile
+++ b/test/plugin/example/Makefile
@@ -19,6 +19,11 @@ override CFLAGS += -fPIC -I${DMTCP_INCLUDE}
 override CXXFLAGS += -fPIC -I${DMTCP_INCLUDE}
 LINK = ${CC}
 
+# if version.h not found:
+ifeq (,$(wildcard ${DMTCP_INCLUDE}/dmtcp/version.h))
+  override CFLAGS += -DDMTCP_PACKAGE_VERSION='"3.0.0"'
+endif
+
 DEMO_PORT=7781
 
 default: ${LIBNAME}.so

--- a/test/plugin/sleep1/Makefile
+++ b/test/plugin/sleep1/Makefile
@@ -19,6 +19,11 @@ override CFLAGS += -fPIC -I${DMTCP_INCLUDE}
 override CXXFLAGS += -fPIC -I${DMTCP_INCLUDE}
 LINK = ${CC}
 
+# if version.h not found:
+ifeq (,$(wildcard ${DMTCP_INCLUDE}/dmtcp/version.h))
+  override CFLAGS += -DDMTCP_PACKAGE_VERSION='"3.0.0"'
+endif
+
 DEMO_PORT=7781
 
 default: ${LIBNAME}.so

--- a/test/plugin/sleep2/Makefile
+++ b/test/plugin/sleep2/Makefile
@@ -20,6 +20,11 @@ override CFLAGS += -fPIC -I${DMTCP_INCLUDE}
 override CXXFLAGS += -fPIC -I${DMTCP_INCLUDE}
 LINK = ${CC}
 
+# if version.h not found:
+ifeq (,$(wildcard ${DMTCP_INCLUDE}/dmtcp/version.h))
+  override CFLAGS += -DDMTCP_PACKAGE_VERSION='"3.0.0"'
+endif
+
 DEMO_PORT=7781
 
 default: ${LIBNAME}.so


### PR DESCRIPTION
Right now, a user (like me) will copy a plugin from test/plugin into their own directory.  They will then coyp `include/dmtcp.h` into that plugin directory and adjust `Makefile~, so ~DMTCP_INCLUDE=.`.  They will then do `make` to make binaries from the source.

This doesn't work because their is a hidden file, `include/dmtcp/version.h`, that is included through `include/dmtcp.h`.

So, the plugin API should not change with newer 3.x DMTCP versions (or at least not change too much).  But the user is not allowed to copy their plugin tarball to a new machine, with their built-in `dmtcp.h`, and compile and run using a public DMTCP executable in their path.  They also have a dependency on `/usr/include/dmtcp/version.h` (or `/usr/local/include/dmtcp/version.h` or some other location that they need to track down), so that they will inherit the version number of the production machine, and not the version number of the development version.  _Why do we care to enforce silly things like this?_  (The rest of DMTCP doesn't care about these versions.)

With this PR, the user can default `DMTCP_PACKAGE_VERSION` to `"3.0.0"` and not worry about it.

