### PR TITLE
dmtcp_coordinator: Change 'xc' (ckpt & exit) to 'kc' (ckpt & kill peers)

### DIFF
--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -1089,7 +1089,8 @@ waitForCheckpointCommand()
   case 'c': case 'C':
     JTRACE("checkpointing...");
     break;
-  case 'k': case 'K':
+  case 'k':
+  case 'K':
   case 'q': case 'Q':
     JTRACE("Received KILL command from user, exiting");
     exitWhenDone = true;

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -1076,22 +1076,21 @@ waitForCheckpointCommand()
 
   bool exitWhenDone = false;
   switch (msg.coordCmd) {
-  // case 'b': case 'B':  // prefix blocking command, prior to checkpoint
+  // case 'b':  // prefix blocking command, prior to checkpoint
   // command
   // JTRACE("blocking checkpoint beginning...");
   // blockUntilDone = true;
   // break;
-  case 's': case 'S':
+  case 's':
     JTRACE("Received status command");
     reply.numPeers = 1;
     reply.isRunning = 1;
     break;
-  case 'c': case 'C':
+  case 'c':
     JTRACE("checkpointing...");
     break;
   case 'k':
-  case 'K':
-  case 'q': case 'Q':
+  case 'q':
     JTRACE("Received KILL command from user, exiting");
     exitWhenDone = true;
     break;

--- a/src/dmtcp_command.cpp
+++ b/src/dmtcp_command.cpp
@@ -49,8 +49,10 @@ static const char *theUsage =
   "    -s, --status:          Print status message\n"
   "    -l, --list:            List connected clients\n"
   "    -c, --checkpoint:      Checkpoint all nodes\n"
+// Could add -B as synonym for -bc
   "    -bc, --bcheckpoint:    Checkpoint all nodes, dmtcp_command blocks until"
                                                                       " done\n"
+// Could add -K as synonym for -kc
   "    -kc, --kcheckpoint     Checkpoint all nodes, kill all nodes when done\n"
 // "    -xc, --xcheckpoint  deprecated synonym for '-kc': kill nodes if done\n"
   "    -i, --interval <val>   Update ckpt interval to <val> seconds (0=never)\n"
@@ -112,12 +114,12 @@ main(int argc, char **argv)
       }
       s = cmd;
 
-      if ((*cmd == 'b' || *cmd == 'K' || *cmd == 'x') && *(cmd + 1) != 'c') {
+      if ((*cmd == 'b' || *cmd == 'K') && *(cmd + 1) != 'c') {
         // If blocking ckpt, next letter must be 'c'; else print the usage
         fprintf(stderr, theUsage, "");
         return 1;
       } else if (*cmd == 's' || *cmd == 'i' || *cmd == 'c' || *cmd == 'b' ||
-                 *cmd == 'K' || *cmd == 'x' /* deprecated */ || *cmd == 'k' ||
+                 *cmd == 'K' || *cmd == 'k' ||
                  *cmd == 'q' || *cmd == 'l') {
         request = s;
         if (*cmd == 'i') {
@@ -156,7 +158,7 @@ main(int argc, char **argv)
     CoordinatorAPI::connectAndSendUserCommand(*cmd, &coordCmdStatus);
     printf("Interval changed to %s\n", interval.c_str());
     break;
-  case 'b': case 'B':
+  case 'b':
   case 'K':
 
     // blocking prefix

--- a/src/dmtcp_command.cpp
+++ b/src/dmtcp_command.cpp
@@ -49,10 +49,10 @@ static const char *theUsage =
   "    -s, --status:          Print status message\n"
   "    -l, --list:            List connected clients\n"
   "    -c, --checkpoint:      Checkpoint all nodes\n"
-  "    -bc, --bcheckpoint:    Checkpoint all nodes, blocking until done\n"
-
-// "    xc, -xc, --xcheckpoint : Checkpoint all nodes, kill all nodes when
-// done\n"
+  "    -bc, --bcheckpoint:    Checkpoint all nodes, dmtcp_command blocks until"
+                                                                      " done\n"
+  "    -kc, --kcheckpoint     Checkpoint all nodes, kill all nodes when done\n"
+// "    -xc, --xcheckpoint  deprecated synonym for '-kc': kill nodes if done\n"
   "    -i, --interval <val>   Update ckpt interval to <val> seconds (0=never)\n"
   "    -k, --kill             Kill all nodes\n"
   "    -q, --quit             Kill all nodes and quit\n"
@@ -107,14 +107,18 @@ main(int argc, char **argv)
       while (*cmd == '-') {
         cmd++;
       }
+      if (*cmd == 'k' && *(cmd+1) == 'c') { // if this is "-kc":
+        *cmd = 'K';  // Need to disambiguate '-k' from '-kc' (now '-Kc')
+      }
       s = cmd;
 
-      if ((*cmd == 'b' || *cmd == 'x') && *(cmd + 1) != 'c') {
+      if ((*cmd == 'b' || *cmd == 'K' || *cmd == 'x') && *(cmd + 1) != 'c') {
         // If blocking ckpt, next letter must be 'c'; else print the usage
         fprintf(stderr, theUsage, "");
         return 1;
       } else if (*cmd == 's' || *cmd == 'i' || *cmd == 'c' || *cmd == 'b' ||
-                 *cmd == 'x' || *cmd == 'k' || *cmd == 'q' || *cmd == 'l') {
+                 *cmd == 'K' || *cmd == 'x' /* deprecated */ || *cmd == 'k' ||
+                 *cmd == 'q' || *cmd == 'l') {
         request = s;
         if (*cmd == 'i') {
           if (isdigit(cmd[1])) { // if -i5, for example
@@ -152,8 +156,8 @@ main(int argc, char **argv)
     CoordinatorAPI::connectAndSendUserCommand(*cmd, &coordCmdStatus);
     printf("Interval changed to %s\n", interval.c_str());
     break;
-  case 'b':
-  case 'x':
+  case 'b': case 'B':
+  case 'K':
 
     // blocking prefix
     CoordinatorAPI::connectAndSendUserCommand(*cmd, &coordCmdStatus);

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -278,15 +278,15 @@ DmtcpCoordinator::handleUserCommand(char cmd, DmtcpMessage *reply /*= NULL*/)
   }
 
   switch (cmd) {
-  case 'b': case 'B':  // prefix blocking command, prior to checkpoint command
+  case 'b':  // prefix blocking command, prior to checkpoint command
     JTRACE("blocking checkpoint beginning...");
     blockUntilDone = true;
     break;
-  case 'K': case 'x':  // prefix kill command, after ckpt cmd ('x' deprecated)
+  case 'K':  // prefix kill command, after ckpt cmd
     JTRACE("Will kill peers after creating the checkpoint...");
     killAfterCkptOnce = true;
     break;
-  case 'c': case 'C':
+  case 'c':
     JTRACE("checkpointing...");
     if (startCheckpoint()) {
       if (reply != NULL) {
@@ -298,7 +298,7 @@ DmtcpCoordinator::handleUserCommand(char cmd, DmtcpMessage *reply /*= NULL*/)
       }
     }
     break;
-  case 'i': case 'I':
+  case 'i':
     JTRACE("setting checkpoint interval...");
     updateCheckpointInterval(theCheckpointInterval);
     if (theCheckpointInterval == 0) {
@@ -314,8 +314,8 @@ DmtcpCoordinator::handleUserCommand(char cmd, DmtcpMessage *reply /*= NULL*/)
       printf("Default Checkpoint Interval: %d\n", theDefaultCheckpointInterval);
     }
     break;
-  case 'l': case 'L':
-  case 't': case 'T':
+  case 'l':
+  case 't':
     if (reply != NULL) {
       replyData = printList();
       reply->extraBytes = replyData.length();
@@ -323,7 +323,7 @@ DmtcpCoordinator::handleUserCommand(char cmd, DmtcpMessage *reply /*= NULL*/)
       JASSERT_STDERR << printList();
     }
     break;
-  case 'u': case 'U':
+  case 'u':
   {
     JASSERT_STDERR << "Host List:\n";
     JASSERT_STDERR << "HOST => # connected clients \n";
@@ -342,7 +342,7 @@ DmtcpCoordinator::handleUserCommand(char cmd, DmtcpMessage *reply /*= NULL*/)
     }
     break;
   }
-  case 'q': case 'Q':
+  case 'q':
   {
     JNOTE("killing all connected peers and quitting ...");
     broadcastMessage(DMT_KILL_PEER);
@@ -360,10 +360,10 @@ DmtcpCoordinator::handleUserCommand(char cmd, DmtcpMessage *reply /*= NULL*/)
     JNOTE("Killing all connected peers...");
     broadcastMessage(DMT_KILL_PEER);
     break;
-  case 'h': case 'H': case '?':
+  case 'h': case '?':
     JASSERT_STDERR << theHelpMessage;
     break;
-  case 's': case 'S':
+  case 's':
   {
     ComputationStatus s = getStatus();
     bool running = (s.minimumStateUnanimous &&

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -519,8 +519,9 @@ def runTestRaw(name, numProcs, cmds):
     coordinatorCmd(CKPT_CMD)
 
     #wait for files to appear and status to return to original
-    WAITFOR(lambda: getNumCkptFiles(ckptDir)>0 and
-                   (CKPT_CMD == b'xc' or doesStatusSatisfy(getStatus(), status)),
+    # b'Kc' input to dmtcp_coordinator is equivalent to 'dmtcp_command -kc'
+    WAITFOR(lambda: getNumCkptFiles(ckptDir)>0 and \
+                 (CKPT_CMD == b'Kc' or doesStatusSatisfy(getStatus(), status)),
             wfMsg("checkpoint error"))
     #we now know there was at least one checkpoint file, and the correct number
     #  of processes have restarted;  but they may fail quickly after restert
@@ -535,8 +536,9 @@ def runTestRaw(name, numProcs, cmds):
           "unexpected number of checkpoint files, %s procs, %d files"
           % (str(status[0]), numFiles))
 
-    if SLOW > 1:
+    if SLOW > 1 and CKPT_CMD != b'Kc':
       #wait and see if some processes will die shortly after checkpointing
+      #but if b'Kc' was requested, processes should die (not resume)
       sleep(S*SLOW)
       CHECK(doesStatusSatisfy(getStatus(), status),
             "error: processes checkpointed, but died upon resume")
@@ -743,7 +745,8 @@ resource.setrlimit(resource.RLIMIT_STACK, [newCurrLimit, oldLimit[1]])
 runTest("dmtcp5",        2, ["./test/dmtcp5"])
 resource.setrlimit(resource.RLIMIT_STACK, oldLimit)
 
-# Test for a bunch of system calls. We want to use the 'xc' mode for
+# Test for a bunch of system calls. We want to use the 'kc' mode for
+# (sets exitAfterCkptOnce in src/dmtcp_coordinator.cpp) for
 # checkpointing so that the process is killed right after checkpoint. Otherwise
 # the syscall-tester could fail in the following case:
 #   1. create and open temp file
@@ -755,7 +758,7 @@ resource.setrlimit(resource.RLIMIT_STACK, oldLimit)
 # program will try to unlink the file once again, but the unlink operation will
 # fail, causing the test to fail.
 old_ckpt_cmd = CKPT_CMD
-CKPT_CMD = b'xc'
+CKPT_CMD = b'Kc' # Equivalent to 'dmtcp_command -kc'
 runTest("syscall-tester",  1, ["./test/syscall-tester"])
 CKPT_CMD = old_ckpt_cmd
 


### PR DESCRIPTION
Logically, the dmtcp_coordinator is asking to "kill the peers after checkpoint".  'xc' ('--exit-after-ckpt' flag) was getting confused with the dmtcp_coordinator flag:  '--exit-on-last'.  So, now we have:
`--kill-after-ckpt` and `--exit-on-last`.  So, we also change 'xc' to 'kc' to correspond.

I've tested this locally, and it works for me.  This is ready for review.

====

As for the history, the 'xc' command was never documented to users.
In the usage command for src/dmtcp_command.cpp, the 'xc' command was commented out in 2013 at commit ee798b0 .   (Maybe it was always commented out.)  The commit comment says "
```
The command to set the flag is 'x' and it must be followed by a 'c'
    command.
    
    Not documenting it right now to allow a name/letter change later.
```
I guess it's about time to document it now. :-) The command is not going to be changing.

