### PR TITLE
After system call & reading errno, reset errno to 0

### DIFF
--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -1045,6 +1045,7 @@ waitForCheckpointCommand()
       break;
     }
     JASSERT(errno == EINTR) (JASSERT_ERRNO); /* EINTR: a signal was caught */
+    errno = 0;
     if (ckptInterval > 0) {
       struct timeval end;
       JASSERT(gettimeofday(&end, NULL) == 0) (JASSERT_ERRNO);

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -44,7 +44,7 @@
  *   maximumState for states of all workers, accessed through getStatus()   *
  *   or through minimumState()                                              *
  * The states for a worker (client) are:                                    *
- * Checkpoint: RUNNING -> SUSPENDED -> CHECKPOINTING                        *
+ * Checkpoint: RUNNING -> PRESUSPEND -> SUSPENDED -> CHECKPOINTING          *
  *                     -> (Checkpoint barriers) -> CHECKPOINTED             *
  *                     -> (Resume barriers) -> RUNNING                      *
  *                                                                          *

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -728,6 +728,7 @@ setNewCkptDir(char *path)
     JASSERT(mkdir(path, S_IRWXU) == 0 || errno == EEXIST)
       (JASSERT_ERRNO) (path)
     .Text("Error creating checkpoint directory");
+    errno = 0;
     JASSERT(0 == access(path, X_OK | W_OK)) (path)
     .Text("ERROR: Missing execute- or write-access to checkpoint dir");
   } else {

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -137,6 +137,7 @@ DmtcpWorker::determineCkptSignal()
   static const char *tmp = getenv(ENV_VAR_SIGCKPT);
 
   if (tmp != NULL) {
+    errno = 0;
     sig = strtol(tmp, &endp, 0);
     if ((errno != 0) || (tmp == endp)) {
       sig = CKPT_SIGNAL;

--- a/src/plugin/ipc/file/posixipcwrappers.cpp
+++ b/src/plugin/ipc/file/posixipcwrappers.cpp
@@ -144,6 +144,7 @@ mq_send(mqd_t mqdes, const char *msg_ptr, size_t msg_len, unsigned msg_prio)
   do {
     JASSERT(clock_gettime(CLOCK_REALTIME, &ts) != -1);
     ts.tv_sec += 1000;
+    errno = 0;
     res = mq_timedsend(mqdes, msg_ptr, msg_len, msg_prio, &ts);
   } while (res == -1 && errno == ETIMEDOUT);
   return res;
@@ -159,6 +160,7 @@ mq_receive(mqd_t mqdes, char *msg_ptr, size_t msg_len, unsigned *msg_prio)
   do {
     JASSERT(clock_gettime(CLOCK_REALTIME, &ts) != -1);
     ts.tv_sec += 1000;
+    errno = 0;
     res = mq_timedreceive(mqdes, msg_ptr, msg_len, msg_prio, &ts);
   } while (res == -1 && errno == ETIMEDOUT);
   return res;

--- a/src/popen.cpp
+++ b/src/popen.cpp
@@ -174,6 +174,7 @@ pclose(FILE *fp)
   }
 
   do {
+    errno = 0;
     wait_pid = waitpid(pid, &wstatus, 0);
   } while (wait_pid == -1 && errno == EINTR);
   if (wait_pid == -1) {

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -377,6 +377,7 @@ void Process : Info::restoreArgvAfterRestart(char *mtcpRestoreArgvStartAddr)
                        PROT_READ | PROT_WRITE);
     if (ret != -1 || errno != ENOMEM) {
       _mtcpRestoreArgvStartAddr = NULL;
+      errno = 0;
       return;
     }
   }
@@ -740,6 +741,7 @@ ProcessInfo::refreshChildTable()
     /* Check to see if the child process is alive*/
     if (kill(pid, 0) == -1 && errno == ESRCH) {
       _childTable.erase(j);
+      errno = 0;
     } else {
       _sessionIds[pid] = getsid(pid);
     }

--- a/src/rwlock.cpp
+++ b/src/rwlock.cpp
@@ -74,6 +74,7 @@ int DmtcpRWLockRdLock(DmtcpRWLock *rwlock)
     // Wait for futex.
     int s = futex_wait(&rwlock->readersFutex, waitVal);
     JASSERT (s != -1 || errno == EAGAIN) (JASSERT_ERRNO);
+    errno = 0;
 
     // Reacquire the exclusive lock.
     JASSERT(DmtcpMutexLock(&rwlock->xLock) == 0);
@@ -118,6 +119,7 @@ int DmtcpRWLockWrLock(DmtcpRWLock *rwlock)
     // Wait for futex.
     int s = futex_wait(&rwlock->writersFutex, waitVal);
     JASSERT (s != -1 || errno == EAGAIN) (JASSERT_ERRNO);
+    errno = 0;
 
     // Reacquire the exclusive lock.
     JASSERT(DmtcpMutexLock(&rwlock->xLock) == 0);

--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -152,6 +152,7 @@ SharedData::initialize(const char *tmpDir = NULL,
        */
       JWARNING(false)
         ("Internal error detected! Shared data area already exists.");
+      errno = 0;
       fd = _real_open(o.str().c_str(), O_RDWR, 0600);
     } else {
       // Extend file to size before 'mmap'
@@ -301,6 +302,7 @@ SharedData::waitForBarrier(const string &barrierId)
                       curRound,
                       NULL, NULL, 0) != 0) {
       JASSERT(errno == EAGAIN);
+      errno = 0;
       Util::lockFile(PROTECTED_SHM_FD);
       Util::unlockFile(PROTECTED_SHM_FD);
     }

--- a/src/siginfo.cpp
+++ b/src/siginfo.cpp
@@ -55,6 +55,7 @@ SigInfo::setupCkptSigHandler(sighandler_t handler)
         JWARNING(false) (getenv("DMTCP_SIGCKPT")) (CKPT_SIGNAL)
         .Text("Your chosen SIGCKPT does not translate to a number, and cannot "
               "be used.  Default signal will be used instead");
+        errno = 0;
         STOPSIGNAL = CKPT_SIGNAL;
       } else if (STOPSIGNAL < 1 || STOPSIGNAL > 31) {
         JNOTE("Your chosen SIGCKPT is not a valid signal, and cannot be used."

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -470,6 +470,7 @@ ThreadList::suspendThreads()
                             SigInfo::ckptSignal()) < 0) {
             JASSERT(errno == ESRCH) (JASSERT_ERRNO) (thread->tid)
             .Text("error signalling thread");
+            errno = 0;
             ThreadList::threadIsDead(thread);
           } else {
             needrescan = 1;
@@ -481,12 +482,14 @@ ThreadList::suspendThreads()
         ret = THREAD_TGKILL(motherpid, thread->tid, 0);
         JASSERT(ret == 0 || errno == ESRCH);
         if (ret == -1 && errno == ESRCH) {
+          errno = 0;
           ThreadList::threadIsDead(thread);
         }
         break;
 
       case ST_SIGNALED:
         if (THREAD_TGKILL(motherpid, thread->tid, 0) == -1 && errno == ESRCH) {
+          errno = 0;
           ThreadList::threadIsDead(thread);
         } else {
           needrescan = 1;
@@ -986,6 +989,7 @@ ThreadList::addToActiveList(Thread *th)
       /* if no thread with this tid, then we can remove zombie descriptor */
       if (-1 == THREAD_TGKILL(motherpid, thread->tid, 0)) {
         JTRACE("Killing zombie thread") (thread->tid);
+        errno = 0;
         threadIsDead(thread);
       }
     }

--- a/src/util_misc.cpp
+++ b/src/util_misc.cpp
@@ -45,8 +45,8 @@ Util::lockFile(int fd)
   // fl.l_pid    = _real_getpid(); // our PID
 
   int result = -1;
-  errno = 0;
   do {
+    errno = 0; // reset errno to 0 in case of EINTR on previous iteration
     result = _real_fcntl(fd, F_SETLKW, &fl);  /* F_GETLK, F_SETLK, F_SETLKW */
   } while (result == -1 && errno == EINTR);
 
@@ -157,6 +157,7 @@ Util::writeAll(int fd, const void *buf, size_t count)
   size_t num_written = 0;
 
   do {
+    errno = 0; // reset errno to 0 in case of EINTR on previous iteration
     ssize_t rc = write(fd, ptr + num_written, count - num_written);
     if (rc == -1) {
       if (errno == EINTR || errno == EAGAIN) {
@@ -186,6 +187,7 @@ Util::readAll(int fd, void *buf, size_t count)
   size_t num_read = 0;
 
   for (num_read = 0; num_read < count;) {
+    errno = 0; // reset errno to 0 in case of EINTR on previous iteration
     rc = read(fd, ptr + num_read, count - num_read);
     if (rc == -1) {
       if (errno == EINTR || errno == EAGAIN) {
@@ -326,6 +328,7 @@ Util::readChar(int fd)
   int rc;
 
   do {
+    errno = 0; // reset errno to 0 in case of EINTR on previous iteration
     rc = read(fd, &c, 1);
   } while (rc == -1 && errno == EINTR);
   if (rc <= 0) {


### PR DESCRIPTION
```
  **********************************************
  * README:  This PR is extremely important!!! *
  **********************************************
```

This is primarily an enhancement.  Originally, I thought that without this enhancement, it would expose a certain bug.  I was wrong about that.  What I was seeing late at night was not actually a bug -- just a little confusion over the code.

Next, I feel that we have been incredibly sloppy in our use of `errno`.  Most of this is from many years ago, when we are not as careful in our coding.  Most of these others are not actual bugs, but they violate the convention that our utility function should act like a syscall:  either it returns '-1', and sets errno, or it returns something else, and either sets 'errno' to 0, or doesn't change the original value of 'errno'.
  (And I include a minor second commit to correct a comment in src/dmtcp_coordinator.cpp.  It's
    not worth including that as a separate PR.)

We have similar, potential bugs in our code for `Util::readAll()`, `Util::writeAll()`, and in lots of other places in the code that is many years old.  While these are not actual bugs, they make it easy to later create new bugs, because we violate the convention that either `rc == -1 && errno != 0` or `rc >= 0 && errno == 0`.  So, we end up with 'errno' set to a non-zero value in lots of places where there is no actual error.

Please someone!  Check my logic to see that I got most or all of these bugs and that my bug fixes are correct.  For example, where we see 'JASSERT(rc == -1 && errno != 0)', there is no bug since we will exit with an assert error.  But when we see a 'while' loop, we often forgot to reset 'errno' to 0 for the next iteration where we will repeat of the system call.