### PR TITLE
./configure --enable-multilib:  check if 32-bit libs available

### DIFF
--- a/configure
+++ b/configure
@@ -5731,6 +5731,13 @@ else
 
 fi
 
+CFLAGS_64="$CFLAGS"
+CXXFLAGS_64="$CXXFLAGS"
+LDFLAGS_64="$LDFLAGS"
+CFLAGS_32="$CFLAGS -m32 -march=i686 -Wa,--32"
+CXXFLAGS_32="$CXXFLAGS -m32 -march=i686 -Wa,--32"
+LDFLAGS_32="$LDFLAGS -m32 -march=i686 -Wl,-m32 -Wl,-melf_i386 -Wa,--32"
+
 # Check whether --enable-m32 was given.
 if test "${enable_m32+set}" = set; then :
   enableval=$enable_m32; use_m32=$enableval
@@ -5756,12 +5763,50 @@ if test "$use_m32" = "yes"; then
 $as_echo "#define CONFIG_M32 1" >>confdefs.h
 
 
-  CFLAGS="$CFLAGS -m32 -march=i686 -Wa,--32"
-  CXXFLAGS="$CXXFLAGS -m32 -march=i686 -Wa,--32"
-  LDFLAGS="$LDFLAGS -m32 -march=i686 -Wl,-m32 -Wl,-melf_i386 -Wa,--32"
+  CFLAGS="$CFLAGS_32"
+  CXXFLAGS="$CXXFLAGS_32"
+  LDFLAGS="$LDFLAGS_32"
+else
+  M32=0
 
+fi
+
+# Check whether --enable-multilib was given.
+if test "${enable_multilib+set}" = set; then :
+  enableval=$enable_multilib; use_multilib=$enableval
+else
+  use_multilib=no
+fi
+
+
+ if test "$use_multilib" = "yes"; then
+  CONFIG_MULTILIB_TRUE=
+  CONFIG_MULTILIB_FALSE='#'
+else
+  CONFIG_MULTILIB_TRUE='#'
+  CONFIG_MULTILIB_FALSE=
+fi
+
+if test "$use_multilib" = "yes"; then
+  MULTILIB=1
+
+  HAS_READLINE=no
+
+
+$as_echo "#define CONFIG_MULTILIB 1" >>confdefs.h
+
+else
+  MULTILIB=0
+
+fi
+
+if test "$use_m32" = "yes" -o "$use_multilib" = "yes"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether multilib $CC compiles using -m32" >&5
 $as_echo_n "checking whether multilib $CC compiles using -m32... " >&6; }
+  CFLAGS="$CFLAGS_32"
+  CXXFLAGS="$CXXFLAGS_32"
+  LDFLAGS="$LDFLAGS_32"
+
   ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -5861,38 +5906,11 @@ as_fn_error $? "Failed to build $CXX program with -m32
      or the equivalent packages for your Linux distro.
 See \`config.log' for more details" "$LINENO" 5; }
   fi
-else
-  M32=0
-
-fi
-
-# Check whether --enable-multilib was given.
-if test "${enable_multilib+set}" = set; then :
-  enableval=$enable_multilib; use_multilib=$enableval
-else
-  use_multilib=no
-fi
-
-
- if test "$use_multilib" = "yes"; then
-  CONFIG_MULTILIB_TRUE=
-  CONFIG_MULTILIB_FALSE='#'
-else
-  CONFIG_MULTILIB_TRUE='#'
-  CONFIG_MULTILIB_FALSE=
-fi
-
-if test "$use_multilib" = "yes"; then
-  MULTILIB=1
-
-  HAS_READLINE=no
-
-
-$as_echo "#define CONFIG_MULTILIB 1" >>confdefs.h
-
-else
-  MULTILIB=0
-
+  if test "$use_multilib" = "yes"; then
+    CFLAGS="$CFLAGS_64"
+    CXXFLAGS="$CXXFLAGS_64"
+    LDFLAGS="$LDFLAGS_64"
+  fi
 fi
 
 # Check whether --enable-static_libstdcxx was given.

--- a/configure.ac
+++ b/configure.ac
@@ -274,6 +274,14 @@ else
   AC_SUBST([HAS_MUTEX_WRAPPERS], [no])
 fi
 
+dnl --enable-m32 will use _32 variant, but --enable_multilib uses _64 variant
+CFLAGS_64="$CFLAGS"
+CXXFLAGS_64="$CXXFLAGS"
+LDFLAGS_64="$LDFLAGS"
+CFLAGS_32="$CFLAGS -m32 -march=i686 -Wa,--32"
+CXXFLAGS_32="$CXXFLAGS -m32 -march=i686 -Wa,--32"
+LDFLAGS_32="$LDFLAGS -m32 -march=i686 -Wl,-m32 -Wl,-melf_i386 -Wa,--32"
+
 AC_ARG_ENABLE([m32],
             [AS_HELP_STRING([--enable-m32],
                             [Compile in 320bit mode on 64-bit Linux. (Works on
@@ -288,11 +296,39 @@ if test "$use_m32" = "yes"; then
   AC_SUBST([HAS_READLINE], [no])
   AC_DEFINE([CONFIG_M32],[1],[Compiling in 32-bit mode on 64-bit Linux.])
 
-  CFLAGS="$CFLAGS -m32 -march=i686 -Wa,--32"
-  CXXFLAGS="$CXXFLAGS -m32 -march=i686 -Wa,--32"
-  LDFLAGS="$LDFLAGS -m32 -march=i686 -Wl,-m32 -Wl,-melf_i386 -Wa,--32"
+  CFLAGS="$CFLAGS_32"
+  CXXFLAGS="$CXXFLAGS_32"
+  LDFLAGS="$LDFLAGS_32"
+else
+  AC_SUBST([M32], [0])
+fi
 
+dnl If --enable-multilib is invoked, then the top-level 'Makefile' will
+dnl   create config.status-multilib-m32.
+dnl Invoking ./config.status-multilib-m32 configures as if --enable-m32 called.
+dnl Invoking ./config.status configures as if --enable-m32 was not called.
+AC_ARG_ENABLE([multilib],
+            [AS_HELP_STRING([--enable-multilib],
+                            [Compile for mixed 32-bit and 64-bit mode.
+                             (Requires gcc-multilib/g++-multilib packages.)])],
+            [use_multilib=$enableval],
+            [use_multilib=no])
+
+AM_CONDITIONAL(CONFIG_MULTILIB, [test "$use_multilib" = "yes"])
+if test "$use_multilib" = "yes"; then
+  AC_SUBST([MULTILIB], [1])
+  AC_SUBST([HAS_READLINE], [no])
+  AC_DEFINE([CONFIG_MULTILIB],[1],[Compiling in 32-bit/64-bit mixed mode.])
+else
+  AC_SUBST([MULTILIB], [0])
+fi
+
+if test "$use_m32" = "yes" -o "$use_multilib" = "yes"; then
   AC_MSG_CHECKING([whether multilib $CC compiles using -m32])
+  CFLAGS="$CFLAGS_32"
+  CXXFLAGS="$CXXFLAGS_32"
+  LDFLAGS="$LDFLAGS_32"
+
   AC_LANG_PUSH([C])
   AC_LINK_IFELSE([AC_LANG_PROGRAM([[
   #include <stdio.h>
@@ -329,28 +365,11 @@ if test "$use_m32" = "yes"; then
      or glibc-devel-32bit (SUSE/OpenSUSE)
      or the equivalent packages for your Linux distro.]])
   fi
-else
-  AC_SUBST([M32], [0])
-fi
-
-dnl If --enable-multilib is invoked, then the top-level 'Makefile' will
-dnl   create config.status-multilib-m32.
-dnl Invoking ./config.status-multilib-m32 configures as if --enable-m32 called.
-dnl Invoking ./config.status configures as if --enable-m32 was not called.
-AC_ARG_ENABLE([multilib],
-            [AS_HELP_STRING([--enable-multilib],
-                            [Compile for mixed 32-bit and 64-bit mode.
-                             (Requires gcc-multilib/g++-multilib packages.)])],
-            [use_multilib=$enableval],
-            [use_multilib=no])
-
-AM_CONDITIONAL(CONFIG_MULTILIB, [test "$use_multilib" = "yes"])
-if test "$use_multilib" = "yes"; then
-  AC_SUBST([MULTILIB], [1])
-  AC_SUBST([HAS_READLINE], [no])
-  AC_DEFINE([CONFIG_MULTILIB],[1],[Compiling in 32-bit/64-bit mixed mode.])
-else
-  AC_SUBST([MULTILIB], [0])
+  if test "$use_multilib" = "yes"; then
+    CFLAGS="$CFLAGS_64"
+    CXXFLAGS="$CXXFLAGS_64"
+    LDFLAGS="$LDFLAGS_64"
+  fi
 fi
 
 AC_ARG_ENABLE([static_libstdcxx],


### PR DESCRIPTION
This changes only `configure.ac` (and therefore `configure`).  When the user invokes:
```
/configure --enable-multilib
```
it now checks if the 32-bit libc and stdc++ libraries are available.  (Needed for mixed 32-/64-bit mode.)

This PR depends on PR #782 being merged first.