### PR TITLE
Fix checkpoint-restore of file-backed regions

### DIFF
--- a/include/procmapsarea.h
+++ b/include/procmapsarea.h
@@ -98,6 +98,7 @@ typedef union ProcMapsArea {
       uint64_t __inodenum;
     };
 
+    off_t    mmapFileSize;
     uint64_t properties;
 
     char name[FILENAMESIZE];

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -570,16 +570,14 @@ mtcp_simulateread(int fd, MtcpHeader *mtcpHdr)
     }
     if ((area.properties & DMTCP_ZERO_PAGE) == 0 &&
         (area.properties & DMTCP_SKIP_WRITING_TEXT_SEGMENTS) == 0) {
-      void *addr = mtcp_sys_mmap(0, area.size, PROT_WRITE | PROT_READ,
-                                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-      if (addr == MAP_FAILED) {
-        MTCP_PRINTF("***Error: mmap failed; errno: %d\n", mtcp_sys_errno);
-        mtcp_abort();
+
+      off_t seekLen = area.size;
+      if (!(area.flags & MAP_ANONYMOUS) && area.mmapFileSize > 0) {
+        seekLen =  area.mmapFileSize;
       }
-      mtcp_readfile(fd, addr, area.size);
-      if (mtcp_sys_munmap(addr, area.size) == -1) {
-        MTCP_PRINTF("***Error: munmap failed; errno: %d\n", mtcp_sys_errno);
-        mtcp_abort();
+      if (mtcp_sys_lseek(fd, seekLen, SEEK_CUR) < 0) {
+         mtcp_printf("Could not seek!\n");
+         break;
       }
     }
 
@@ -587,7 +585,7 @@ mtcp_simulateread(int fd, MtcpHeader *mtcpHdr)
 
                 // "%x %u:%u %u"
                 "          %s\n",
-                area.addr, area.addr + area.size,
+                area.addr, area.endAddr,
                 (area.prot & PROT_READ  ? 'r' : '-'),
                 (area.prot & PROT_WRITE ? 'w' : '-'),
                 (area.prot & PROT_EXEC  ? 'x' : '-'),
@@ -1113,7 +1111,13 @@ read_one_memory_area(int fd, VA endOfStack)
        */
 
       /* ANALYZE THE CONDITION FOR DOING mmapfile MORE CAREFULLY. */
-      mtcp_readfile(fd, area.addr, area.size);
+      if (area.mmapFileSize > 0 && area.name[0] == '/') {
+        MTCP_PRINTF("restoring shared-memory region %p of %p bytes at %p\n",
+                    area.mmapFileSize, area.size, area.addr);
+        mtcp_readfile(fd, area.addr, area.mmapFileSize);
+      } else {
+        mtcp_readfile(fd, area.addr, area.size);
+      }
       if (!(area.prot & PROT_WRITE)) {
         if (mtcp_sys_mprotect(area.addr, area.size, area.prot) < 0) {
           MTCP_PRINTF("error %d write-protecting %p bytes at %p\n",

--- a/src/procselfmaps.cpp
+++ b/src/procselfmaps.cpp
@@ -243,6 +243,7 @@ ProcSelfMaps::getNextArea(ProcMapsArea *area)
     area->flags |= MAP_ANONYMOUS;
   }
 
+  area->mmapFileSize = -1;
   area->properties = 0;
 
   return 1;


### PR DESCRIPTION
The issue is related to the fact that an application is allowed to
mmap a large region of memory even though the entire region may not be
backed by a file. For example, for a file that is just 1 MB on disk,
the application can make an mmap call asking for 2 GB, but only the
first 1 MB of the memory region will be actually made available. There
are two different behaviors of the Linux kernel when one tries to read
anything beyond the first 1 MB:

- If one tries to read any byte in user-land (load instruction) beyond the first
  1 MB, it generates a SIGBUS.

- If one makes a system call such as write() that uses the entire memory
  region (2 GB), the system call returns success, meaning that it wrote
  2 GB, but it actually only writes out 1 MB!

Now, this confuses the restart code: since we recorded that the size
of the region is 2 GB, the code expects that the memory region would be
2 GB, but the kernel only wrote 1 MB. The code then tries to read 2 GB from
the image. There are two possible outcomes:

 - Either the read fails (because of EOF), or

 - The read succeeds (if the image had sufficient data). However, for the
   subsequent memory region, we'll end up seeing garbage data.

Basically, the checkpoint image has all the checkpoint data but it's
not at the offsets that we are expecting.