### PR TITLE
Fix for master branch for glibc 2.33 using stat() family

### DIFF
--- a/plugin/pathvirt/pathvirt.cpp
+++ b/plugin/pathvirt/pathvirt.cpp
@@ -23,6 +23,27 @@
 #include <cstring>
 #include <cstdlib>
 
+// glibc version 2.33 and later stopped defining _STAT_VER (for the 'vers'
+// argument of the xstat family of functions), and stopped
+// defining the xstat family.  It now defines the stat family directly.
+// instead of defining stat as a macro that expands to __xstat, etc.
+// We are macro expanding the xstat family to the stat family,
+// whenever _STAT_VER not defined..
+#ifndef _STAT_VER
+# undef __xstat
+# undef __xstat64
+# undef __lxstat
+# undef __lxstat64
+# define __xstat(vers,path,buf)         stat(path,buf)
+# define __xstat64(vers,path,buf)       stat64(path,buf)
+# define __lxstat(vers,path,buf)        lstat(path,buf)
+# define __lxstat64(vers,path,buf)      lstat64(path,buf)
+# define _real_xstat(vers,path,buf)     _real_stat(path,buf)
+# define _real_xstat64(vers,path,buf)   _real_stat64(path,buf)
+# define _real_lxstat(vers,path,buf)    _real_lstat(path,buf)
+# define _real_lxstat64(vers,path,buf)  _real_lstat64(path,buf)
+#endif
+
 #undef open
 #undef open64
 #undef openat
@@ -50,10 +71,17 @@
 #define _real_openat     NEXT_FNC(openat)
 #define _real_openat64   NEXT_FNC(openat64)
 #define _real_opendir    NEXT_FNC(opendir)
-#define _real_xstat      NEXT_FNC(__xstat)
-#define _real_xstat64    NEXT_FNC(__xstat64)
-#define _real_lxstat     NEXT_FNC(__lxstat)
-#define _real_lxstat64   NEXT_FNC(__lxstat64)
+#ifdef _STAT_VER
+# define _real_xstat      NEXT_FNC(__xstat)
+# define _real_xstat64    NEXT_FNC(__xstat64)
+# define _real_lxstat     NEXT_FNC(__lxstat)
+# define _real_lxstat64   NEXT_FNC(__lxstat64)
+#else
+# define _real_stat      NEXT_FNC(stat)
+# define _real_stat64    NEXT_FNC(stat64)
+# define _real_lstat     NEXT_FNC(lstat)
+# define _real_lstat64   NEXT_FNC(lstat64)
+#endif
 #define _real_readlink   NEXT_FNC(readlink)
 #define _real_realpath   NEXT_FNC(realpath)
 #define _real_access     NEXT_FNC(access)

--- a/src/plugin/ipc/file/ptywrappers.h
+++ b/src/plugin/ipc/file/ptywrappers.h
@@ -25,10 +25,17 @@
 
 #include "dmtcp.h"
 
-# define _real_xstat        NEXT_FNC(__xstat)
-# define _real_xstat64      NEXT_FNC(__xstat64)
-# define _real_lxstat       NEXT_FNC(__lxstat)
-# define _real_lxstat64     NEXT_FNC(__lxstat64)
+# ifdef _STAT_VER
+#  define _real_xstat        NEXT_FNC(__xstat)
+#  define _real_xstat64      NEXT_FNC(__xstat64)
+#  define _real_lxstat       NEXT_FNC(__lxstat)
+#  define _real_lxstat64     NEXT_FNC(__lxstat64)
+# else
+#  define _real_stat         NEXT_FNC(stat)
+#  define _real_stat64       NEXT_FNC(stat64)
+#  define _real_lstat        NEXT_FNC(lstat)
+#  define _real_lstat64      NEXT_FNC(lstat64)
+# endif
 # define _real_readlink     NEXT_FNC(readlink)
 # define _real_ptsname_r    NEXT_FNC(ptsname_r)
 # define _real_ttyname_r    NEXT_FNC(ttyname_r)

--- a/src/plugin/pid/pid_syscallsreal.c
+++ b/src/plugin/pid/pid_syscallsreal.c
@@ -523,6 +523,11 @@ _real_opendir(const char* name)
   REAL_FUNC_PASSTHROUGH_TYPED(DIR*, opendir) (name);
 }
 
+// FIXME:
+//   _real_*stat*() is not called anywhere in plugin/pid/*
+//   _real___*stat*() is defined and called in src/syscall*.*
+//   Therefore, we should delete all of these defs of _real_*stat*() below.
+#ifdef _STAT_VER
 int
 _real_xstat(int vers, const char *path, struct stat *buf)
 {
@@ -546,6 +551,23 @@ _real_lxstat64(int vers, const char *path, struct stat64 *buf)
 {
   REAL_FUNC_PASSTHROUGH(__lxstat64) (vers, path, buf);
 }
+#else
+int _real_stat(const char *path, struct stat *buf) {
+  REAL_FUNC_PASSTHROUGH(stat) (path, buf);
+}
+
+int _real_stat64(const char *path, struct stat64 *buf) {
+  REAL_FUNC_PASSTHROUGH(stat64) (path, buf);
+}
+
+int _real_lstat(const char *path, struct stat *buf) {
+  REAL_FUNC_PASSTHROUGH(lstat) (path, buf);
+}
+
+int _real_lstat64(const char *path, struct stat64 *buf) {
+  REAL_FUNC_PASSTHROUGH(lstat64) (path, buf);
+}
+#endif
 
 ssize_t
 _real_readlink(const char *path, char *buf, size_t bufsiz)

--- a/src/plugin/pid/pidwrappers.h
+++ b/src/plugin/pid/pidwrappers.h
@@ -119,6 +119,44 @@ LIB_PRIVATE pid_t dmtcp_gettid();
 LIB_PRIVATE int dmtcp_tkill(int tid, int sig);
 LIB_PRIVATE int dmtcp_tgkill(int tgid, int tid, int sig);
 
+// FIXME:  We must support glibc versions post-33 and pre-33 for now.
+//         Eventually, we should remove the xstat macros and support
+//         only the stat family that is defined in glibc-33 and later.
+// glibc version 2.33 and later stopped defining _STAT_VER (for the 'vers'
+// argument of the xstat family of functions), and stopped
+// defining the xstat family.  It now defines the stat family directly.
+// instead of defining stat as a macro that expands to __xstat, etc.
+// We are macro expanding the xstat family to the stat family,
+// whenever _STAT_VER not defined.
+#ifndef _STAT_VER
+# undef __xstat
+# undef __xstat64
+# undef __lxstat
+# undef __lxstat64
+# define __xstat(vers,path,buf)         stat(path,buf)
+# define __xstat64(vers,path,buf)       stat64(path,buf)
+# define __lxstat(vers,path,buf)        lstat(path,buf)
+# define __lxstat64(vers,path,buf)      lstat64(path,buf)
+# define _real_xstat(vers,path,buf)     _real_stat(path,buf)
+# define _real_xstat64(vers,path,buf)   _real_stat64(path,buf)
+# define _real_lxstat(vers,path,buf)    _real_lstat(path,buf)
+# define _real_lxstat64(vers,path,buf)  _real_lstat64(path,buf)
+#endif
+
+#ifdef _STAT_VER
+# define FOREACH_PIDVIRT_STAT_WRAPPER(MACRO) \
+  MACRO(__xstat)                             \
+  MACRO(__xstat64)                           \
+  MACRO(__lxstat)                            \
+  MACRO(__lxstat64)
+#else
+# define FOREACH_PIDVIRT_STAT_WRAPPER(MACRO) \
+  MACRO(stat)                                \
+  MACRO(stat64)                              \
+  MACRO(lstat)                               \
+  MACRO(lstat64)
+#endif
+
 #define FOREACH_PIDVIRT_WRAPPER(MACRO) \
   MACRO(fork)                          \
   MACRO(vfork)                         \
@@ -161,11 +199,8 @@ LIB_PRIVATE int dmtcp_tgkill(int tgid, int tid, int sig);
   MACRO(dup2)                          \
   MACRO(fopen64)                       \
   MACRO(opendir)                       \
-  MACRO(__xstat)                       \
-  MACRO(__xstat64)                     \
-  MACRO(__lxstat)                      \
-  MACRO(__lxstat64)                    \
-  MACRO(readlink)
+  MACRO(readlink)                      \
+  FOREACH_PIDVIRT_STAT_WRAPPER(MACRO)
 
 #define FOREACH_SYSVIPC_CTL_WRAPPER(MACRO) \
   MACRO(shmctl)                            \

--- a/src/syscallsreal.c
+++ b/src/syscallsreal.c
@@ -46,7 +46,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include "constants.h"
-#include "syscallwrappers.h"
+#include "syscallwrappers.h"  /* glibc > ver. 2.33: redefines xstat to stat */
 #include "trampolines.h"
 
 typedef int (*funcptr_t) ();
@@ -893,6 +893,7 @@ _real_syscall(long sys_num, ...)
                                               arg[5], arg[6]);
 }
 
+#ifdef _STAT_VER
 LIB_PRIVATE
 int
 _real___xstat(int vers, const char *path, struct stat *buf)
@@ -920,6 +921,31 @@ _real___lxstat64(int vers, const char *path, struct stat64 *buf)
 {
   REAL_FUNC_PASSTHROUGH(__lxstat64) (vers, path, buf);
 }
+#else
+LIB_PRIVATE
+int
+_real_stat(const char *path, struct stat *buf) {
+  REAL_FUNC_PASSTHROUGH(stat) (path, buf);
+}
+
+LIB_PRIVATE
+int
+_real_stat64(const char *path, struct stat64 *buf) {
+  REAL_FUNC_PASSTHROUGH(stat64) (path, buf);
+}
+
+LIB_PRIVATE
+int
+_real_lstat(const char *path, struct stat *buf) {
+  REAL_FUNC_PASSTHROUGH(lstat) (path, buf);
+}
+
+LIB_PRIVATE
+int
+_real_lstat64(const char *path, struct stat64 *buf) {
+  REAL_FUNC_PASSTHROUGH(lstat64) (path, buf);
+}
+#endif
 
 LIB_PRIVATE
 int

--- a/src/syscallwrappers.h
+++ b/src/syscallwrappers.h
@@ -74,6 +74,30 @@
 #include "dmtcp.h"
 #include "mtcp/ldt.h"
 
+// glibc version 2.33 stopped defining _STAT_VER, which was the 'vers'
+// argument to the xtat family of function.  Now, glibc-2.33 is defining
+// lstat directly, instead of defining lstat as a macro that expands
+// to __lxstat.  We are macro expanding the xstat family to the stat family,
+// whenever _STAT_VER not defined.
+#ifndef _STAT_VER
+# undef __xstat
+# undef __xstat64
+# undef __lxstat
+# undef __lxstat64
+# undef _real_xstat
+# undef _real_xstat64
+# undef _real_lxstat
+# undef _real_lxstat64
+# define __xstat(vers,path,buf)          stat(path, buf)
+# define __xstat64(vers,path,buf)        stat64(path, buf)
+# define __lxstat(vers,path,buf)         lstat(path, buf)
+# define __lxstat64(vers,path,buf)       lstat64(path, buf)
+# define _real___xstat(vers,path,buf)    _real_stat(path, buf)
+# define _real___xstat64(vers,path,buf)  _real_stat64(path, buf)
+# define _real___lxstat(vers,path,buf)   _real_lstat(path, buf)
+# define _real___lxstat64(vers,path,buf) _real_lstat64(path, buf)
+#endif
+
 #ifdef HAVE_SYS_EPOLL_H
 # include <sys/epoll.h>
 #else // ifdef HAVE_SYS_EPOLL_H
@@ -108,6 +132,20 @@ LIB_PRIVATE int dmtcp_tgkill(int tgid, int tid, int sig);
 extern int dmtcp_wrappers_initializing;
 
 LIB_PRIVATE extern __thread int thread_performing_dlopen_dlsym;
+
+#ifdef _STAT_VER
+# define FOREACH_DMTCP_STAT_WRAPPER(MACRO)  \
+  MACRO(__xstat)                            \
+  MACRO(__xstat64)                          \
+  MACRO(__lxstat)                           \
+  MACRO(__lxstat64)
+#else
+# define FOREACH_DMTCP_STAT_WRAPPER(MACRO) \
+  MACRO(stat)                               \
+  MACRO(stat64)                             \
+  MACRO(lstat)                              \
+  MACRO(lstat64)
+#endif
 
 #define FOREACH_DMTCP_WRAPPER(MACRO)  \
   MACRO(dlopen)                       \
@@ -201,10 +239,6 @@ LIB_PRIVATE extern __thread int thread_performing_dlopen_dlsym;
   MACRO(dup)                          \
   MACRO(dup2)                         \
   MACRO(dup3)                         \
-  MACRO(__xstat)                      \
-  MACRO(__xstat64)                    \
-  MACRO(__lxstat)                     \
-  MACRO(__lxstat64)                   \
   MACRO(readlink)                     \
   MACRO(realpath)                     \
   MACRO(access)                       \
@@ -244,7 +278,8 @@ LIB_PRIVATE extern __thread int thread_performing_dlopen_dlsym;
   MACRO(pthread_tryjoin_np)           \
   MACRO(pthread_timedjoin_np)         \
   MACRO(pthread_sigmask)              \
-  MACRO(pthread_getspecific)
+  MACRO(pthread_getspecific)          \
+  FOREACH_DMTCP_STAT_WRAPPER(MACRO)
 
 #define ENUM(x)     enum_ ## x
 #define GEN_ENUM(x) ENUM(x),


### PR DESCRIPTION
DMTCP fails to compile with glibc-2.33.  In particular, the future release of  Fedora 2.34 (and other distros) will start to use gcc-10.0 and glibc-2.33.

The problem is that in glibc version 2.33, they stop defining `_STAT_VER`.  glibc originally used `_STAT_VER` as the value in an extra argument in `__xstat(vers, path, buf)` .  Presumably, gcc/g++ then macro-expanded `stat(path,buf)` to `__xstat(_STAT_VER,path,buf)`.  But glibc-2.33 now removes `_STAT_VER` and directly defines `stat(path,buf)`, etc.

This PR uses `#ifdef _STAT_VER` to have DMTCP refer either to `__xstat()` or `stat()`, according to whether `_STAT_VER` is defined.

**NOTE:**  mknod() in test/syscall_tester.c also uses _STAT_VER prior to glibc-2.33.  In Fedora rawhide, test/syscall_tester.c fails even without using DMTCP, because mknod can succeed with glibc-2.33, where it would have failed in the past.  I'm not fixing this now.  Let's wait for the release of the distros to see if this problem persists.

Finally, please note the comment in this commit:
```
glibc-2.33: src/plugin/pid/: __xstat->stat, etc.

  **************************************************************************
  * PLEASE READ THE FIXME IN:  src/plugin/pid/pid_syscallsreal.c           *
  * We should remove definitions of _real_*stat*(), since they're not used.*
  **************************************************************************
```

The previous code was the result of commit 3d43ac6e9e0bd8bf596aac9a5d827fbe66d7848a by @karya0.  I think that code is dead code and can be removed.  But I'd rather have @karya0 check me on this, and then eitehr submit his own PR or ask me to do it.
