### PR TITLE
Complete 'make display-build-env' before the rest of the build in 'make'

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -67,7 +67,7 @@ endif
 
 build-multilib: build-multilib-m32 build-multilib-m64
 
-build-multilib-m32: config.status-multilib-m32
+build-multilib-m32: display-build-env config.status-multilib-m32
 	./config.status-multilib-m32
 	${MAKE} -f Makefile clean # Makefile changed; use '-f'
 	${MAKE} -f Makefile build # Makefile changed; use '-f'
@@ -108,7 +108,7 @@ config.status-multilib-m64: config.status
 	> config.status-multilib-m64
 	chmod a+x ./config.status-multilib-m64
 
-mkdirs:
+mkdirs: display-build-env
 	$(MKDIR_P) $(targetdir)/bin
 	$(MKDIR_P) $(targetdir)/lib/dmtcp
 ifeq ($(M32),1)
@@ -175,7 +175,7 @@ ${_hooksdir}/%: util/hooks/%
 # If the developer accidentally leaves an old src/config.h in place (e.g.,
 #   after examining an old revision when this really existed), then some
 #   source code would pull in src/config.h in preference to include/config.h
-dmtcp:
+dmtcp: mkdirs
 	rm -f src/config.h
 	cd src && $(MAKE)
 


### PR DESCRIPTION
Currently, the display-build-env target of `Makefile.in` is executed in parallel with the `build` target.  As a result, the lst few lines of information in `make display-build-env` become intermixed with the first few lines of output from the 'g++' compilations.  This fixes that so that the 'display-build-env' happens first, followed by a blank line.

This also ensures that the build target 'dmtcp' happens only after 'mkdirs', although usually this doesn't cause a bug.  It's because the new directories are needed by the 'dmtcp' target only near the end of the build.