### PR TITLE
github/travis: cat /tmp/dmtcp-*/backtrace.* debugging files on jassert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,10 @@ compiler:
   - gcc
 
 script: ./configure && make -j4 && make tests && ./test/autotest.py --retry-once
+
+# NOTE: https://docs.travis-ci.com/user/running-build-in-debug-mode/
+# NOTE: https://docs.travis-ci.com/user/environment-variables/
+# NOTE: some environment vars available: /${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}
+# NOTE: The after_script retrieves files suitable for util/dmtcp_backtrace.py; but we should
+#       call the utility in travis since our local libdmtcp.so binary is probably different.
+after_script: FILES=`ls -t /tmp/dmtcp-travis@travis-job-*/{proc-maps.*,backtrace.*} | head -6` && for file in $FILES; do echo ""; echo '*********' $file '*********'; cat $file; done

--- a/util/dmtcp_backtrace.py
+++ b/util/dmtcp_backtrace.py
@@ -6,7 +6,7 @@ import subprocess
 
 # Set defaults
 host = subprocess.Popen("hostname", shell=True, stdout=subprocess.PIPE)
-host = host.stdout.read().rstrip()
+host = str(host.stdout.read().rstrip())
 dmtcpTmpDir = "/tmp/dmtcp-" + os.environ['USER'] + '@' + host + '/'
 (libdmtcp, tmpBacktrace, tmpProcMaps) = \
   ('libdmtcp.so', dmtcpTmpDir+'backtrace', dmtcpTmpDir+'proc-maps')
@@ -83,7 +83,7 @@ for callFrame in backtrace:
     else: # This subprocess prints to stdout
       # print(callFrame)
       # print(addr2line + hexOffset)
-      print("** FNC: ", end="")
+      os.write(sys.stdout.fileno(), "** FNC: ")
       sys.stdout.flush()
       subprocess.call(addr2line + hexOffset, shell=True)
   else:


### PR DESCRIPTION
.travis.yml modified to add scirpt_failure: entry to cat /tmp/dmtcp-*/backtrace.* files.