### PR TITLE
use multi-stage build and update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,16 @@
 # Dockerfile to build DMTCP container images.
-FROM ubuntu:15.04
-MAINTAINER Kapil Arya <kapil@ccs.neu.edu>
+FROM debian:10-slim as builder
+LABEL maintain="Kapil Arya <kapil@ccs.neu.edu>"
 
 RUN apt-get update -q && apt-get -qy install    \
       build-essential                           \
       git-core                                  \
       make
 
-RUN mkdir -p /dmtcp
-RUN mkdir -p /tmp
-
 WORKDIR /dmtcp
-RUN git clone https://github.com/dmtcp/dmtcp.git /dmtcp && \
-      git checkout master &&                    \
-      git log -n 1
+COPY . .
+ARG MAKE_JOBS="2"
+RUN ./configure --prefix=/usr && make -j "$MAKE_JOBS" && make install
 
-RUN ./configure --prefix=/usr && make -j 2 && make install
+FROM debian:10-slim
+COPY --from=builder /usr/local/ /usr/local/


### PR DESCRIPTION
- use debian:10-slim as base image instead of EOL ubuntu 15.04
- use multi-stage build to remove compile-time dependencies
  - this reduces image size by 456 megabytes
- update maintainer instruction to label (maintainer instruction has been deprecated)
- add `MAKE_JOBS` build argument to pass in the number of jobs (`-j`) for `make`
- remove redundant `RUN mkdir ...` instructions