### PR TITLE
Fix for test/epoll1.c:  Fixing commit b02d3e867d1

### DIFF
--- a/test/epoll1.c
+++ b/test/epoll1.c
@@ -127,11 +127,15 @@ main(int argc, char *argv[])
     perror("bind");
     exit(1);
   }
-  listen(listen_sockfd, 5);
+  rc = listen(listen_sockfd, 5);
+  if (rc == -1) {
+    perror("listen");
+    exit(1);
+  }
 
   // This is informational only; it could be deleted.
   struct sockaddr_in sockaddr_tmp;
-  socklen_t addrlen;
+  socklen_t addrlen = sizeof(sockaddr_tmp);
   rc = getsockname(listen_sockfd, (struct sockaddr *)&sockaddr_tmp, &addrlen);
   if (rc == -1) {
     perror("getsockname");


### PR DESCRIPTION
The title says it all.  getsockname() was not being used correctly.  More recent glibc's do better testing.