### PR TITLE
Add 'default:' to 'switch' for: gcc -Wswitch/-Wall

### DIFF
--- a/plugin/batch-queue/rm_main.cpp
+++ b/plugin/batch-queue/rm_main.cpp
@@ -87,6 +87,9 @@ rm_EventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
     dmtcp_global_barrier("RM::Restart");
     restart_resume();
     break;
+
+  default:  // other events are not registered
+    break;
   }
 }
 

--- a/plugin/modify-env/modify-env.c
+++ b/plugin/modify-env/modify-env.c
@@ -94,6 +94,9 @@ modifyenv_EventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
   case DMTCP_EVENT_RESTART:
     restart();
     break;
+
+  default:  // other events are not registered
+    break;
   }
 }
 

--- a/plugin/unique-ckpt/unique-ckpt.cpp
+++ b/plugin/unique-ckpt/unique-ckpt.cpp
@@ -40,6 +40,9 @@ uniqueckpt_EventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
   case DMTCP_EVENT_PRECHECKPOINT:
     updateCkptDir();
     break;
+
+  default:  // other events are not registered
+    break;
   }
 }
 

--- a/src/plugin/ipc/connection.cpp
+++ b/src/plugin/ipc/connection.cpp
@@ -110,7 +110,7 @@ Connection::restoreOptions()
 
   errno = 0;
 #ifndef WSL
-  // WSL doesn't seem to support this yet (as of Windows 10 build 1803)
+  // WSL doesn't seem to support this yet (as of Windows 10 build 1903)
   JASSERT(fcntl(_fds[0], F_SETSIG, (int)_fcntlSignal) == 0)
     (_fds[0]) (_fcntlSignal) (JASSERT_ERRNO);
 #endif

--- a/src/plugin/ipc/event/eventconnlist.cpp
+++ b/src/plugin/ipc/event/eventconnlist.cpp
@@ -40,6 +40,9 @@ dmtcp_EventConnList_EventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
     dmtcp_global_barrier("Event::RESTART_REFILL");
     EventConnList::restartResume();
     break;
+
+  default:  // other events are not registered
+    break;
   }
 }
 

--- a/src/plugin/ipc/file/fileconnlist.cpp
+++ b/src/plugin/ipc/file/fileconnlist.cpp
@@ -119,6 +119,9 @@ dmtcp_FileConnList_EventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
     FileConnList::restartResume();
     dmtcp_global_barrier("File::RESTART_RESUME");
     break;
+
+  default:  // other events are not registered
+    break;
   }
 }
 

--- a/src/plugin/ipc/file/ptyconnlist.cpp
+++ b/src/plugin/ipc/file/ptyconnlist.cpp
@@ -54,6 +54,9 @@ dmtcp_PtyConnList_EventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
     dmtcp_global_barrier("Pty::RESTART_POST_RESTART");
     PtyConnList::restartRefill();
     break;
+
+  default:  // other events are not registered
+    break;
   }
 }
 

--- a/src/plugin/ipc/socket/socketconnlist.cpp
+++ b/src/plugin/ipc/socket/socketconnlist.cpp
@@ -44,7 +44,6 @@ dmtcp_SocketConnList_EventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
     dmtcp_global_barrier("Socket::Resume_Refill");
     SocketConnList::resumeResume();
     dmtcp_global_barrier("Socket::Resume_Resume");
-
     break;
 
   case DMTCP_EVENT_RESTART:
@@ -60,6 +59,9 @@ dmtcp_SocketConnList_EventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
     dmtcp_global_barrier("Socket::Restart_Refill");
     SocketConnList::restartResume();
     dmtcp_global_barrier("Socket::Restart_Resume");
+    break;
+
+  default:  // other events are not registered
     break;
   }
 }

--- a/src/plugin/ipc/ssh/ssh.cpp
+++ b/src/plugin/ipc/ssh/ssh.cpp
@@ -61,6 +61,9 @@ dmtcp_SSH_EventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
   case DMTCP_EVENT_RESTART:
     dmtcp_ssh_restart();
     break;
+
+  default:  // other events are not registered
+    break;
   }
 }
 

--- a/src/terminal.cpp
+++ b/src/terminal.cpp
@@ -120,6 +120,9 @@ terminal_EventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
   case DMTCP_EVENT_RESTART:
     restore_term_settings();
     break;
+
+  default:  // other events are not registered
+    break;
   }
 }
 


### PR DESCRIPTION
`./configure --enable-debug` invokes `gcc -Wall', which implies `gcc -Wswitch`.  We then get spurious warnings unless we add a default case:
```
  default:  // other events are not registered
    break;
```