### PR TITLE
Disable ckpt while processing dmtcp_dlsym.

### DIFF
--- a/src/dmtcp_dlsym.cpp
+++ b/src/dmtcp_dlsym.cpp
@@ -545,6 +545,13 @@ print_debug_messages(dt_tag tags,
 EXTERNC void *
 dmtcp_dlsym(void *handle, const char *symbol)
 {
+  // Acquire checkpoint lock. We need to release it before returning it from the
+  // function. Ideally, we would use the WrapperLock class to avoid calling
+  // dmtcp_enable_ckpt multiple times within the same function but that would
+  // require removing this file's dependency from dmtcp_restart.cpp and
+  // adjusting Makefile.am.
+  dmtcp_disable_ckpt();
+
   dt_tag tags;
   Elf32_Word default_symbol_index = 0;
 
@@ -559,6 +566,7 @@ dmtcp_dlsym(void *handle, const char *symbol)
                                                        return_address, &tags,
                                                        &default_symbol_index);
     print_debug_messages(tags, default_symbol_index, symbol);
+    dmtcp_enable_ckpt();
     return result;
   }
 #endif /* ifdef __USE_GNU */
@@ -567,12 +575,16 @@ dmtcp_dlsym(void *handle, const char *symbol)
                                                         NULL, &tags,
                                                         &default_symbol_index);
   print_debug_messages(tags, default_symbol_index, symbol);
+  dmtcp_enable_ckpt();
   return result;
 }
 
 EXTERNC void *
 dmtcp_dlvsym(void *handle, char *symbol, const char *version)
 {
+  // Acquire checkpoint lock.
+  dmtcp_disable_ckpt();
+
   dt_tag tags;
   Elf32_Word default_symbol_index = 0;
 
@@ -585,6 +597,7 @@ dmtcp_dlvsym(void *handle, char *symbol, const char *version)
                                                        version,
                                                        return_address, &tags,
                                                        &default_symbol_index);
+    dmtcp_enable_ckpt();
     return result;
   }
 #endif
@@ -592,12 +605,16 @@ dmtcp_dlvsym(void *handle, char *symbol, const char *version)
   void *result = dlsym_default_internal_library_handler(handle, symbol, version,
                                                         &tags,
                                                         &default_symbol_index);
+  dmtcp_enable_ckpt();
   return result;
 }
 
 EXTERNC void *
 dmtcp_dlsym_lib(const char *libname, const char *symbol)
 {
+  // Acquire checkpoint lock.
+  dmtcp_disable_ckpt();
+
   dt_tag tags;
   Elf32_Word default_symbol_index = 0;
 
@@ -607,6 +624,7 @@ dmtcp_dlsym_lib(const char *libname, const char *symbol)
                                                      NULL,
                                                      return_address, &tags,
                                                      &default_symbol_index);
+  dmtcp_enable_ckpt();
   return result;
 }
 


### PR DESCRIPTION
Other plugins might call dmtcp_dlsym without holding ckpt-lock and can introduce a deadlock if the ckpt-thread suspends a user-thread while it is holding an internal dlsym lock. Later on, ckpt-thread will deadlock if it also tries to call dmtcp_dlsym.