### PR TITLE
Accept Python3 or Python2 for all python scripts

### DIFF
--- a/contrib/python/autocount.py
+++ b/contrib/python/autocount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys, time
 
@@ -8,8 +8,8 @@ def increment():
 
 def print_i():
     global num
-    print num
-    print "Hello World! %d" % (num)
+    print(num)
+    print("Hello World! %d" % (num))
     sys.stdout.flush()
 
 def rest():
@@ -22,4 +22,4 @@ while True:
     print_i()
     #rest()
     if num == 10:
-        print "put breakpoint here."
+        print("put breakpoint here.")

--- a/contrib/python/counter.py
+++ b/contrib/python/counter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import time
 import sys
@@ -6,6 +6,6 @@ import sys
 n = 0
 while True:
     n += 1
-    print "%d " % (n),
+    print("%d " % (n), end="")
     sys.stdout.flush()
     time.sleep(1)

--- a/contrib/python/dmtcp.py
+++ b/contrib/python/dmtcp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # The contents of this file are inspired from the python script dmtcp_ctypes.py
 # originally supplied by Neal Becker.
@@ -92,12 +92,12 @@ def restore(sessionId = 0):
         if len(sessionList) == 0:
             createSessionList()
         if len(sessionList) == 0:
-            print 'No checkpoint session found'
+            print('No checkpoint session found')
             return
-        print 'Restoring the latest session'
+        print('Restoring the latest session')
     else:
         if len(sessionList) == 0:
-            print 'Please do a listSession to see the list of available sessions'
+            print('Please do a listSession to see the list of available sessions')
             return
         if sessionId < 1 or sessionId > len(sessionList):
             return 'Invalid session id'
@@ -123,15 +123,15 @@ def listSessions():
         createSessionList()
     count = 1;
     for session in sessionList:
-        print '[%d]' %(count),
+        print('[%d]' %(count), end="")
         count += 1
-        print session
+        print(session)
 
     if len(sessionList) == 0:
-        print 'No checkpoint sessions found'
+        print('No checkpoint sessions found')
 
 def removeSession(sessionId = 0):
-    print "TODO"
+    print("TODO")
 ########################################################################
 # VNC handling
 ########################################################################
@@ -140,7 +140,7 @@ def startGraphics():
     global vncserver_addr
 
     if vncserver_addr != -1:
-        print 'VNC server already running at: ' + vncserver_addr
+        print('VNC server already running at: ' + vncserver_addr)
         return
 
     addr = 0
@@ -159,7 +159,7 @@ def showGraphics():
     global vncserver_addr
 
     if vncserver_addr == -1:
-        print "VNC server not running."
+        print("VNC server not running.")
         return
     fnull = open(os.devnull, "w")
     saved_display = os.environ['DISPLAY']
@@ -175,7 +175,7 @@ def stopGraphics():
     global vncserver_addr
 
     if vncserver_addr == -1:
-        print "VNC server not running."
+        print("VNC server not running.")
         return
 
     try:
@@ -184,20 +184,20 @@ def stopGraphics():
                                       stderr=subprocess.STDOUT)
         del os.environ['DISPLAY']
     except subprocess.CalledProcessError:
-        print 'Error killing vncserver: ' + out
+        print('Error killing vncserver: ' + out)
 
 
 
 if __name__ == '__main__':
     if isEnabled:
-        print 'DMTCP Status: Enabled'
+        print('DMTCP Status: Enabled')
         if isRunning():
-            print '    isRunning: YES'
+            print('    isRunning: YES')
         else:
-            print '    isRunning: NO'
-        print '    numProcesses: ', numProcesses()
-        print '    numCheckpoints: ', numCheckpoints()
-        print '    numRestarts: ', numRestarts()
-        print '    checkpointFilename: ', checkpointFilename()
+            print('    isRunning: NO')
+        print('    numProcesses: ', numProcesses())
+        print('    numCheckpoints: ', numCheckpoints())
+        print('    numRestarts: ', numRestarts())
+        print('    checkpointFilename: ', checkpointFilename())
     else:
-        print 'DMTCP Status: Disabled'
+        print('DMTCP Status: Disabled')

--- a/contrib/python/hookexample.py
+++ b/contrib/python/hookexample.py
@@ -1,21 +1,23 @@
+#!/usr/bin/env python
+
 import dmtcp
 
 def my_ckpt():
-    print "About to checkpoint."
+    print("About to checkpoint.")
 
     dmtcp.checkpoint()
-    print "Checkpoint done."
+    print("Checkpoint done.")
 
     if dmtcp.isResume():
-        print "The process is resuming from a checkpoint."
+        print("The process is resuming from a checkpoint.")
     else:
-        print "The process is restarting from a previous checkpoint."
+        print("The process is restarting from a previous checkpoint.")
     return
 
 x = 1
-print x
+print(x)
 
-print "Calling my_ckpt()"
+print("Calling my_ckpt()")
 my_ckpt()
 x = 12
-print x
+print(x)

--- a/plugin/modify-env/modify-env.py
+++ b/plugin/modify-env/modify-env.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # Copyright (C) 2016 Kyle Harrigan (kwharrigan@gmail.com)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,23 +41,23 @@ getenv.restype = c_char_p # getenv returns a char*
 
 def do_ckpt():
     '''
-    Check point, and then indicate if we are in the initial checkpoint
+    Checkpoint, and then indicate if we are in the initial checkpoint
     or in a restarted version
     '''
-    print "About to checkpoint."
+    print("About to checkpoint.")
     dmtcp.checkpoint()
-    print "Checkpoint done."
+    print("Checkpoint done.")
     if dmtcp.isResume():
-        print "The process is resuming from a checkpoint."
+        print("The process is resuming from a checkpoint.")
     else:
-        print "The process is restarting from a previous checkpoint."
+        print("The process is restarting from a previous checkpoint.")
     return
 
-print "Calling do_ckpt()"
+print("Calling do_ckpt()")
 do_ckpt()
 if dmtcp.isRestart():
-    print 'Restarted...HOME should be set to value in dmtcp_env.txt'
+    print('Restarted...HOME should be set to value in dmtcp_env.txt')
 else:
-    print 'First time...HOME should be set to your home'
-print 'HOME=[%s] (from libc.so getenv)' % getenv('HOME')
-print 'HOME=[%s] (from os.getenv)' % os.getenv('HOME')
+    print('First time...HOME should be set to your home')
+print('HOME=[%s] (from libc.so getenv)' % getenv('HOME'))
+print('HOME=[%s] (from os.getenv)' % os.getenv('HOME'))

--- a/plugin/pathvirt/test/slot5/pv-test.py
+++ b/plugin/pathvirt/test/slot5/pv-test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os, sys, time
 
@@ -13,7 +13,7 @@ docpath = '{}/doc{}/{}'.format(cwd, last_digit, fil)
 libpath = '{}/lib{}/{}'.format(cwd, last_digit, fil)
 
 while True:
-    print '[{}] Appending...'.format(count)
+    print('[{}] Appending...'.format(count))
     try:
         with open(binpath, 'a+') as f:
             f.write('{} appending\n'.format(count))
@@ -24,5 +24,5 @@ while True:
         count += 1
         time.sleep(1)
     except IOError:
-        print 'could not open file'
+        print('could not open file')
         sys.exit(1)

--- a/util/dmtcp-style.py
+++ b/util/dmtcp-style.py
@@ -91,8 +91,8 @@ class LinterBase(object):
         # (possibly nested) paths.
         for source_dir in self.source_dirs:
             if not os.path.exists(source_dir):
-                print "Could not find '{dir}'".format(dir=source_dir)
-                print 'Please run from the root of the DMTCP source directory'
+                print("Could not find '{dir}'".format(dir=source_dir))
+                print('Please run from the root of the DMTCP source directory')
                 exit(1)
 
         # Add all source file candidates to candidates list.
@@ -114,10 +114,10 @@ class LinterBase(object):
 
         if filtered_candidates_set:
             plural = '' if len(filtered_candidates_set) == 1 else 's'
-            print 'Checking {num_files} {linter} file{plural}'.\
+            print('Checking {num_files} {linter} file{plural}'.
                     format(num_files=len(filtered_candidates_set),
                            linter=self.linter_type,
-                           plural=plural)
+                           plural=plural))
 
             total_errors = self.run_lint(list(filtered_candidates_set))
 
@@ -126,7 +126,7 @@ class LinterBase(object):
 
             return total_errors
         else:
-            print "No {linter} files to lint".format(linter=self.linter_type)
+            print("No {linter} files to lint".format(linter=self.linter_type))
             return 0
 
 

--- a/util/dmtcp_backtrace.py
+++ b/util/dmtcp_backtrace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os
@@ -12,10 +12,10 @@ dmtcpTmpDir = "/tmp/dmtcp-" + os.environ['USER'] + '@' + host + '/'
   ('libdmtcp.so', dmtcpTmpDir+'backtrace', dmtcpTmpDir+'proc-maps')
 
 if len(sys.argv) > 1 and (sys.argv[1] == '--help' or sys.argv[1] == '-h'):
-  print "USAGE:  dmtcp_backtrace.py [filename [backtrace [proc-maps]]]\n" \
-  + "  Default:  filename = libdmtcp.so\n" \
-  + "            backtrace = " + tmpBacktrace + "\n" \
-  + "            proc-maps = " + tmpProcMaps + "\n"
+  print("USAGE:  dmtcp_backtrace.py [filename [backtrace [proc-maps]]]\n"
+        + "  Default:  filename = libdmtcp.so\n"
+        + "            backtrace = " + tmpBacktrace + "\n"
+        + "            proc-maps = " + tmpProcMaps + "\n")
   sys.exit(1)
 
 # Override defaults
@@ -35,12 +35,12 @@ if libdmtcp.find('/') == -1:
 else:
   pathname = libdmtcp
 if pathname.find("CAN'T FIND FILE") != -1:
-  print pathname
-  print "Please check " + tmpProcMaps + " to see if the process that crashed"
-  print "  was really using:  " + libdmtcp
+  print(pathname)
+  print("Please check " + tmpProcMaps + " to see if the process that crashed")
+  print("  was really using:  " + libdmtcp)
   sys.exit(1)
-print "Examing stack for call frames from:\n  " + pathname + "\n" \
-      + "FORMAT:  FNC: ..., followed by file:line_number (most recent first).\n"
+print("Examing stack for call frames from:\n  " + pathname + "\n"
+      + "FORMAT:  FNC: ..., followed by file:line_number (most recent first).\n")
 
 def getOrigOffset(pathname,procMaps):
   # The text segment in memory must always start at a page boundary.
@@ -54,7 +54,7 @@ def getOrigOffset(pathname,procMaps):
       textOffset = '0x' + segment[:segment.find('-')]
       break
   if textOffset == 0:
-    print os.path.basename(pathname) + " not found in proc maps: " + procMaps
+    print(os.path.basename(pathname) + " not found in proc maps: " + procMaps)
     sys.exit(1)
   # Now we get the offset of the text section in the file.  When the text
   #   section was mapped to memory, in fact all the program header table
@@ -79,14 +79,14 @@ for callFrame in backtrace:
     if hexOffset[0] == '-':
       # This happens because backtrace() can ascribe to libdmtcp
       #  what came from /lib/ld-2.10.1.so
-      print callFrame
+      print(callFrame)
     else: # This subprocess prints to stdout
-      # print callFrame
-      # print addr2line + hexOffset
-      print "** FNC: ",
+      # print(callFrame)
+      # print(addr2line + hexOffset)
+      print("** FNC: ", end="")
       sys.stdout.flush()
       subprocess.call(addr2line + hexOffset, shell=True)
   else:
-    print callFrame
+    print(callFrame)
 
 # That's it.  We're done.

--- a/util/gdb-add-libdmtcp-symbol-file.py
+++ b/util/gdb-add-libdmtcp-symbol-file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # This file is a hack, meant to overcome the disabling of the logic for
 #   'add-symbol-file libdmtcp.so' in mtcp/mtcp_restart.c
 # If that logic is restored, this file should be deleted. 
@@ -10,11 +10,11 @@ import sys
 import re
 import subprocess
 
-print "Usage:  "+sys.argv[0]+" <PID> <ADDR> [<LIBMTCP=lib/dmtcp/libdmtcp.so>]"
-print "  This assumes that ADDR is in libdmtcp.so."
-print "  In gdb: 'info proc' will provide <PID>; and  'print $pc' will"
-print "    provide <ADDR>, providing that PC is currently in libdmtcp.so."
-# print "OR Usage:  "+sys.argv[0]+" <PID> <LIB>"
+print("Usage:  "+sys.argv[0]+" <PID> <ADDR> [<LIBMTCP=lib/dmtcp/libdmtcp.so>]")
+print("  This assumes that ADDR is in libdmtcp.so.")
+print("  In gdb: 'info proc' will provide <PID>; and  'print $pc' will")
+print("    provide <ADDR>, providing that PC is currently in libdmtcp.so.")
+# print("OR Usage:  "+sys.argv[0]+" <PID> <LIB>")
 
 if len(sys.argv) == 1:
   sys.exit(0)
@@ -52,11 +52,11 @@ for line in file:
     readelf.stdout.close()
     readelf.stdout.close()
     gdbCmd = "add-symbol-file "+libdmtcp+" "+hex(fields[0]+int(textOffset,16))
-    print "Type this in gdb:"
-    print gdbCmd
+    print("Type this in gdb:")
+    print(gdbCmd)
     break
 if not gdbCmd:
-  print "Couldn't find libdmtcp.so in", "/proc/"+str(pid)+"/maps"
+  print("Couldn't find libdmtcp.so in", "/proc/"+str(pid)+"/maps")
 file.close()
 sys.exit(0)
 
@@ -67,16 +67,16 @@ for line in file:
   fields = map(lambda(x):int(x,16), fields[0].split("-")) + [fields[1]]
   # ACTUALLY, THIS SHOULD BE LINE AFTER text SEGMENT
   if fields[0] < pc and pc < fields[1] and fields[2] == "rw-p":
-    print int(fields[0])
+    print(int(fields[0]))
     readelf = subprocess.Popen(
         "/usr/bin/readelf -S "+libnmtcp+" | grep '\.data'",
         shell=True, stdout=subprocess.PIPE)
     dataOffset = readelf.stdout.read().split()[4]
     readelf.stdout.close()
-    print dataOffset
+    print(dataOffset)
     readelf.stdout.close()
     gdbCmd += " -s "+hex(fields[0]+int(dataOffset,16))
-    print gdbCmd
+    print(gdbCmd)
     break
 file.close()
 

--- a/util/gdb.py
+++ b/util/gdb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Here are some gdb commands written in python using the gdb Python API
 # described here:
@@ -18,8 +18,8 @@ class ProcSelfFd(gdb.Command):
 
     def invoke(self, arg, from_tty):
         pid = str(gdb.inferiors()[0].pid)
-        print "ls -l /proc/" + pid + "/fd"
-        print gdb.execute("shell ls -l /proc/" + pid + "/fd", True, True)
+        print("ls -l /proc/" + pid + "/fd")
+        print(gdb.execute("shell ls -l /proc/" + pid + "/fd", True, True))
 
 ProcSelfFd()
 
@@ -31,8 +31,8 @@ class ProcSelfMaps(gdb.Command):
 
     def invoke(self, arg, from_tty):
         pid = str(gdb.inferiors()[0].pid)
-        print "cat /proc/" + pid + "/maps"
-        print gdb.execute("shell cat /proc/" + pid + "/maps", True, True)
+        print("cat /proc/" + pid + "/maps")
+        print(gdb.execute("shell cat /proc/" + pid + "/maps", True, True))
 
 ProcSelfMaps()
 
@@ -70,8 +70,8 @@ class AddSymbolFile(gdb.Command):
         res = subprocess.Popen(cmd + arg,
                                shell=True, stdout=subprocess.PIPE).communicate()[0]
         if (len(res) == 0):
-            print '**** Library %s not found. ' % arg
-            print '  Do:  cat /proc/%d/maps to see all libs.' % pid
+            print('**** Library %s not found. ' % arg)
+            print('  Do:  cat /proc/%d/maps to see all libs.' % pid)
             return
 
         lib=subprocess.Popen(cmd + arg + " | head -1 | sed -e 's%[^/]*\\(/.*\\)%\\1%'",


### PR DESCRIPTION
The PR title says it all.  The test/autotest.py was already made compatible with Python3 in PR #792.  Now, this PR provides the same treatment to the many other Python scripts in DMTCP.