### PR TITLE
More intutitive autotest format;  ';' = new process

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -592,7 +592,7 @@ def runTestRaw(name, numProcs, cmds):
       #wait for launched processes to settle down, before we try to checkpoint
       sleep(S*SLOW)
       testCheckpoint()
-      printFixed("PASSED ")
+      printFixed("PASSED; ")
       testKill()
 
       printFixed("rstr:")
@@ -631,10 +631,12 @@ def runTestRaw(name, numProcs, cmds):
               printFixed("(Either first process didn't die, or else this long" +
                          " delay has been observed due to a slow" +
                          " NFS-based filesystem.)")
-            printFixed(" retry:")
+            printFixed("; retry:")
             testKill()
       if i != CYCLES - 1:
-        printFixed("; ")
+        printFixed(" -> ")
+        if i % 2 == 1:
+          printFixed("(cont.)") 
 
     testKill()
     printFixed("\n")


### PR DESCRIPTION
If you try `make -j check`, you'll now see:
```
== Tests ==
dmtcp1         ckpt:PASSED; rstr:PASSED -> ckpt:PASSED; rstr:PASSED
dmtcp2         ckpt:PASSED; rstr:PASSED -> ckpt:PASSED; rstr:PASSED
 ...
```
So, ';' means end of last process and starting a new process.  And '->' means continuation of current process.  This seems more intuitive for new users.