### PR TITLE
Add PROT_READ guard pages

### DIFF
--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -406,10 +406,10 @@ mtcp_write_non_rwx_and_anonymous_pages(int fd, Area *orig_area)
     a.size = size;
 
     rc = Util::writeAll(fd, &a, sizeof(a));
-    JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed at ckpt");
+    JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed during ckpt");
     if (!is_zero) {
       rc = Util::writeAll(fd, a.addr, a.size);
-      JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed at ckpt");
+      JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed during ckpt");
     } else {
       if (madvise(a.addr, a.size, MADV_DONTNEED) == -1) {
         JNOTE("error doing madvise(..., MADV_DONTNEED)")
@@ -509,13 +509,13 @@ writememoryarea(int fd, Area *area, int stack_was_seen)
     if (skipWritingTextSegments && (area->prot & PROT_EXEC)) {
       area->properties |= DMTCP_SKIP_WRITING_TEXT_SEGMENTS;
       rc = Util::writeAll(fd, area, sizeof(*area));
-      JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed at ckpt");
+      JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed during ckpt");
       JTRACE("Skipping over text segments") (area->name) ((void *)area->addr);
     } else {
       rc = Util::writeAll(fd, area, sizeof(*area));
-      JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed at ckpt");
+      JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed during ckpt");
       rc = Util::writeAll(fd, area->addr, area->size);
-      JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed at ckpt");
+      JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed during ckpt");
     }
   }
 }

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -391,6 +391,7 @@ mtcp_write_non_rwx_and_anonymous_pages(int fd, Area *orig_area)
   }
 
   while (area.size > 0) {
+    int rc = 0;
     size_t size;
     int is_zero;
     Area a = area;
@@ -404,9 +405,11 @@ mtcp_write_non_rwx_and_anonymous_pages(int fd, Area *orig_area)
     a.properties = is_zero ? DMTCP_ZERO_PAGE : 0;
     a.size = size;
 
-    Util::writeAll(fd, &a, sizeof(a));
+    rc = Util::writeAll(fd, &a, sizeof(a));
+    JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed at ckpt");
     if (!is_zero) {
-      Util::writeAll(fd, a.addr, a.size);
+      rc = Util::writeAll(fd, a.addr, a.size);
+      JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed at ckpt");
     } else {
       if (madvise(a.addr, a.size, MADV_DONTNEED) == -1) {
         JNOTE("error doing madvise(..., MADV_DONTNEED)")
@@ -429,6 +432,7 @@ mtcp_write_non_rwx_and_anonymous_pages(int fd, Area *orig_area)
 static void
 writememoryarea(int fd, Area *area, int stack_was_seen)
 {
+  int rc = 0;
   void *addr = area->addr;
 
   if (!(area->flags & MAP_ANONYMOUS)) {
@@ -504,11 +508,14 @@ writememoryarea(int fd, Area *area, int stack_was_seen)
 
     if (skipWritingTextSegments && (area->prot & PROT_EXEC)) {
       area->properties |= DMTCP_SKIP_WRITING_TEXT_SEGMENTS;
-      Util::writeAll(fd, area, sizeof(*area));
+      rc = Util::writeAll(fd, area, sizeof(*area));
+      JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed at ckpt");
       JTRACE("Skipping over text segments") (area->name) ((void *)area->addr);
     } else {
-      Util::writeAll(fd, area, sizeof(*area));
-      Util::writeAll(fd, area->addr, area->size);
+      rc = Util::writeAll(fd, area, sizeof(*area));
+      JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed at ckpt");
+      rc = Util::writeAll(fd, area->addr, area->size);
+      JASSERT(rc != -1)(JASSERT_ERRNO).Text("writeAll failed at ckpt");
     }
   }
 }


### PR DESCRIPTION
Add PROT_READ to guard page of restore buffer

* This works around a Linux 3.10 kernel bug affecting sched_test. 
* A second commit also does a JASSERT if writeAll() in ckpt of a memory segment fails.

Note that PROT_READ was added to 'mprotect' on the guard pages around the restore buffer.  Without this, writeAll was failing on the guard pages during ckpt in the child process, in the case of test/{dmtcp5,sched_test,shared-fd1} and other tests during the _first_ checkpoint, only.  write() was failing with EFAULT (but no SEGFAULT) for the guard pages in Linux 3.10.0-1062.9.1.el7.x86_64 in CentOS 7.7.1908.  (But it did not occur in Ubuntu 18.04 with Linux 4.15.)  This is arguably a bug in the Linux 3.10 kernel.  