### PR TITLE
protected-fds: Add ability to set protected fd base at runtime

### DIFF
--- a/include/protectedfds.h
+++ b/include/protectedfds.h
@@ -22,30 +22,71 @@
 #ifndef DMTCPPROTECTEDFDS_H
 #define DMTCPPROTECTEDFDS_H
 
+#include <stdint.h>
+#include <stdlib.h>
+
+#define DEFAULT_PROTECTED_FD_BASE   820
+
+uint32_t protectedFdBase();
+
+inline uint32_t protectedFdBase()
+{
+  static uint32_t base = DEFAULT_PROTECTED_FD_BASE;
+  const char *buf = getenv("DMTCP_PROTECTED_FD_BASE");
+
+  if (buf) {
+    base = atol(buf);
+  }
+  return base;
+}
+
 enum ProtectedFds {
-  PROTECTED_FD_START = 820,
-  PROTECTED_COORD_FD,
-  PROTECTED_VIRT_COORD_FD,
-  PROTECTED_RESTORE_IP4_SOCK_FD,
-  PROTECTED_RESTORE_IP6_SOCK_FD,
-  PROTECTED_RESTORE_UDS_SOCK_FD,
-  PROTECTED_COORD_ALT_FD,
-  PROTECTED_STDERR_FD,
-  PROTECTED_JASSERTLOG_FD,
-  PROTECTED_LIFEBOAT_FD,
-  PROTECTED_CKPT_DIR_FD,
-  PROTECTED_SHM_FD,
-  PROTECTED_PIDMAP_FD,
-  PROTECTED_PTRACE_FD,
-  PROTECTED_FILE_FDREWIRER_FD,
-  PROTECTED_SOCKET_FDREWIRER_FD,
-  PROTECTED_EVENT_FDREWIRER_FD,
-  PROTECTED_READLOG_FD,
-  PROTECTED_ENVIRON_FD,
-  PROTECTED_NS_FD,
-  PROTECTED_DEBUG_SOCKET_FD,
-  PROTECTED_FD_END
+  FD_START = 0,
+  COORD_FD,
+  VIRT_COORD_FD,
+  RESTORE_IP4_SOCK_FD,
+  RESTORE_IP6_SOCK_FD,
+  RESTORE_UDS_SOCK_FD,
+  COORD_ALT_FD,
+  STDERR_FD,
+  JASSERTLOG_FD,
+  LIFEBOAT_FD,
+  CKPT_DIR_FD,
+  SHM_FD,
+  PIDMAP_FD,
+  PTRACE_FD,
+  FILE_FDREWIRER_FD,
+  SOCKET_FDREWIRER_FD,
+  EVENT_FDREWIRER_FD,
+  READLOG_FD,
+  ENVIRON_FD,
+  NS_FD,
+  DEBUG_SOCKET_FD,
+  FD_END
 };
+
+#define PROTECTED_FD_START               (protectedFdBase() + FD_START)
+#define PROTECTED_COORD_FD               protectedFdBase() + COORD_FD
+#define PROTECTED_VIRT_COORD_FD          protectedFdBase() + VIRT_COORD_FD
+#define PROTECTED_RESTORE_IP4_SOCK_FD    protectedFdBase() + RESTORE_IP4_SOCK_FD
+#define PROTECTED_RESTORE_IP6_SOCK_FD    protectedFdBase() + RESTORE_IP6_SOCK_FD
+#define PROTECTED_RESTORE_UDS_SOCK_FD    protectedFdBase() + RESTORE_UDS_SOCK_FD
+#define PROTECTED_COORD_ALT_FD           protectedFdBase() + COORD_ALT_FD
+#define PROTECTED_STDERR_FD              protectedFdBase() + STDERR_FD
+#define PROTECTED_JASSERTLOG_FD          protectedFdBase() + JASSERTLOG_FD
+#define PROTECTED_LIFEBOAT_FD            protectedFdBase() + LIFEBOAT_FD
+#define PROTECTED_CKPT_DIR_FD            protectedFdBase() + CKPT_DIR_FD
+#define PROTECTED_SHM_FD                 protectedFdBase() + SHM_FD
+#define PROTECTED_PIDMAP_FD              protectedFdBase() + PIDMAP_FD
+#define PROTECTED_PTRACE_FD              protectedFdBase() + PTRACE_FD
+#define PROTECTED_FILE_FDREWIRER_FD      protectedFdBase() + FILE_FDREWIRER_FD
+#define PROTECTED_SOCKET_FDREWIRER_FD    protectedFdBase() + SOCKET_FDREWIRER_FD
+#define PROTECTED_EVENT_FDREWIRER_FD     protectedFdBase() + EVENT_FDREWIRER_FD
+#define PROTECTED_READLOG_FD             protectedFdBase() + READLOG_FD
+#define PROTECTED_ENVIRON_FD             protectedFdBase() + ENVIRON_FD
+#define PROTECTED_NS_FD                  protectedFdBase() + NS_FD
+#define PROTECTED_DEBUG_SOCKET_FD        protectedFdBase() + DEBUG_SOCKET_FD
+#define PROTECTED_FD_END                 protectedFdBase() + FD_END
 
 #define DMTCP_IS_PROTECTED_FD(fd) \
   ((fd) > PROTECTED_FD_START && (fd) < PROTECTED_FD_END)

--- a/include/util.h
+++ b/include/util.h
@@ -175,6 +175,7 @@ char *findExecutable(char *executable, const char *path_env, char *exec_path);
 char *getPath(const char *cmd, bool is32bit = false);
 char **getDmtcpArgs();
 void allowGdbDebug(int currentDebugLevel);
+void setProtectedFdBase();
 }
 }
 #endif // ifdef __cplusplus

--- a/jalib/jalib.cpp
+++ b/jalib/jalib.cpp
@@ -141,7 +141,7 @@ int dup2(int oldfd, int newfd) {
   struct rlimit file_limit;
   getrlimit(RLIMIT_NOFILE, &file_limit);
   JASSERT ( (unsigned int)newfd < file_limit.rlim_cur )
-          (newfd)(file_limit.rlim_cur)
+          (oldfd)(newfd)(file_limit.rlim_cur)
           .Text("dup2: newfd is >= current limit on number of files");
   REAL_FUNC_PASSTHROUGH(int, dup2) (oldfd, newfd);
 }

--- a/src/constants.h
+++ b/src/constants.h
@@ -117,6 +117,7 @@
 #define ENV_VAR_DISABLE_STRICT_CHECKING "DMTCP_DISABLE_STRICT_CHECKING"
 
 #define ENV_VAR_REMOTE_SHELL_CMD        "DMTCP_REMOTE_SHELL_CMD"
+#define ENV_VAR_PROTECTED_FD_BASE       "DMTCP_PROTECTED_FD_BASE"
 
 // this list should be kept up to date with all "protected" environment vars
 #define ENV_VARS_ALL                  \
@@ -140,6 +141,7 @@
   ENV_VAR_SCREENDIR,                  \
   ENV_VAR_VIRTUAL_PID,                \
   ENV_VAR_SKIP_WRITING_TEXT_SEGMENTS, \
+  ENV_VAR_PROTECTED_FD_BASE,          \
   ENV_DELTACOMPRESSION
 
 #define DMTCP_RESTART_CMD       "dmtcp_restart"

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -48,7 +48,11 @@ LIB_PRIVATE sem_t sem_launch;
 namespace dmtcp {
 namespace CoordinatorAPI {
 
-const int coordinatorSocket = PROTECTED_COORD_FD;
+// NOTE:  PROTECTED_COORD_FD looks like a macro, but it's a fnc,
+//        whose initial value changes as another part of DMTCP initializes.
+const int coordinatorSocket() {
+  return PROTECTED_COORD_FD;
+}
 int nsSock = -1;
 static int childCoordinatorSocket = -1;
 
@@ -254,7 +258,7 @@ void resetCoordinatorSocket(int sock)
   JASSERT(Util::isValidFd(sock));
   JASSERT(sock != PROTECTED_COORD_FD);
   Util::changeFd(sock, PROTECTED_COORD_FD);
-  JASSERT(Util::isValidFd(coordinatorSocket));
+  JASSERT(Util::isValidFd(coordinatorSocket()));
 
   JTRACE("Informing coordinator of new process") (UniquePid::ThisProcess());
 
@@ -297,7 +301,7 @@ void vforkChild()
 void
 closeConnection()
 {
-  _real_close(coordinatorSocket);
+  _real_close(coordinatorSocket());
 }
 
 char*
@@ -460,18 +464,18 @@ recvMsgFromCoordinatorRaw(int fd, DmtcpMessage *msg, void **extraData)
 
 void sendMsgToCoordinator(DmtcpMessage msg, const void *extraData, size_t len)
 {
-  sendMsgToCoordinatorRaw(coordinatorSocket, msg, extraData, len);
+  sendMsgToCoordinatorRaw(coordinatorSocket(), msg, extraData, len);
 }
 
 void sendMsgToCoordinator(const DmtcpMessage &msg, const string &data)
 {
-  sendMsgToCoordinatorRaw(coordinatorSocket, msg,
+  sendMsgToCoordinatorRaw(coordinatorSocket(), msg,
                           data.c_str(), data.length() + 1);
 }
 
 void recvMsgFromCoordinator(DmtcpMessage *msg, void **extraData)
 {
-  recvMsgFromCoordinatorRaw(coordinatorSocket, msg, extraData);
+  recvMsgFromCoordinatorRaw(coordinatorSocket(), msg, extraData);
 }
 
 bool waitForBarrier(const string& barrier,
@@ -615,7 +619,7 @@ createNewConnToCoord(CoordinatorMode mode)
   }
 
   Util::changeFd(sockfd, PROTECTED_COORD_FD);
-  JASSERT(Util::isValidFd(coordinatorSocket));
+  JASSERT(Util::isValidFd(coordinatorSocket()));
 }
 
 DmtcpMessage
@@ -690,7 +694,7 @@ connectToCoordOnStartup(CoordinatorMode mode,
   DmtcpMessage hello_local(DMT_NEW_WORKER);
   hello_local.virtualPid = -1;
 
-  DmtcpMessage hello_remote = sendRecvHandshake(coordinatorSocket,
+  DmtcpMessage hello_remote = sendRecvHandshake(coordinatorSocket(),
                                                 hello_local,
                                                 progname);
 
@@ -705,7 +709,7 @@ connectToCoordOnStartup(CoordinatorMode mode,
   coordInfo->id = hello_remote.from.upid();
   coordInfo->timeStamp = hello_remote.coordTimeStamp;
   coordInfo->addrLen = sizeof (coordInfo->addr);
-  JASSERT(getpeername(coordinatorSocket,
+  JASSERT(getpeername(coordinatorSocket(),
                       (struct sockaddr*) &coordInfo->addr,
                       &coordInfo->addrLen) == 0)
     (JASSERT_ERRNO);
@@ -761,7 +765,7 @@ connectToCoordOnRestart(CoordinatorMode  mode,
   hello_local.numPeers = np;
   hello_local.compGroup = compGroup;
 
-  DmtcpMessage hello_remote = sendRecvHandshake(coordinatorSocket,
+  DmtcpMessage hello_remote = sendRecvHandshake(coordinatorSocket(),
                                                 hello_local,
                                                 progname,
                                                 &compGroup);
@@ -770,7 +774,7 @@ connectToCoordOnRestart(CoordinatorMode  mode,
     coordInfo->id = hello_remote.from.upid();
     coordInfo->timeStamp = hello_remote.coordTimeStamp;
     coordInfo->addrLen = sizeof(coordInfo->addr);
-    JASSERT(getpeername(coordinatorSocket,
+    JASSERT(getpeername(coordinatorSocket(),
                         (struct sockaddr *)&coordInfo->addr,
                         &coordInfo->addrLen) == 0)
       (JASSERT_ERRNO);
@@ -831,7 +835,7 @@ sendKeyValPairToCoordinator(const char *id,
   msg.keyLen = key_len;
   msg.valLen = val_len;
   msg.extraBytes = key_len + val_len;
-  int sock = coordinatorSocket;
+  int sock = coordinatorSocket();
   if (dmtcp_is_running_state()) {
     if (nsSock == -1) {
       nsSock = createNewSocketToCoordinator(COORD_ANY);
@@ -869,7 +873,7 @@ sendQueryToCoordinator(const char *id,
   msg.keyLen = key_len;
   msg.valLen = 0;
   msg.extraBytes = key_len;
-  int sock = coordinatorSocket;
+  int sock = coordinatorSocket();
 
   if (key == NULL || key_len == 0 || val == NULL || val_len == 0) {
     return 0;
@@ -920,7 +924,7 @@ int getUniqueIdFromCoordinator(const char *id,
   msg.extraBytes = key_len;
   msg.uniqueIdOffset = offset;
   msg.valLen = *val_len;
-  int sock = coordinatorSocket;
+  int sock = coordinatorSocket();
 
   if (key == NULL || key_len == 0 || val == NULL || val_len == 0) {
     return 0;
@@ -962,7 +966,7 @@ sendQueryAllToCoordinator(const char *id, void **buf, int *len)
 
   JWARNING(strlen(id) < sizeof(msg.nsid));
   strncpy(msg.nsid, id, sizeof msg.nsid);
-  int sock = coordinatorSocket;
+  int sock = coordinatorSocket();
   if (dmtcp_is_running_state()) {
     if (nsSock == -1) {
       nsSock = createNewSocketToCoordinator(COORD_ANY);
@@ -1034,7 +1038,7 @@ setupVirtualCoordinator(CoordinatorInfo *coordInfo, struct in_addr *localIP)
     .Text("Failed to create listen socket.");
 
   Util::changeFd(sock.sockfd(), PROTECTED_COORD_FD);
-  JASSERT(Util::isValidFd(coordinatorSocket));
+  JASSERT(Util::isValidFd(coordinatorSocket()));
 
   setCoordPort(sock.port());
 
@@ -1085,7 +1089,7 @@ waitForCheckpointCommand()
     }
 
     struct pollfd socketFd = {0};
-    socketFd.fd = coordinatorSocket;
+    socketFd.fd = coordinatorSocket();
     socketFd.events = POLLIN;
     uint64_t millis = timeout ? ((timeout->tv_sec * (uint64_t)1000) +
                                  (timeout->tv_usec / 1000))
@@ -1118,7 +1122,7 @@ waitForCheckpointCommand()
   DmtcpMessage reply(DMT_USER_CMD_RESULT);
   do {
     cmdSock.close();
-    jalib::JServerSocket sock(coordinatorSocket);
+    jalib::JServerSocket sock(coordinatorSocket());
     cmdSock = sock.accept();
     msg.poison();
     JTRACE("Reading from incoming connection...");

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -256,7 +256,7 @@ void init()
 void resetCoordinatorSocket(int sock)
 {
   JASSERT(Util::isValidFd(sock));
-  JASSERT(sock != PROTECTED_COORD_FD);
+  JASSERT(sock != (int)PROTECTED_COORD_FD);
   Util::changeFd(sock, PROTECTED_COORD_FD);
   JASSERT(Util::isValidFd(coordinatorSocket()));
 
@@ -884,7 +884,7 @@ sendQueryToCoordinator(const char *id,
       nsSock = createNewSocketToCoordinator(COORD_ANY);
       JASSERT(nsSock != -1);
       nsSock = Util::changeFd(nsSock, PROTECTED_NS_FD);
-      JASSERT(nsSock == PROTECTED_NS_FD);
+      JASSERT(nsSock == (int)PROTECTED_NS_FD);
       DmtcpMessage m(DMT_NAME_SERVICE_WORKER);
       JASSERT(Util::writeAll(nsSock, &m, sizeof(m)) == sizeof(m));
     }
@@ -935,7 +935,7 @@ int getUniqueIdFromCoordinator(const char *id,
       nsSock = createNewSocketToCoordinator(COORD_ANY);
       JASSERT(nsSock != -1);
       nsSock = Util::changeFd(nsSock, PROTECTED_NS_FD);
-      JASSERT(nsSock == PROTECTED_NS_FD);
+      JASSERT(nsSock == (int)PROTECTED_NS_FD);
       DmtcpMessage m(DMT_NAME_SERVICE_WORKER);
       JASSERT(Util::writeAll(nsSock, &m, sizeof(m)) == sizeof(m));
     }
@@ -972,7 +972,7 @@ sendQueryAllToCoordinator(const char *id, void **buf, int *len)
       nsSock = createNewSocketToCoordinator(COORD_ANY);
       JASSERT(nsSock != -1);
       nsSock = Util::changeFd(nsSock, PROTECTED_NS_FD);
-      JASSERT(nsSock == PROTECTED_NS_FD);
+      JASSERT(nsSock == (int)PROTECTED_NS_FD);
       DmtcpMessage m(DMT_NAME_SERVICE_WORKER);
       JASSERT(Util::writeAll(nsSock, &m, sizeof(m)) == sizeof(m));
     }

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -1484,6 +1484,7 @@ DmtcpCoordinator::addDataSocket(CoordClient *client)
 int
 main(int argc, char **argv)
 {
+  Util::setProtectedFdBase();
   initializeJalib();
 
   // parse port

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -411,6 +411,7 @@ processArgs(int *orig_argc, const char ***orig_argv)
 int
 main(int argc, const char **argv)
 {
+  Util::setProtectedFdBase();
   for (size_t fd = PROTECTED_FD_START; fd < PROTECTED_FD_END; fd++) {
     close(fd);
   }

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -753,6 +753,8 @@ main(int argc, char **argv)
   char *tmpdir_arg = NULL;
   char *ckptdir_arg = NULL;
 
+  Util::setProtectedFdBase();
+
   initializeJalib();
 
   if (!getenv(ENV_VAR_QUIET)) {

--- a/src/execwrappers.cpp
+++ b/src/execwrappers.cpp
@@ -442,6 +442,7 @@ dmtcpPrepareForExec(const char *path,
   JTRACE("Will exec filename instead of path") (path) (*filename);
 
   Util::adjustRlimitStack();
+  Util::setProtectedFdBase();
 
   // Remove FD_CLOEXEC flag from protected file descriptors.
   for (size_t i = PROTECTED_FD_START; i < PROTECTED_FD_END; i++) {

--- a/src/util_init.cpp
+++ b/src/util_init.cpp
@@ -23,7 +23,9 @@
 #include <fcntl.h>
 #include <pwd.h>
 #include <string.h>
+#include <sys/resource.h>
 #include <sys/stat.h>
+#include <sys/time.h>
 #include <sys/types.h>
 #include "../jalib/jassert.h"
 #include "../jalib/jconvert.h"
@@ -168,4 +170,21 @@ Util::initializeLogFile(const char *tmpDir,
   jassert_quiet = 2;
 #endif // ifdef QUIET
   unsetenv(ENV_VAR_STDERR_PATH);
+}
+
+void Util::setProtectedFdBase()
+{
+  struct rlimit rlim = {0};
+  char protectedFdBaseBuf[64] = {0};
+  uint32_t base = 0;
+  // Check the max no. of FDs supported for the process
+  if (getrlimit(RLIMIT_NOFILE, &rlim) < 0) {
+    JWARNING(false)(JASSERT_ERRNO)
+            .Text("Could not figure out the max. number of fds");
+    return;
+  }
+  base = rlim.rlim_cur - (PROTECTED_FD_END - PROTECTED_FD_START) - 1;
+  snprintf(protectedFdBaseBuf, sizeof protectedFdBaseBuf, "%u", base);
+  JASSERT(base).Text("Setting the base of protected fds to");
+  setenv(ENV_VAR_PROTECTED_FD_BASE, protectedFdBaseBuf, 1);
 }

--- a/src/util_init.cpp
+++ b/src/util_init.cpp
@@ -172,6 +172,41 @@ Util::initializeLogFile(const char *tmpDir,
   unsetenv(ENV_VAR_STDERR_PATH);
 }
 
+#define FD_IS_OPEN(fd) (fcntl(fd, F_GETFL) != -1 || errno != EBADF)
+static void migrateProtectedFdBase(int fromBaseFd, int toBaseFd) {
+  int fromFd, toFd;
+  int num_fds = PROTECTED_FD_END - PROTECTED_FD_START;
+  // The range of protected fds for fromBaseFd and toBaseFd might overlap.
+  // So, dup2 from low fd to high fd, or from high fd to low fd, depending.
+  // toBaseFd < fromBaseFd; So, copy from low protected fd to high protected fd
+  if (toBaseFd < fromBaseFd) {
+    for (toFd = toBaseFd, fromFd = fromBaseFd;
+         toFd < toBaseFd + num_fds;
+         toFd++, fromFd++) {
+      if (FD_IS_OPEN(fromFd)) {
+        JASSERT(!FD_IS_OPEN(toFd))(toFd);
+        dup2(fromFd, toFd);
+        JASSERT(_real_close(fromFd) != -1)(JASSERT_ERRNO);
+      }
+    }
+  }
+  // toBaseFd > fromBaseFd; So, copy from high protected fd to low protected fd
+  if (toBaseFd > fromBaseFd) {
+    for (toFd = toBaseFd + num_fds - 1, fromFd = fromBaseFd + num_fds - 1;
+         toFd >= toBaseFd;
+         toFd--, fromFd--) {
+      if (FD_IS_OPEN(fromFd)) {
+        JASSERT(!FD_IS_OPEN(toFd))(toFd);
+        dup2(fromFd, toFd);
+        JASSERT(_real_close(fromFd) != -1)(JASSERT_ERRNO);
+      }
+    }
+  }
+  // toBaseFd == fromBaseFd; Nothing to do.
+}
+
+// NOTE:  This should be called only when no other thread would be
+// using the protected fd's:  e.g., dmtcp_launch, exec of new program.
 void Util::setProtectedFdBase()
 {
   struct rlimit rlim = {0};
@@ -184,6 +219,12 @@ void Util::setProtectedFdBase()
     return;
   }
   base = rlim.rlim_cur - (PROTECTED_FD_END - PROTECTED_FD_START) - 1;
+  JTRACE("new protected base for fd's")(base);
+  if (getenv(ENV_VAR_PROTECTED_FD_BASE) != NULL) {
+    int fromBaseFd = atol(getenv(ENV_VAR_PROTECTED_FD_BASE));
+    migrateProtectedFdBase(fromBaseFd, base);
+    JTRACE("old protected base for fd's")(fromBaseFd);
+  }
   snprintf(protectedFdBaseBuf, sizeof protectedFdBaseBuf, "%u", base);
   JASSERT(base).Text("Setting the base of protected fds to");
   setenv(ENV_VAR_PROTECTED_FD_BASE, protectedFdBaseBuf, 1);

--- a/test/rlimit-nofile.c
+++ b/test/rlimit-nofile.c
@@ -16,9 +16,9 @@ int main(int argc, char* argv[])
     while (1);
   }
 
-  // Parent DMTCP  lib was already initizlied using default RLIMIT_NOFILE.
+  // Parent DMTCP lib was already initialized using default RLIMIT_NOFILE.
   // This fd_limit should cause the child to initialize with different limits.
-  // Verify that this does not create inconcsistency in DMTCP protectedFdBase.
+  // Verify that this does not create inconsistency in DMTCP protectedFdBase.
   struct rlimit fd_limit = {4096/2, 4096/2} ;
   int retStatus = getrlimit(RLIMIT_NOFILE, &fd_limit) ;
   if( retStatus == -1 ) {


### PR DESCRIPTION
_[ This PR is interacting badly with test/rlimit-*.c.  Most likely the issue is that in 3.0/master some
  variables are now initialized globally, whereas in DMTCP-2.6, they were members of a class
  that were initialized after main() was called by the init method.  This was the case with the first
  of the two commits here.  I'll debug test/rlimit-* later.  But those tests are not currently passing. ]_

PR #468 created this commit in DMTCP-2.5.0.  At the time, @karya0 and @gc00 believed there was a better approach, to be implemented for 3.0.  But it was never implemented, and we hit the same bug again now in 3.0/master.  So, this ports the 2.x branch commit to 3.0/master for common code. 

This creates an internal environment variable "DMTCP_PROTECTED_FD_BASE" in DMTCP.  It chooses the maximum fd's for our protected fd's.  It is reset on launch, exec, restart, etc.  This is important on restart, since we can move to a differently configured host.  (QUESTION:  Does it also detect the maximum fd after restart, and set things like coordinatorapi.cpp:coordinatorSocket correctly if we're on a new host with a different maximum fd?)

If we decide later to implement the better approach, the improvements can be made next to both branches.  In particular, if some application also wants to use our protected fds, via dup2(), then they will overwrite it.  In the next PR, we will have dup2() check if the destination is a protected fd, and JASSERT in that case.

For now, let's make sure that "the perfect is not the enemy of the good".  This commit has been valid (no bugs reported) for more than two years in the 2.6 branch.   It's needed right now, to avoid a bug seen by a "customer" using 3.0/master.