### PR TITLE
Fix commit d67aac7b (contrib/ckpttimer plugin); and bzero in jsocket.cpp -> memset

### DIFF
--- a/contrib/ckpttimer/ckpttimer.cpp
+++ b/contrib/ckpttimer/ckpttimer.cpp
@@ -226,7 +226,7 @@ ckpttimer_event_hook(DmtcpEvent_t event, DmtcpEventData_t *data)
     pre_ckpt();
     break;
 
-  case DMTCP_EVENT_RESTART:
+  case DMTCP_EVENT_RESUME:
     resume();
     break;
 

--- a/jalib/jsocket.cpp
+++ b/jalib/jsocket.cpp
@@ -94,7 +94,7 @@ jalib::JSockAddr::JSockAddr(const char *hostname /* == NULL*/,
 #else // if 0
   struct addrinfo hints;
   struct addrinfo *res;
-  bzero(&hints, sizeof hints);
+  memset(&hints, '\0', sizeof hints);
   hints.ai_family = AF_INET;
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_flags = AI_ADDRCONFIG;


### PR DESCRIPTION
 This is easy to review.  (Just two lines changed.)

- @JainTwinkle caught the bug in the contrib/ckpttimer plugin.  (Thanks.)
   (contrib/ckpttimer exists only in master (version 3.0), not in version 2.x)
   (Fix in commit d67aac7b for PR #773)
 - 'bzero' is deprecated in favor of 'memset'