### PR TITLE
Ensure all restarting processes have connected before releasing a barrier.

### DIFF
--- a/include/shareddata.h
+++ b/include/shareddata.h
@@ -161,21 +161,23 @@ struct Header {
 
 bool initialized();
 
-void initialize(const char *tmpDir,
-                const char *installDir,
-                DmtcpUniqueProcessId *compId,
-                CoordinatorInfo *coordInfo,
-                struct in_addr *localIP);
+void initialize(const char *tmpDir = NULL,
+                const char *installDir = NULL,
+                DmtcpUniqueProcessId *compId = NULL,
+                CoordinatorInfo *coordInfo = NULL,
+                struct in_addr *localIPAddr = NULL,
+                uint32_t numPeers = 0);
 void initializeHeader(const char *tmpDir,
                       const char *installDir,
                       DmtcpUniqueProcessId *compId,
                       CoordinatorInfo *coordInfo,
-                      struct in_addr *localIP);
+                      struct in_addr *localIP,
+                      uint32_t numPeers);
 
 bool isSharedDataRegion(void *addr);
-void initializeBarrier();
+void initializeBarrier(uint32_t numPeers);
 void resetBarrierInfo();
-void prepareForCkpt();
+void prepareForCkpt(uint32_t numPeers);
 void postRestart();
 void waitForBarrier(const string &barrierId);
 

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -452,6 +452,12 @@ DmtcpCoordinator::releaseBarrier(const string &barrier)
   ComputationStatus status = getStatus();
 
   if (workersAtCurrentBarrier == status.numPeers) {
+    if (numPeers > 0 && status.numPeers != numPeers) {
+      JNOTE("Waiting for all restarting processes to connect.")
+        (numPeers) (status.numPeers);
+      return;
+    }
+
     JTRACE("Releasing barrier") (barrier);
     prevBarrier = currentBarrier;
     currentBarrier.clear();

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -311,7 +311,8 @@ class RestoreTarget
                                installDir.c_str(),
                                &compId,
                                &coordInfo,
-                               &localIPAddr);
+                               &localIPAddr,
+                               _pInfo.numPeers());
 
         Util::initializeLogFile(SharedData::getTmpDir().c_str(),
                                 _pInfo.procname().c_str(),

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -447,12 +447,12 @@ DmtcpWorker::preCheckpoint()
     SharedData::getCompId()._computation_generation;
   ProcessInfo::instance().set_generation(computationGeneration);
 
-  SharedData::prepareForCkpt();
-
   uint32_t numPeers;
   JTRACE("Waiting for DMT_CHECKPOINT barrier");
   CoordinatorAPI::waitForBarrier("DMT:CHECKPOINT", &numPeers);
   JTRACE("Computation information") (numPeers);
+
+  SharedData::prepareForCkpt(numPeers);
 
   ProcessInfo::instance().numPeers(numPeers);
 

--- a/src/plugin/ipc/file/fileconnlist.cpp
+++ b/src/plugin/ipc/file/fileconnlist.cpp
@@ -547,9 +547,7 @@ FileConnList::scanForPreExisting()
     }
     struct stat statbuf;
     JASSERT(fstat(fd, &statbuf) == 0);
-    bool isRegularFile =
-      (S_ISREG(statbuf.st_mode) || S_ISCHR(statbuf.st_mode) ||
-       S_ISDIR(statbuf.st_mode) || S_ISBLK(statbuf.st_mode));
+    bool isRegularFile = (S_ISREG(statbuf.st_mode) || S_ISDIR(statbuf.st_mode));
 
     string device = jalib::Filesystem::GetDeviceName(fd);
 
@@ -581,15 +579,15 @@ FileConnList::scanForPreExisting()
        */
       continue;
     } else if (Util::strStartsWith(device.c_str(), "/") &&
-               !Util::isPseudoTty(device.c_str())) {
-      if (isRegularFile) {
-        Connection *c = findDuplication(fd, device.c_str());
-        if (c != NULL) {
-          add(fd, c);
-          continue;
-        }
+               !Util::isPseudoTty(device.c_str()) &&
+               isRegularFile) {
+      Connection *c = findDuplication(fd, device.c_str());
+      if (c != NULL) {
+        add(fd, c);
+        continue;
       }
-      add(fd, new FileConnection(device.c_str(), -1, -1));
+    } else {
+      JTRACE("Ignoring pre-existing fd") (device);
     }
   }
 }


### PR DESCRIPTION
We removed the numPeers check when we moved to the newer barrier design. This PR reintroduces the concept.