### PR TITLE
Delay *.ckpt.temp to *.ckpt rename until after WriteCkpt barrier.

### DIFF
--- a/src/ckptserializer.h
+++ b/src/ckptserializer.h
@@ -32,7 +32,9 @@ namespace CkptSerializer
 {
 int openCkptFileToWrite(const string &path);
 void createCkptDir();
-void writeCkptImage(void *mtcpHdr, size_t mtcpHdrLen);
+void writeCkptImage(void *mtcpHdr,
+                    size_t mtcpHdrLen,
+                    const string& ckptFilename);
 void writeDmtcpHeader(int fd);
 }
 }

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -464,16 +464,26 @@ void
 DmtcpWorker::postCheckpoint()
 {
   WorkerState::setCurrentState(WorkerState::CHECKPOINTED);
+
+  // TODO: Merge this barrier with the previous `sendCkptFilename` msg.
+  JTRACE("Waiting for Write-Ckpt barrier");
+  CoordinatorAPI::waitForBarrier("DMT:WriteCkpt");
+
+
+  /* Now that temp checkpoint file is complete, rename it over old permanent
+   * checkpoint file.  Uses rename() syscall, which doesn't change i-nodes.
+   * So, gzip process can continue to write to file even after renaming.
+   */
+  JASSERT(rename(ProcessInfo::instance().getTempCkptFilename().c_str(),
+                 ProcessInfo::instance().getCkptFilename().c_str()) == 0);
+
+
   CoordinatorAPI::sendCkptFilename();
 
   if (exitAfterCkpt) {
     JTRACE("Asked to exit after checkpoint. Exiting!");
     _exit(0);
   }
-
-  // TODO: Merge this barrier with the previous `sendCkptFilename` msg.
-  JTRACE("Waiting for Write-Ckpt barrier");
-  CoordinatorAPI::waitForBarrier("DMT:WriteCkpt");
 
   PluginManager::eventHook(DMTCP_EVENT_RESUME);
 

--- a/src/processinfo.h
+++ b/src/processinfo.h
@@ -139,6 +139,7 @@ class ProcessInfo
     uint64_t endOfStack(void) const { return _endOfStack; }
 
     string getCkptFilename() const { return _ckptFileName; }
+    string getTempCkptFilename() const { return _ckptFileName + ".temp"; }
 
     string getCkptFilesSubDir() const { return _ckptFilesSubDir; }
 

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -330,7 +330,10 @@ ThreadList::writeCkpt()
 
   MtcpHeader mtcpHdr;
   prepareMtcpHeader(&mtcpHdr);
-  CkptSerializer::writeCkptImage(&mtcpHdr, sizeof(mtcpHdr));
+
+  string ckptFilename = ProcessInfo::instance().getTempCkptFilename();
+
+  CkptSerializer::writeCkptImage(&mtcpHdr, sizeof(mtcpHdr), ckptFilename);
 }
 
 /*************************************************************************


### PR DESCRIPTION
This helps prevent partial checkpoints when a large process takes long time to write a ckpt image.