### PR TITLE
jalib/jalloc.c: 'size_t _blockSize;' wasn't initialized to 0

### DIFF
--- a/jalib/jalloc.cpp
+++ b/jalib/jalloc.cpp
@@ -220,7 +220,7 @@ class JFixedAllocStack
 
   private:
     FreeItem *volatile _root;
-    size_t _blockSize;
+    size_t _blockSize = 0;
     char padding[128];
     int volatile _numExpands;
 };


### PR DESCRIPTION
In `jalib/jalloc.c`, `size_t _blockSize;` was not initialized to 0.

This one-line bug fix initializes it to `0`.  This should be easy to review.