### PR TITLE
Fix 'dmtcp_command -l' and show port w/ 'ps', 'top'

### DIFF
--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -1142,6 +1142,9 @@ waitForCheckpointCommand()
     reply.numPeers = 1;
     reply.isRunning = 1;
     break;
+  case 'l':
+    JTRACE("Received list command");
+    break;
   case 'c':
     JTRACE("checkpointing...");
     break;

--- a/src/dmtcp_command.cpp
+++ b/src/dmtcp_command.cpp
@@ -218,7 +218,7 @@ main(int argc, char **argv)
     return 2;
   }
 
-  if(*cmd == 's'){
+  if(*cmd == 's' || *cmd == 'l'){
     printf("Coordinator:\n");
     char *host = getenv(ENV_VAR_NAME_HOST);
     if (host == NULL) {


### PR DESCRIPTION
Two commits:
  1.  `dmtcp_command -l`     now works.  This bug has been in DMTCP forever.
  2.  `top` and `ps` should now show the port number for dmtcp_coordinator.