### PR TITLE
autotest.py syscall-tester: ckpt w/ -Kc: no resume

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -745,7 +745,7 @@ resource.setrlimit(resource.RLIMIT_STACK, [newCurrLimit, oldLimit[1]])
 runTest("dmtcp5",        2, ["./test/dmtcp5"])
 resource.setrlimit(resource.RLIMIT_STACK, oldLimit)
 
-# Test for a bunch of system calls. We want to use the 'kc' mode for
+# Test for a bunch of system calls. We want to use the 'Kc' mode for
 # (sets exitAfterCkptOnce in src/dmtcp_coordinator.cpp) for
 # checkpointing so that the process is killed right after checkpoint. Otherwise
 # the syscall-tester could fail in the following case:


### PR DESCRIPTION
This fixes a long-standing bug that affected `./autotest.py --slow syscall-tester`.  The autotest file uses `b'Kc'` to do an exit after checkpoint that kills the process after the first checkpoint.  As explained in the autotest.py file, this is needed for a correct test in case of syscall-tester calling 'unlink'.  But autotest.py had a line that expected the process to resume after checkpoint.  If `b'Kc'` is used, the process will _not_ resume after checkpoint.  So now, if `b'Kc'` was used, it's not an error if the process doesn't resume.