### PR TITLE
autotest.py: fix commit 7e00e93 for syscall-tester

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -753,7 +753,7 @@ resource.setrlimit(resource.RLIMIT_STACK, oldLimit)
 # program will try to unlink the file once again, but the unlink operation will
 # fail, causing the test to fail.
 old_ckpt_cmd = CKPT_CMD
-CKPT_CMD = 'xc'
+CKPT_CMD = b'xc'
 runTest("syscall-tester",  1, ["./test/syscall-tester"])
 CKPT_CMD = old_ckpt_cmd
 


### PR DESCRIPTION
commit 7e00e93 extended autotest.py to support both Python and Python-3.

If fails with 'python3' for the test syscall-tester.  Apparently, travis uses Python-2.7, and so this bug with Python-3 wasn't caught.

This bug fix is easy to review (just one line: convert general string to ASCII string using `b'xc'` notation for `xc`.