### PR TITLE
Fix: Coord didn't reset alarm() if nothing running

### DIFF
--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -484,14 +484,19 @@ startNewCoordinator(CoordinatorMode mode)
                                                  port, 128);
   JASSERT(coordinatorListenerSocket.isValid())
     (coordinatorListenerSocket.port()) (JASSERT_ERRNO) (host) (port)
-    .Text("Failed to create socket to coordinator port."
-          "\nIf the above message (sterror) is:"
-          "\n           \"Address already in use\" or \"Bad file descriptor\","
-          "\n  then this may be an old coordinator."
-          "\nEither try again a few seconds or a minute later,"
-          "\nOr kill other coordinator (using same host and port):"
-          "\n    dmtcp_command ---coord-host XXX --coord-port YYY --quit"
-          "\nOr specify --join-coordinator if joining existing computation.");
+    .Text("Failed to create socket to connect to coordinator port."
+          "\n  If the above message (sterror) is:"
+          "\n            \"Address already in use\" or \"Bad file descriptor\","
+          "\n    then this may be an old coordinator."
+          "\n    Or maybe you're joining an existing coordinator, and forgot"
+          "\n      to use 'dmtcp_launch --join-coordinator'."
+          "\n  Either:"
+          "\n    (a) use '--join-coordinator; or"
+          "\n    (b) kill the old coordinator with 'pkill -9 dmtcp_coord' or"
+          "\n        (while using same host and port):"
+          "\n        dmtcp_command ---coord-host XX --coord-port YY --quit; or"
+          "\n    (c) if the old coordinator is already gone, wait a few seconds"
+          "\n        or a minute for the O/S to free up that port again.\n");
   // Now dup the sockfd to
   coordinatorListenerSocket.changeFd(PROTECTED_COORD_FD);
   setCoordPort(coordinatorListenerSocket.port());

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -47,6 +47,7 @@
  * Checkpoint: RUNNING -> SUSPENDED -> CHECKPOINTING                        *
  *                     -> (Checkpoint barriers) -> CHECKPOINTED             *
  *                     -> (Resume barriers) -> RUNNING                      *
+ *             [State returns to UNKNOWN if no active workers.]
  *                                                                          *
  * Restart:    RESTARTING -> (Restart barriers) -> RUNNING                  *
  * If debugging, set gdb breakpoint on:                                     *
@@ -867,6 +868,7 @@ DmtcpCoordinator::onConnect()
     client->virtualPid(hello_remote.from.pid());
     _virtualPidToClientMap[client->virtualPid()] = client;
   } else if (hello_remote.type == DMT_NEW_WORKER) {
+    // Comping from dmtcp_launch or fork(), ssh(), etc.
     JASSERT(hello_remote.state == WorkerState::RUNNING ||
             hello_remote.state == WorkerState::UNKNOWN);
     JASSERT(hello_remote.virtualPid == -1);
@@ -1392,7 +1394,13 @@ DmtcpCoordinator::eventLoop(bool daemon)
 
 
     // The ckpt timer has expired; it's time to checkpoint.
-    if (nfds == -1 && errno == EINTR && timerExpired) {
+    //   NOTE:  We need minimumStateUnanimous and RUNNING, in case
+    //   worker had reached 'main()' of application and paused (e.g.,
+    //   under GDB), while the ckpt interval timer went off.  We want
+    //   startCheckpoint() to be deferred until the worker is RUNNING.
+    ComputationStatus s = getStatus();
+    if (timerExpired &&
+        s.minimumStateUnanimous && s.minimumState == WorkerState::RUNNING) {
       timerExpired = false;
       startCheckpoint();
       continue;


### PR DESCRIPTION
I found a better fix for the original problem and for a second problem.  This new version has nothing to do with the earlier version under this PR.  The git commit also has some explanation.
  (And the second commit is just to improve the error msg.  It was too small for a separate PR.)

[FROM git commit:]
 - This fixes a long pause (e.g., GDB) when at main() in the target application. 
   The ckpt interval timer goes off at this time 
 - In addition, it fixes a problem of:  dmtcp_launch and break at execvp (e.g., in GDB) 
   In this case also, the ckpt interval timer goes off, and the workerState is not yet running\
   or the last worker exited and the worker state is UNKNOWN                                       

[FURTHER EXPLANATION:]
This fixes two bugs.  Both can occur when using GDB for debugging and there are long pauses while using a ckpt interval timer.
1.  Even though `alarm()` was called by the coordinator for periodic checkpointing, the alarm might have gone off at a time when there was no active executable running under DMTCP control.  In this case, no checkpoint was executed.  But we would call resetCkptTimer() only at the last step before finishing the checkpoint.  (That's important, since we don't want the interval timer going off in the _middle_ of an ongoing checkpoint.)  So, in this scenario, 'theCheckpointInterval' is correct and 'timerExpired' is false, as they should be.  But we never called 'alarm()' again for the next checkpoint interval.

2.  A second bug was occurring when we start the dmtcp_coordinator() and then start the application (e.g., test/plugin/presuspend).  If we run the application under GDB and stop at main within the application and then pause while the checkpoint interval timer goes off, then the worker state can be set to RUNNING, and then set to PRESUSPEND early.  Then, some JASSERT's fail that were expecting the state RUNNING.

