### PR TITLE
Saving and restoring more RLIMIT_XXX values

### DIFF
--- a/src/rlimitfloatenv.cpp
+++ b/src/rlimitfloatenv.cpp
@@ -18,7 +18,14 @@ namespace dmtcp
 
 static int roundingMode = -1;
 static fenv_t envp;
+static rlim_t rlim_cur_as = 0;
+static rlim_t rlim_cur_core = 0;
+static rlim_t rlim_cur_cpu = 0;
+static rlim_t rlim_cur_data = 0;
+static rlim_t rlim_cur_fsize = 0;
+static rlim_t rlim_cur_nice = 0;
 static rlim_t rlim_cur_nofile = 0;
+static rlim_t rlim_cur_nproc = 0;
 static rlim_t rlim_cur_stack = 0;
 
 static void
@@ -28,11 +35,19 @@ save_rlimit_float_settings()
   fegetenv(&envp);
 
   struct rlimit rlim = {0, 0};
-  getrlimit(RLIMIT_NOFILE, &rlim);
-  rlim_cur_nofile = rlim.rlim_cur;
+#define SAVE_RLIMIT(_RLIMIT,_rlim_cur) \
+  getrlimit(_RLIMIT, &rlim); \
+  _rlim_cur = rlim.rlim_cur;
 
-  getrlimit(RLIMIT_STACK, &rlim);
-  rlim_cur_stack = rlim.rlim_cur;
+  SAVE_RLIMIT(RLIMIT_AS, rlim_cur_as);
+  SAVE_RLIMIT(RLIMIT_CORE, rlim_cur_core);
+  SAVE_RLIMIT(RLIMIT_CPU, rlim_cur_cpu);
+  SAVE_RLIMIT(RLIMIT_DATA, rlim_cur_data);
+  SAVE_RLIMIT(RLIMIT_FSIZE, rlim_cur_fsize);
+  SAVE_RLIMIT(RLIMIT_NICE, rlim_cur_nice);
+  SAVE_RLIMIT(RLIMIT_NOFILE, rlim_cur_nofile);
+  SAVE_RLIMIT(RLIMIT_NPROC, rlim_cur_nproc);
+  SAVE_RLIMIT(RLIMIT_STACK, rlim_cur_stack);
 }
 
 static void
@@ -42,19 +57,23 @@ restore_rlimit_float_settings()
   fesetround(roundingMode);
 
   struct rlimit rlim = {0, 0};
-  getrlimit(RLIMIT_NOFILE, &rlim);
-  JWARNING(rlim_cur_nofile <= rlim.rlim_max)
-    (rlim_cur_nofile) (rlim.rlim_max)
-    .Text("Previous soft limit of RLIMIT_NOFILE lowered to new hard limit");
-  rlim.rlim_cur = MIN(rlim_cur_nofile, rlim.rlim_max);
-  JASSERT(setrlimit(RLIMIT_NOFILE, &rlim) == 0);
 
-  getrlimit(RLIMIT_STACK, &rlim);
-  JWARNING(rlim_cur_stack <= rlim.rlim_max)
-    (rlim_cur_stack) (rlim.rlim_max)
-    .Text("Previous soft limit of RLIMIT_STACK lowered to new hard limit");
-  rlim.rlim_cur = MIN(rlim_cur_stack, rlim.rlim_max);
-  JASSERT(setrlimit(RLIMIT_STACK, &rlim) == 0);
+#define RESTORE_RLIMIT(_RLIMIT,_rlim_cur) \
+  getrlimit(_RLIMIT, &rlim); \
+  JWARNING(_rlim_cur <= rlim.rlim_max) (_rlim_cur) (rlim.rlim_max) \
+    .Text("Prev. soft limit of " #_RLIMIT " lowered to new hard limit"); \
+  rlim.rlim_cur = _rlim_cur; \
+  JASSERT(setrlimit(_RLIMIT, &rlim) == 0);
+
+  RESTORE_RLIMIT(RLIMIT_AS, rlim_cur_as);
+  RESTORE_RLIMIT(RLIMIT_CORE, rlim_cur_core);
+  RESTORE_RLIMIT(RLIMIT_CPU, rlim_cur_cpu);
+  RESTORE_RLIMIT(RLIMIT_DATA, rlim_cur_data);
+  RESTORE_RLIMIT(RLIMIT_FSIZE, rlim_cur_fsize);
+  RESTORE_RLIMIT(RLIMIT_NICE, rlim_cur_nice);
+  RESTORE_RLIMIT(RLIMIT_NOFILE, rlim_cur_nofile);
+  RESTORE_RLIMIT(RLIMIT_NPROC, rlim_cur_nproc);
+  RESTORE_RLIMIT(RLIMIT_STACK, rlim_cur_stack);
 }
 
 static void

--- a/test/syscall-tester.c
+++ b/test/syscall-tester.c
@@ -4627,8 +4627,10 @@ BasicGetSetlimit(void)
   EXPECTED_RESP;
   passed = expect_val(nrlim.rlim_cur, crlim.rlim_cur);
   EXPECTED_RESP;
-  passed = expect_val(nrlim.rlim_max, crlim.rlim_max);
-  EXPECTED_RESP;
+  /* NOTE: Skipping test; DMTCP allows a larger max on a new, restart machine.
+   * passed = expect_val(nrlim.rlim_max, crlim.rlim_max);
+   * EXPECTED_RESP;
+   */
 
   /* This can't be done by a non-super user */
   /*    passed = expect_zng(SUCCESS, setrlimit_test(&orlim));*/


### PR DESCRIPTION
The 'syscall-tester' was testing on RLIMIT_CORE, and we weren't restoring that.  So, `autotest.py --stress syscall-tester` was failing.

This PR includes about 7 additional RLIMIT_XXX values to save and restore.  It uses a macro to handle the repetitive code.

In addition, `test/syscall-tester.c` was modified to not test if crlim.rlim_max is restored.  There's no need for us to restore the maximum RLIMIT_CORE, since the new restart machine may allow a larger CORE limit.