### PR TITLE
Fixes for aarch64

### DIFF
--- a/src/execwrappers.cpp
+++ b/src/execwrappers.cpp
@@ -20,16 +20,6 @@
  ****************************************************************************/
 
 #include <sys/syscall.h>
-#ifdef __aarch64__
-#define __ARCH_WANT_SYSCALL_DEPRECATED
-
-// SYS_fork is a deprecated kernel call in aarch64; in favor of SYS_clone?
-#include <asm-generic/unistd.h>
-
-// SYS_fork undefined in aarch64, but add extra insurance
-#undef SYS_fork
-#define SYS_fork __NR_fork
-#endif  // ifdef __aarch64__
 #include "../jalib/jassert.h"
 #include "../jalib/jconvert.h"
 #include "../jalib/jfilesystem.h"
@@ -168,7 +158,11 @@ extern "C" pid_t
 fork()
 {
   if (isPerformingCkptRestart()) {
+#ifndef __aarch64__
     return _real_syscall(SYS_fork);
+#else
+    return _real_fork();
+#endif
   }
 
   /* Acquire the wrapperExeution lock to prevent checkpoint to happen while

--- a/src/miscwrappers.cpp
+++ b/src/miscwrappers.cpp
@@ -55,22 +55,21 @@
 // SYS_fork is a deprecated kernel call in aarch64; in favor of SYS_clone?
 # include <asm-generic/unistd.h>
 
-// SYS_fork undefined in aarch64, but add extra insurance
-# undef SYS_fork
-# undef SYS_open
-# undef SYS_pipe
-# undef SYS_poll
-# define SYS_fork         __NR_fork
-# define SYS_open         __NR_open
-# define SYS_pipe         __NR_pipe
-# define SYS_poll         __NR_poll
+// SYS_fork, etc., are undefined in aarch64
+// Presumably, libc translates the POSIX syscalls into later kernel calls.
+// # define SYS_fork         __NR_fork
+// # define SYS_open         __NR_open
+// # define SYS_pipe         __NR_pipe
+// # define SYS_poll         __NR_poll
 
-// These kernel calls are not deprecated.  But SYS_XXX is not defined for them.
-# define SYS_epoll_create __NR_epoll_create
-# define SYS_inotify_init __NR_inotify_init
-# define SYS_signalfd     __NR_signalfd
-# define SYS_eventfd      __NR_eventfd
+// These kernel calls are now often gone on aarch64.  SYS_XXX should not be
+//   defined for them.
+// # define SYS_epoll_create __NR_epoll_create
+// # define SYS_inotify_init __NR_inotify_init
+// # define SYS_signalfd     __NR_signalfd
+// # define SYS_eventfd      __NR_eventfd
 #endif // ifdef __aarch64__
+
 
 using namespace dmtcp;
 
@@ -349,23 +348,27 @@ syscall(long sys_num, ...)
     break;
   }
 
+# ifndef __aarch64__
   case SYS_fork:
   {
     ret = fork();
     break;
   }
+# endif // ifndef __aarch64__
   case SYS_exit:
   {
     SYSCALL_GET_ARG(int, status);
     exit(status);
     break;
   }
+# ifndef __aarch64__
   case SYS_open:
   {
     SYSCALL_GET_ARGS_3(const char *, pathname, int, flags, mode_t, mode);
     ret = open(pathname, flags, mode);
     break;
   }
+# endif // ifndef __aarch64__
   case SYS_close:
   {
     SYSCALL_GET_ARG(int, fd);
@@ -515,12 +518,14 @@ syscall(long sys_num, ...)
   }
 #endif // ifdef __x86_64__
 
+# ifndef __aarch64__
   case SYS_pipe:
   {
     SYSCALL_GET_ARG(int *, fds);
     ret = pipe(fds);
     break;
   }
+# endif // ifdef __aarch64__
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)) && __GLIBC_PREREQ(2, 9)
   case SYS_pipe2:
   {
@@ -572,33 +577,42 @@ syscall(long sys_num, ...)
   }
 # endif // ifdef __x86_64__
 #endif // ifndef DISABLE_SYS_V_IPC
+# ifndef __aarch64__
   case SYS_poll:
   {
     SYSCALL_GET_ARGS_3(struct pollfd *, fds, nfds_t, nfds, int, timeout);
     ret = poll(fds, nfds, timeout);
     break;
   }
+# endif // ifdef __aarch64__
+# ifndef __aarch64__
   case SYS_epoll_create:
   {
     SYSCALL_GET_ARG(int, size);
     ret = epoll_create(size);
     break;
   }
+# endif // ifdef __aarch64__
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 13) && __GLIBC_PREREQ(2, 4)
+# ifndef __aarch64__
   case SYS_inotify_init:
   {
     ret = inotify_init();
     break;
   }
+# endif // ifdef __aarch64__
 #endif // if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 13) && __GLIBC_PREREQ(2,
        // 4)
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 22) && __GLIBC_PREREQ(2, 8)
+# ifndef __aarch64__
   case SYS_signalfd:
   {
     SYSCALL_GET_ARGS_3(int, fd, sigset_t *, mask, int, flags);
     ret = signalfd(fd, mask, flags);
     break;
   }
+# endif // ifndef __aarch64__
 #endif // if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 22) && __GLIBC_PREREQ(2,
        // 8)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27) && __GLIBC_PREREQ(2, 8)
@@ -611,12 +625,14 @@ syscall(long sys_num, ...)
 #endif // if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27) && __GLIBC_PREREQ(2,
        // 8)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 22) && __GLIBC_PREREQ(2, 8)
+# ifndef __aarch64__
   case SYS_eventfd:
   {
     SYSCALL_GET_ARGS_2(unsigned int, initval, int, flags);
     ret = eventfd(initval, flags);
     break;
   }
+# endif // ifndef __aarch64__
 #endif // if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 22) && __GLIBC_PREREQ(2,
        // 8)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27) && __GLIBC_PREREQ(2, 8)
@@ -632,7 +648,7 @@ syscall(long sys_num, ...)
   case SYS_epoll_create1:
   {
     SYSCALL_GET_ARG(int, flags);
-    ret = epoll_create(flags);
+    ret = epoll_create1(flags);
     break;
   }
   case SYS_inotify_init1:

--- a/src/plugin/pid/pid_miscwrappers.cpp
+++ b/src/plugin/pid/pid_miscwrappers.cpp
@@ -21,16 +21,6 @@
 
 #include <semaphore.h>
 #include <sys/syscall.h>
-#ifdef __aarch64__
-#define __ARCH_WANT_SYSCALL_DEPRECATED
-
-// SYS_getpgrp is a deprecated kernel call in aarch64, but in favor of what?
-#include <asm-generic/unistd.h>
-
-// SYS_getpgrp undefined in aarch64, but add extra insurance
-#undef SYS_getpgrp
-#define SYS_getpgrp __NR_getpgrp
-#endif  // ifdef __aarch64__
 #include <linux/version.h>
 
 #include "jassert.h"
@@ -373,11 +363,16 @@ syscall(long sys_num, ...)
     break;
   }
 
+// SYS_getpgrp undefined in aarch64.
+// Presumably, it's handled by libc, and is not a kernel call
+//   in AARCH64 (e.g., v5.01).
+#ifndef __aarch64__
   case SYS_getpgrp:
   {
     ret = getpgrp();
     break;
   }
+#endif
 
   case SYS_getpgid:
   {


### PR DESCRIPTION
This fixes DMTCP for aarch64 (ARM64).

It was failing for recent releases of Linux/libc for aarch64 primarily because the kernel for aarch64 had dropped its original aarch64 support for certain older kernel calls.  Presumably, this was because there were no (or almost no) aarch64 applications using those kernel calls since aarch64 is a newer architecture, and libc was now redirecting only to the newer kernel calls.  And, in principle, applications for Linux that were developed for other CPUs (as is the case for DMTCP) were assumed non-portable if they were making direct kernel calls.  So, we have now done that porting.