### PR TITLE
3.0 fix restart mtcp header

### DIFF
--- a/src/mtcp/mtcp_header.h
+++ b/src/mtcp/mtcp_header.h
@@ -1,6 +1,7 @@
 #ifndef MTCP_HEADER_H
 #define MTCP_HEADER_H
 
+#include <stdint.h>  // For 'uint64_t'
 #include "ldt.h"
 
 #ifdef __i386__
@@ -45,7 +46,8 @@ typedef union _MtcpHeader {
     void *saved_brk;
     void *end_of_stack;
     void *restore_addr;
-    size_t restore_size;
+    // uint64_t processinfo.h:_restoreBufLen; 64-bit aligned for 32-64-bit
+    uint64_t restore_size; /* must be 64-bit aligned */
     void *vdsoStart;
     void *vdsoEnd;
     void *vvarStart;

--- a/src/mtcp/mtcp_header.h
+++ b/src/mtcp/mtcp_header.h
@@ -47,7 +47,7 @@ typedef union _MtcpHeader {
     void *end_of_stack;
     void *restore_addr;
     // uint64_t processinfo.h:_restoreBufLen; 64-bit aligned for 32-64-bit
-    uint64_t restore_size; /* must be 64-bit aligned */
+    uint64_t restore_len; /* must be 64-bit aligned */
     void *vdsoStart;
     void *vdsoEnd;
     void *vvarStart;

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -97,7 +97,7 @@ typedef struct RestoreInfo {
   VA saved_brk;
   VA restore_addr;
   VA restore_end;
-  uint64_t restore_size;
+  uint64_t restore_len;
   VA vdsoStart;
   VA vdsoEnd;
   VA vvarStart;
@@ -314,8 +314,8 @@ main(int argc, char *argv[], char **environ)
 
   rinfo.saved_brk = mtcpHdr.saved_brk;
   rinfo.restore_addr = mtcpHdr.restore_addr;
-  rinfo.restore_end = mtcpHdr.restore_addr + mtcpHdr.restore_size;
-  rinfo.restore_size = mtcpHdr.restore_size;
+  rinfo.restore_end = mtcpHdr.restore_addr + mtcpHdr.restore_len;
+  rinfo.restore_len = mtcpHdr.restore_len;
   rinfo.vdsoStart = mtcpHdr.vdsoStart;
   rinfo.vdsoEnd = mtcpHdr.vdsoEnd;
   rinfo.vvarStart = mtcpHdr.vvarStart;
@@ -329,9 +329,9 @@ main(int argc, char *argv[], char **environ)
   rinfo.myinfo_gs = mtcpHdr.myinfo_gs;
 
   restore_brk(rinfo.saved_brk, rinfo.restore_addr,
-              rinfo.restore_addr + rinfo.restore_size);
+              rinfo.restore_addr + rinfo.restore_len);
 
-  if (hasOverlappingMapping(rinfo.restore_addr, rinfo.restore_size)) {
+  if (hasOverlappingMapping(rinfo.restore_addr, rinfo.restore_len)) {
     MTCP_PRINTF("*** Not Implemented.\n\n");
     mtcp_abort();
     restart_slow_path();
@@ -553,7 +553,7 @@ mtcp_simulateread(int fd, MtcpHeader *mtcpHdr)
   mtcp_printf("\nMTCP: %s", buf);
   mtcp_printf("**** mtcp_restart (will be copied here): %p..%p\n",
               mtcpHdr->restore_addr,
-              mtcpHdr->restore_addr + mtcpHdr->restore_size);
+              mtcpHdr->restore_addr + mtcpHdr->restore_len);
   mtcp_printf("**** DMTCP entry point (ThreadList::postRestart()): %p\n",
               mtcpHdr->post_restart);
   mtcp_printf("**** brk (sbrk(0)): %p\n", mtcpHdr->saved_brk);
@@ -1329,7 +1329,7 @@ remapMtcpRestartToReservedArea(RestoreInfo *rinfo)
 
   // Make sure we can fit all mtcp_restart regions in the restore area.
   MTCP_ASSERT(mem_regions[num_regions - 1].endAddr - mem_regions[0].addr <=
-                rinfo->restore_size);
+                rinfo->restore_len);
 
   // Now remap mtcp_restart at the restore location. Note that for memory
   // regions with write permissions, we copy over the bits from the original
@@ -1378,7 +1378,7 @@ remapMtcpRestartToReservedArea(RestoreInfo *rinfo)
   VA guard_page_end_addr = guard_page + MTCP_PAGE_SIZE;
 
   size_t remaining_restore_area =
-    rinfo->restore_addr + rinfo->restore_size - guard_page_end_addr;
+    rinfo->restore_addr + rinfo->restore_len - guard_page_end_addr;
 
 #ifdef WSL
   // FIXME:  The assert below used to fail on WSL.  (Still a work in progress.)
@@ -1398,7 +1398,7 @@ remapMtcpRestartToReservedArea(RestoreInfo *rinfo)
 #endif
   MTCP_ASSERT(remaining_restore_area >= rinfo->old_stack_size);
 
-  void *new_stack_end_addr = rinfo->restore_addr + rinfo->restore_size;
+  void *new_stack_end_addr = rinfo->restore_addr + rinfo->restore_len;
   void *new_stack_start_addr = new_stack_end_addr - rinfo->old_stack_size;
 
   rinfo->new_stack_addr =

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -97,7 +97,7 @@ typedef struct RestoreInfo {
   VA saved_brk;
   VA restore_addr;
   VA restore_end;
-  size_t restore_size;
+  uint64_t restore_size;
   VA vdsoStart;
   VA vdsoEnd;
   VA vvarStart;

--- a/src/mtcp/restore_libc.h
+++ b/src/mtcp/restore_libc.h
@@ -64,7 +64,7 @@ extern "C" {
 #ifdef LOGGING
 # define DPRINTF PRINTF
 #else // ifdef LOGGING
-# define DPRINTF(args ...) // debug printing
+# define DPRINTF(args ...) // debug printing if: ./configure --enable-logging
 #endif // ifdef LOGGING
 
 #define ASSERT(condition)                            \

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -294,7 +294,7 @@ prepareMtcpHeader(MtcpHeader *mtcpHdr)
   // TODO: Now that we have a separate mtcp dir, the code dealing with
   // restoreBuf should go in there.
   mtcpHdr->restore_addr = (void *)ProcessInfo::instance().restoreBufAddr();
-  mtcpHdr->restore_size = ProcessInfo::instance().restoreBufLen();
+  mtcpHdr->restore_len = ProcessInfo::instance().restoreBufLen();
 
   mtcpHdr->vdsoStart = (void *)ProcessInfo::instance().vdsoStart();
   mtcpHdr->vdsoEnd = (void *)ProcessInfo::instance().vdsoEnd();


### PR DESCRIPTION
Two commits (This is now final.  Ready for review.):

1. MtcpHeader: size_t->uint64_t: for 32-/64-bit mode
    This is important for mixed 32-64-bit computations.  mtcp/mtcp_header.h is shared between dmtcp_restart.cpp (64-bit process) and mtcp_restart_m32 (32-bit process).  So, the fields in the struct must be 64-bit aligned.  In 32-bit Linux, 'size_t' and 'ssize_t' are 4 bytes.  There are changed to 8 bytes here to be 64-bit aligned.  The bug would be seen on restart when doing:
`./configure --enable-multilib && make -j check-dmtcp1-m32`

2. restore_size->restore_len: like restoreBufLen/mmap
    This doesn't change any functionality.  It's just a variable name change from 'restore_size' to 'restore_len'.  This is in keeping with the existing variable/fnc name 'restoreBufLen()'.  In turn, that is in keeping with 'man mmap', which refers to the second argument as 'length'.

NOTE: I'm seeing a compiler warning about comparison of signed and unsigned int expressions.  But it seems to happen _only when compiling in 32-bit mode_, and when it involves Util::readAll() or Util::writeAll().  I have now fixed that in the next PR (PR #824).  So, this PR can still be reviewed independently of the next PR.