### PR TITLE
autotest.py:  fix print bug in commit 7e00e93

### DIFF
--- a/src/signalwrappers.cpp
+++ b/src/signalwrappers.cpp
@@ -342,7 +342,7 @@ pthread_sigmask(int how, const sigset_t *set, sigset_t *oldmask)
 }
 
 /*
- * TODO: man page says that sigwait is implemented via sigtimedwait, however
+ * TODO: man page says that sigwait is implemented via sigtimedwait. However,
  * sigtimedwait can return EINTR (acc. to man page) whereas sigwait won't.
  * Should we make the wrappers for sigwait/sigtimedwait homogeneous??
  *                                                          -- Kapil
@@ -366,8 +366,8 @@ sigwait(const sigset_t *set, int *sig)
 
 /*
  * In sigwaitinfo and sigtimedwait, it is not possible to differentiate between
- * a DMTCP_SIGCKPT and any other signal (that is outside the given signal set)
- * that might have occurred while executing the system call. These system call
+ * a DMTCP_SIGCKPT and any other signal (that is outside the given signal set),
+ * which might have occurred while executing the system call. These system calls
  * will return -1 with errno set to EINTR.
  * To deal with the situation, we do not remove the DMTCP_SIGCKPT from the
  * signal set (if it is present); instead, we check the return value and if it
@@ -383,7 +383,7 @@ sigwait(const sigset_t *set, int *sig)
  * user supplied 'set' and then call sigwaitinfo and then we won't need to
  * raise the STOPSIGNAL ourselves. However, there is a catch. sigwaitinfo will
  * return 'EINTR' if the wait was interrupted by a signal handler (STOPSIGNAL
- * in our case), thus we can either call sigwaitinfo again or return the error
+ * in our case). Thus, we can either call sigwaitinfo again or return the error
  * to the user code; I would like to do the former.
  *                                                              -- Kapil
  */

--- a/src/threadwrappers.cpp
+++ b/src/threadwrappers.cpp
@@ -259,7 +259,7 @@ pthread_exit(void *retval)
  *   while !succeeded
  *     futex(&pd->tid, FUTEX_WAIT, 0, _tid, ...)
  * As we can see, if the checkpoint is issued during pthread_join(), on
- * restart, the tid would have changed, but the call to futex would still used
+ * restart, the tid would have changed, but the call to futex would still use
  * the previously cached tid. This causes the caller to spin with 100% cpu
  * usage.
  *

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -211,7 +211,6 @@ if not os.path.isfile('./bin/dmtcp_launch'):
 
 #pad a string and print/flush it
 def printFixed(str, w=1):
-  # The comma at end of print prevents a "newline", but still adds space.
   os.write(sys.stdout.fileno(), str.ljust(w).encode("ascii"))
   sys.stdout.flush()
 
@@ -585,7 +584,7 @@ def runTestRaw(name, numProcs, cmds):
 
     for i in range(CYCLES):
       if i!=0 and i%2==0:
-        print() #newline
+        printFixed("\n")
         printFixed("",15)
       printFixed("ckpt:")
       # NOTE:  If this faile, it will throw an exception to CheckFailed
@@ -638,7 +637,7 @@ def runTestRaw(name, numProcs, cmds):
         printFixed("; ")
 
     testKill()
-    print() #newline
+    printFixed("\n")
     stats[0]+=1
 
   except CheckFailed as e:


### PR DESCRIPTION
The only part really to review is the two print statements in autotest.py.  Everything, else isjust  polishing comments.

In PR #792, I tested `python3 autotest.py` and `print #newline` had to be changed to `print()`.  But then, I didn't notice that in testing `python autotest.py`, this will print `()`.  So, now I use `printFixed("\n")` to do the same thing with both Python2 and Python3.