### PR TITLE
Minor bug fix for a0567cbd (and improved text): DMTCP_RESTART_PAUSE msg changed

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -697,8 +697,8 @@ restorememoryareas(RestoreInfo *rinfo_ptr)
       "You should now be in 'ThreadList::postRestartDebug()'\n"
       "  (gdb) list\n"
       "  (gdb) p dummy = 0\n"
-      "  # Since Linux 3.10 (prctl:PR_SET_MM), you will also need to do:\n"
-      "  (gdb) source DMTCP_ROOT/util/gdb-add-symbol-files-all\n",
+      "  # In some recent Linuxes/glibc/gdb, you may also need to do:\n"
+      "  (gdb) source DMTCP_ROOT/util/gdb-add-symbol-files-all\n"
       "  (gdb) add-symbol-files-all\n",
       mtcp_sys_getpid()
     );


### PR DESCRIPTION
This is a trivial PR to review.  I'm removing one comma  (and changing a print string).
 
* Remove misplaced comma in DMTCP_RESTART_PAUSE msg in mtcp_restart.c
 * Improve msg about issue with Linux/glibc/gdb