### PR TITLE
Fix for test/plugin/presuspend.c: bad use of pthread_kill()

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -1110,7 +1110,9 @@ if HAS_GCL == "yes":
 if HAS_OPENMP == "yes":
   S=3*DEFAULT_S
   runTest("openmp-1",         1,  ["./test/openmp-1"])
+  POST_LAUNCH_SLEEP=2
   runTest("openmp-2",         1,  ["./test/openmp-2"])
+  POST_LAUNCH_SLEEP=DEFAULT_POST_LAUNCH_SLEEP
   S=DEFAULT_S
 
 # SHOULD HAVE matlab RUN LARGE FACTORIAL OR SOMETHING.

--- a/test/plugin/presuspend/presuspend.c
+++ b/test/plugin/presuspend/presuspend.c
@@ -59,13 +59,8 @@ int is_child() {
   return (plugin_childpid == -1 || plugin_childpid == 0);
 }
 
-int is_alive(pid_t tid) {
-  int rc;
-  if (tid == plugin_childpid) {
-    rc = kill(tid, 0);
-  } else {
-    rc = pthread_kill(tid, 0);
-  }
+int is_alive(pid_t pid) {
+  int rc = kill(pid, 0);
   return (rc == -1 && errno == ESRCH ? 0 : 1);
 }
 


### PR DESCRIPTION
Fix to a silly bug:  pthread_kill was used instead of kill() for a childpid.
This should be trivial to review.