### PR TITLE
Makefile.in, hooks/{pre-commit,post-rewrite}: use Python 2 or 3

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -207,21 +207,27 @@ tests-32: build
 LIMIT=ulimit -v 33554432
 
 check: tests
-	@ if python -c 'print("Python exits.")' > /dev/null; then \
-	  bash -c "$(LIMIT) && $(top_srcdir)/test/autotest.py ${AUTOTEST} $*"; \
-	  else echo '*** No python found in your path.'; echo '*** Please add' \
-	   ' python to path or build Python 2.x for x >= 3.'; \
-	  fi
+	@ if test "@HAS_PYTHON3@" = yes; then \
+	 bash -c "$(LIMIT) && python3 $(top_srcdir)/test/autotest.py ${AUTOTEST} $*";\
+	elif test "@HAS_PYTHON@" = yes; then \
+	 bash -c "$(LIMIT) && python $(top_srcdir)/test/autotest.py ${AUTOTEST} $*";\
+	else echo '*** No python found in your path.'; \
+	 echo '*** Please add python to path'; \
+	fi
 
 check-32: tests-32
 	@ if python -c 'print("Python exits.")' > /dev/null; then \
 	  bash -c "$(LIMIT) && $(top_srcdir)/test/autotest.py ${AUTOTEST} $*"; \
 	  else echo '*** No python found in your path.'; echo '*** Please add' \
-	   ' python to path or build Python 2.x for x >= 3.'; \
+	   ' python to path or build Python 2 or use python3.'; \
 	  fi
 
 check-%: tests
-	bash -c "$(LIMIT) && $(top_srcdir)/test/autotest.py ${AUTOTEST} '$*'"
+	@ if test "@HAS_PYTHON3@" = yes; then \
+	bash -c "$(LIMIT) && python3 $(top_srcdir)/test/autotest.py ${AUTOTEST} '$*'";\
+	elif test "@HAS_PYTHON@" = yes; then \
+	bash -c "$(LIMIT) && python $(top_srcdir)/test/autotest.py ${AUTOTEST} '$*'";\
+	fi
 
 check-32-%: tests-32
 	bash -c "$(LIMIT) && $(top_srcdir)/test/autotest.py ${AUTOTEST} '$*'"

--- a/configure
+++ b/configure
@@ -657,6 +657,7 @@ HAS_ZSH
 HAS_TCSH
 HAS_DASH
 HAS_PYTHON
+HAS_PYTHON3
 HAS_PS
 HAS_EPOLL_CREATE1
 HAS_CMA
@@ -6825,6 +6826,46 @@ HAS_PYTHON=$ac_cv_prog_HAS_PYTHON
 if test -n "$HAS_PYTHON"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $HAS_PYTHON" >&5
 $as_echo "$HAS_PYTHON" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+
+#check for python3
+# Extract the first word of "python3", so it can be a program name with args.
+set dummy python3; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_HAS_PYTHON3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$HAS_PYTHON3"; then
+  ac_cv_prog_HAS_PYTHON3="$HAS_PYTHON3" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in /usr/bin
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_HAS_PYTHON3="yes"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_prog_HAS_PYTHON3" && ac_cv_prog_HAS_PYTHON3="no"
+fi
+fi
+HAS_PYTHON3=$ac_cv_prog_HAS_PYTHON3
+if test -n "$HAS_PYTHON3"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $HAS_PYTHON3" >&5
+$as_echo "$HAS_PYTHON3" >&6; }
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -567,6 +567,9 @@ AC_CHECK_PROG(HAS_PS, [ps], [yes], [no], [/usr/bin:/bin])
 #check for python
 AC_CHECK_PROG(HAS_PYTHON, [python], [yes], [no], [/usr/bin])
 
+#check for python3
+AC_CHECK_PROG(HAS_PYTHON3, [python3], [yes], [no], [/usr/bin])
+
 #check for dash
 AC_CHECK_PROG(HAS_DASH, [dash], [yes], [no], [/bin])
 

--- a/util/dmtcp-style.py
+++ b/util/dmtcp-style.py
@@ -175,8 +175,9 @@ class CppLinter(LinterBase):
             'whitespace/todo']
 
         rules_filter = '--filter=-,+' + ',+'.join(active_rules)
+        python_version = 'python3' if sys.version_info[0] == 3 else 'python'
         p = subprocess.Popen(
-            ['python', 'util/cpplint.py', rules_filter] + source_paths,
+            [python_version, 'util/cpplint.py', rules_filter] + source_paths,
             stderr=subprocess.PIPE,
             close_fds=True)
 

--- a/util/hooks/post-rewrite
+++ b/util/hooks/post-rewrite
@@ -25,5 +25,11 @@ if [ "$ADDED_OR_MODIFIED" ]; then
     # many implementations do not support the `-r` flag, (which instructs
     # `xargs` to not run the script if the arguments are empty), so we also
     # cannot use that.
-    ./util/dmtcp-style.py $ADDED_OR_MODIFIED || exit 1
+    if command -v python; then \
+      python ./util/dmtcp-style.py $ADDED_OR_MODIFIED || exit 1; \
+    elif command -v python3; then \
+      python3 ./util/dmtcp-style.py $ADDED_OR_MODIFIED || exit 1; \
+    else \
+      exit 1; \
+    fi;
 fi

--- a/util/hooks/pre-commit
+++ b/util/hooks/pre-commit
@@ -30,5 +30,11 @@ if [ -n "$ADDED_OR_MODIFIED" ]; then
     # many implementations do not support the `-r` flag, (which instructs
     # `xargs` to not run the script if the arguments are empty), so we also
     # cannot use that.
-    ./util/dmtcp-style.py $ADDED_OR_MODIFIED || exit 1
+    if command -v python; then \
+      python ./util/dmtcp-style.py $ADDED_OR_MODIFIED || exit 1; \
+    elif command -v python3; then \
+      python3 ./util/dmtcp-style.py $ADDED_OR_MODIFIED || exit 1; \
+    else \
+      exit 1; \
+    fi;
 fi


### PR DESCRIPTION
The top-level `Makefile.in` and `.git/hooks/{pre-commit,post-rewrrite}` were modified so that they will invoke python or python3 -- whatever is available.
 
* This now also works when 'python3' is available, but not 'python'.