### PR TITLE
Bug fix for misidentifying region as stack

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -974,7 +974,7 @@ read_one_memory_area(int fd, VA endOfStack)
    * prepareMtcpHeader() in threadlist.cpp and ProcessInfo::growStack()
    * in processinfo.cpp.
    */
-  if ((area.name[0] && mtcp_strstr(area.name, "stack"))
+  if ((area.name[0] && area.name[0] != '/' && mtcp_strstr(area.name, "stack"))
       || (area.endAddr == endOfStack)) {
     area.flags = area.flags | MAP_GROWSDOWN;
     DPRINTF("Detected stack area. End of stack (%p); Area end address (%p)\n",


### PR DESCRIPTION
In mtcp_restart.c function read_one_memory_areas(): limit using string comparison to identify a stack region to regions whose name is not filename starting with "/".

This fixes a problem with dmtcp_restart failing to mmap a file whose path name includes the substring "stack" because  the MAP_GROWSDOWN flag gets used.