### PR TITLE
Define mtcp_strrchr; Fix mtcp_strcpy: final '\0'

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -1087,10 +1087,9 @@ read_one_memory_area(int fd, VA endOfStack)
 
     /*
      * The function is not used but is truer to maintaining the user's
-     * view of /proc/*/
-    maps.It can be enabled again in the future after
-    *we fix the logic to handle zero - sized files.
-    * /
+     * view of /proc/ * /maps. It can be enabled again in the future after
+     * we fix the logic to handle zero-sized files.
+     */
     if (imagefd >= 0) {
       adjust_for_smaller_file_size(&area, imagefd);
     }

--- a/src/mtcp/mtcp_util.h
+++ b/src/mtcp/mtcp_util.h
@@ -175,6 +175,7 @@ void mtcp_strncat(char *dest, const char *src, size_t n);
 int mtcp_strncmp(const char *s1, const char *s2, size_t n);
 int mtcp_strcmp(const char *s1, const char *s2);
 char *mtcp_strchr(const char *s, int c);
+char *mtcp_strrchr(const char *s, int c);
 int mtcp_strstartswith(const char *s1, const char *s2);
 int mtcp_strendswith(const char *s1, const char *s2);
 int mtcp_readmapsline(int mapsfd, Area *area);

--- a/src/mtcp/mtcp_util.ic
+++ b/src/mtcp/mtcp_util.ic
@@ -92,6 +92,7 @@ void mtcp_strcpy(char *dest, const char *src)
   while (*src != '\0') {
     *dest++ = *src++;
   }
+  *dest = '\0';
 }
 
 void mtcp_strncat(char *dest, const char *src, size_t n)
@@ -144,14 +145,24 @@ const void *mtcp_strstr(const char *string, const char *substring)
   return NULL;
 }
 
-//   The  strchr() function from earlier C library returns a ptr to the first
-//   occurrence  of  c  (converted  to a  char) in string s, or a
-//   null pointer  if  c  does  not  occur  in  the  string.
+// See 'man strchr'
 char *mtcp_strchr(const char *s, int c) {
   for (; *s != (char)'\0'; s++)
     if (*s == (char)c)
       return (char *)s;
   return NULL;
+}
+
+// See 'man strrchr'
+char *mtcp_strrchr(const char *s, int c) {
+  char *rc = NULL;
+  char *suffix = (char *)s;
+  while (1) {
+    if (*suffix == '\0') { break; }
+    if (*suffix == c) { rc = suffix; }
+    suffix++;
+  }
+  return rc;
 }
 
 int mtcp_strstartswith (const char *s1, const char *s2)


### PR DESCRIPTION
1.  Add `mtcp_strrchr()` to mtcp_util.ic  (mtcp_strchr()) is already there.
2. Fix bug in `mtcp_util.ic:mtcp_strcpy()`.  (It wasn't copying the final '\0'.)
3. Fix minor bug:  `/proc/*/mappings` was inside a comment.  The Intel icc compiler was catching this as `*/' (end-of-comment).  (It was inside a '#if 0 ... endif', and so the compiler only generated a warning.)