### PR TITLE
Remove presuspend/precheckpoint events

### DIFF
--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -105,6 +105,7 @@ PluginManager::eventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
 
   // Process ckpt barriers.
   case DMTCP_EVENT_PRESUSPEND:
+#if 0
     for (size_t i = 0; i < pluginManager->pluginInfos.size(); i++) {
       CoordinatorAPI::waitForBarrier(
           "PreSuspend:" + pluginManager->pluginInfos[i]->pluginName);
@@ -112,9 +113,11 @@ PluginManager::eventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
         pluginManager->pluginInfos[i]->event_hook(event, data);
       }
     }
+#endif
     break;
 
   case DMTCP_EVENT_PRECHECKPOINT:
+#if 0
     for (size_t i = 0; i < pluginManager->pluginInfos.size(); i++) {
       CoordinatorAPI::waitForBarrier(
           "PreCkpt:" + pluginManager->pluginInfos[i]->pluginName);
@@ -122,6 +125,7 @@ PluginManager::eventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
         pluginManager->pluginInfos[i]->event_hook(event, data);
       }
     }
+#endif
     break;
 
   // Process resume/restart barriers in reverse-order.


### PR DESCRIPTION
This PR should not be pushed in.  @karya0 , can you provide a substitute for this PR?
Since the reorganization of the barriers for the coordinator, we're now seeing 44 extra
barriers, requiring several seconds.  This performance bug is making our current
research and enhancements seem to have unacceptable performance.  IDEAS??  (Thanks.)

And here's one observation that could improve performance.  Most of the PRESUSPEND events (which are empty for most plugins) can be run in parallel.  So, the plugin descriptor could include a field for "local" or "parallel" to indicate that the plugin can run the PRESUSPEND phase in parallel with all other plugins.  So, they can share a single barrier.

In the same way, most of the PRECHECKPOINT events and most of the RESUME events can be declared as "local" or "parallel".  In this way, most of the barriers seen by the DMTCP coordinator can be eliminated, as the remaining barriers will be shared by many events.
 
These are the comments within the commit:
- This makes it impossible to restart, but it allows us to take
   reasonable timings for the time to checkpoint.  Without this option,
   our checkpoint times will be much lager than they used to be (or with
   DMTCP-2.6).  This seems to be related to the reorganization of events,
   which is important for having elegant code, but now we need to fix
   the performance bug introduced by it.  These events add 44 barriers,
   and if each barrier implies the time for a context switch to the
   coordinator process, or the time for a coordinator to accept
   a new message on the socket, then the performance is unacceptable.

```
dmtcp-3.0% more barriers2.out                                                                                 barrier = PreSuspend:ssh                                                                                                
barrier = PreSuspend:event                                                                                              
barrier = PreSuspend:file                                                                                               
barrier = PreSuspend:pty                                                                                                
barrier = PreSuspend:socket                                                                                             
barrier = PreSuspend:sysvipc                                                                                            
barrier = PreSuspend:timer                                                                                             
barrier = PreSuspend:syslog                                                                                             
barrier = PreSuspend:rlimit_float                                                                                       
barrier = PreSuspend:alarm                                                                                              
barrier = PreSuspend:terminal                                                                                           
barrier = PreSuspend:coordinatorapi                                                                                     
barrier = PreSuspend:processInfo                                                                                        
barrier = PreSuspend:pid                                                                                                
barrier = DMT:SUSPEND                                                                                                   
barrier = DMT:CHECKPOINT                                                                                                
barrier = PreCkpt:ssh                                                                                                   
barrier = PreCkpt:event                                                                                                 
barrier = Event::PRE_CKPT                                                                                               
barrier = Event::LEADER_ELECTION                                                                                        
barrier = Event::DRAIN                                                                                                  
barrier = PreCkpt:file                                                                                                  
barrier = File::PRE_CKPT                                                                                                
barrier = File::LEADER_ELECTION                                                                                         
barrier = File::DRAIN                                                                                                   
barrier = File::WRITE_CKPT                                                                                              
barrier = PreCkpt:pty                                                                                                   
barrier = PreCkpt:socket                                                                                                
barrier = Socket::Pre_Ckpt                                                                                              
barrier = Socket::Leader_Election                                                                                       
barrier = Socket::Ckpt_Register_Peer_Info                                                                               
barrier = Socket::Ckpt_Retrieve_Peer_Info                                                                               
barrier = Socket::Drain                                                                                                 
barrier = Socket::Write_Ckpt                                                                                            
barrier = PreCkpt:sysvipc                                                                                               
barrier = SVIPC:Leader_Election                                                                                         
barrier = SVIPC:Drain                                                                                                   
barrier = PreCkpt:timer                                                                                                 
barrier = PreCkpt:syslog                                                                                                
barrier = PreCkpt:rlimit_float                                                                                          
barrier = PreCkpt:alarm                                                                                                 
barrier = PreCkpt:terminal                                                                                              
barrier = PreCkpt:coordinatorapi                                                                                        
barrier = PreCkpt:processInfo                                                                                           
barrier = PreCkpt:pid                                                                                                   
barrier = Resume:pid                                                                                                    
barrier = Resume:processInfo                                                                                            
barrier = Resume:coordinatorapi                                                                                         
barrier = Resume:terminal                                                                                               
barrier = Resume:alarm                                                                                                  
barrier = Resume:rlimit_float                                                                                           
barrier = Resume:syslog                                                                                                 
barrier = Resume:timer                                                                                                  
barrier = Resume:sysvipc                                                                                                
barrier = Resume:socket                                                                                                 
barrier = Socket::Resume_Refill                                                                                         
barrier = Socket::Resume_Resume                                                                                         
barrier = Resume:pty                                                                                                    
barrier = Resume:file                                                                                                   
barrier = File::RESUME_REFILL                                                                                           
barrier = File::RESUME_RESUME                                                                                           
barrier = Resume:event                                                                                                  
barrier = Event::RESUME_REFILL                                                                                          
barrier = Resume:ssh                                                                                                    
barrier = DMT::RESUME 
```