### PR TITLE
Autotest pty fixes for tcsh, zsh, and vim.

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -245,7 +245,7 @@ def runCmd(cmd):
   for str in cmd:
     # Checkpoint image can be emacs23_x, or whatever emacs is a link to.
     # vim can be vim.gnome, etc.
-    if re.search("(_|/|^)(screen|script|vim.*|emacs.*|pty)(_|$)", str):
+    if re.search("(_|/|^)(screen|script|vim.*|emacs.*|pty|tcsh|zsh)(_|$)", str):
       ptyMode = True
   try:
     os.stat(cmd[0])

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -987,7 +987,7 @@ if HAS_VIM == "yes":
   S=10*DEFAULT_S
   if sys.version_info[0:2] >= (2,6):
     # Delete previous vim processes.  Vim behaves poorly with stale processes.
-    vimCommand = VIM + " /etc/passwd +3" # +3 makes cmd line unique
+    vimCommand = VIM + " -X -u DEFAULTS -i NONE /etc/passwd +3" # +3 makes cmd line unique
     def killCommand(cmdToKill):
       if os.getenv('USER') == None or HAS_PS == 'no':
         return


### PR DESCRIPTION
* Force ptymode for zsh/tcsh.
* Disable plugins for vim. In complex setups, plugins could involve external processes such as ycm server for youcompleteme plugin.