### PR TITLE
Fix for DMTCP/Makefile.in for Python3

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -207,14 +207,14 @@ tests-32: build
 LIMIT=ulimit -v 33554432
 
 check: tests
-	@ if python -c 'print "Python exits."' > /dev/null; then \
+	@ if python -c 'print("Python exits.")' > /dev/null; then \
 	  bash -c "$(LIMIT) && $(top_srcdir)/test/autotest.py ${AUTOTEST} $*"; \
 	  else echo '*** No python found in your path.'; echo '*** Please add' \
 	   ' python to path or build Python 2.x for x >= 3.'; \
 	  fi
 
 check-32: tests-32
-	@ if python -c 'print "Python exits."' > /dev/null; then \
+	@ if python -c 'print("Python exits.")' > /dev/null; then \
 	  bash -c "$(LIMIT) && $(top_srcdir)/test/autotest.py ${AUTOTEST} $*"; \
 	  else echo '*** No python found in your path.'; echo '*** Please add' \
 	   ' python to path or build Python 2.x for x >= 3.'; \


### PR DESCRIPTION
Two lines are changed in the top-level `Makefile.in`.

This uses `python`, and in the case that python refers to Python3, the python print statement was failing because it was lacking the parentheses that are needed for Python3 syntax.

This should be easy to review.