### PR TITLE
Rlimit: handle RLIM_INFINITY.

### DIFF
--- a/src/rlimitfloatenv.cpp
+++ b/src/rlimitfloatenv.cpp
@@ -35,7 +35,7 @@ save_rlimit_float_settings()
   fegetenv(&envp);
 
   struct rlimit rlim = {0, 0};
-#define SAVE_RLIMIT(_RLIMIT,_rlim_cur) \
+#define SAVE_RLIMIT(_RLIMIT, _rlim_cur) \
   getrlimit(_RLIMIT, &rlim); \
   _rlim_cur = rlim.rlim_cur;
 
@@ -58,12 +58,14 @@ restore_rlimit_float_settings()
 
   struct rlimit rlim = {0, 0};
 
-#define RESTORE_RLIMIT(_RLIMIT,_rlim_cur) \
-  getrlimit(_RLIMIT, &rlim); \
-  JWARNING(_rlim_cur <= rlim.rlim_max) (_rlim_cur) (rlim.rlim_max) \
-    .Text("Prev. soft limit of " #_RLIMIT " lowered to new hard limit"); \
-  rlim.rlim_cur = _rlim_cur; \
-  JASSERT(setrlimit(_RLIMIT, &rlim) == 0);
+#define RESTORE_RLIMIT(_RLIMIT, _rlim_cur) \
+  if (_rlim_cur != RLIM_INFINITY) { \
+    getrlimit(_RLIMIT, &rlim); \
+    JWARNING(_rlim_cur <= rlim.rlim_max) (_rlim_cur) (rlim.rlim_max) \
+      .Text("Prev. soft limit of " #_RLIMIT " lowered to new hard limit"); \
+    rlim.rlim_cur = _rlim_cur; \
+    JASSERT(setrlimit(_RLIMIT, &rlim) == 0) (JASSERT_ERRNO); \
+  }
 
   RESTORE_RLIMIT(RLIMIT_AS, rlim_cur_as);
   RESTORE_RLIMIT(RLIMIT_CORE, rlim_cur_core);


### PR DESCRIPTION
We shouldn't change rlimit on restore if the pre-ckpt limit was set to infinity.