### PR TITLE
dup2/dup3 now check if they're copying to prot. fd

### DIFF
--- a/src/miscwrappers.cpp
+++ b/src/miscwrappers.cpp
@@ -28,7 +28,6 @@
 #include "constants.h"
 #include "dmtcpworker.h"
 #include "processinfo.h"
-#include "protectedfds.h"
 #include "syscallwrappers.h"
 #include "threadsync.h"
 #include "util.h"
@@ -75,18 +74,9 @@ using namespace dmtcp;
 
 EXTERNC int dmtcp_is_popen_fp(FILE *fp) __attribute((weak));
 
-/*
- * FIXME: Add wrapper for dup2 and dup3 to detect a protected fd.
-extern "C" int dup2(int oldfd, int newfd)
-{
-  if (DMTCP_IS_PROTECTED_FD(newfd)) {
-  }
-  return _real_dup2(oldfd, newfd);
-}
-*/
-
 // Linux prlimit() could also be wrapped for protected fd, but it's a rare case.
-extern "C" int setrlimit (int resource, const struct rlimit *rlim) {
+extern "C" int
+setrlimit (int resource, const struct rlimit *rlim) {
   if ( resource == RLIMIT_NOFILE &&
        (rlim->rlim_cur < 1024 || rlim->rlim_max < 1024) ) {
     JNOTE("Blocked attempt to lower RLIMIT_NOFILE\n"

--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -19,6 +19,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include "protectedfds.h"
 
 #undef open
 #undef open64
@@ -434,11 +435,19 @@ dup2(int oldfd, int newfd)
 {
   WrapperLock wrapperLock;
 
+  // FIXME:  The meaning of PROTECTED_FD_START/PROTECTED_FD_END
+  //         can change if we adopt a dynamic protected fd base.
+  JASSERT( !DMTCP_IS_PROTECTED_FD(newfd) )
+         ("\n*** Blocked attempt to dup2 into a protected fd;\n"
+          "    If you must use larger fd's in range of protected fd's, then\n"
+          "    please let the developers know that you need the option:\n"
+          "      'dmtcp_launch --protected-fd <NEW_PROT_FD_START>'")
+         (PROTECTED_FD_START)(PROTECTED_FD_END)
+         (oldfd)(newfd);
   int ret = _real_dup2(oldfd, newfd);
   if (ret != -1) {
     processDupFd(oldfd, ret);
   }
-
   return ret;
 }
 
@@ -448,11 +457,19 @@ dup3(int oldfd, int newfd, int flags)
 {
   WrapperLock wrapperLock;
 
+  // FIXME:  The meaning of PROTECTED_FD_START/PROTECTED_FD_END
+  //         can change if we adopt a dynamic protected fd base.
+  JASSERT( !DMTCP_IS_PROTECTED_FD(newfd) )
+         ("\n*** Blocked attempt to dup3 into a protected fd;\n"
+          "    If you must use larger fd's in range of protected fd's, then\n"
+          "    please let the developers know that you need the option:\n"
+          "      'dmtcp_launch --protected-fd <NEW_PROT_FD_START>'")
+         (PROTECTED_FD_START)(PROTECTED_FD_END)
+         (oldfd)(newfd);
   int ret = _real_dup3(oldfd, newfd, flags);
   if (ret != -1) {
     processDupFd(oldfd, ret);
   }
-
   return ret;
 }
 


### PR DESCRIPTION
If dup2() or dup3() tries to copy an fd into a protected fd, then we detect that, and JASSERT.