### PR TITLE
Stop using cast for basename (Fix for 97d45952)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
     packages:
     - tcsh
     - zsh
-    
+ 
 language: cpp
 compiler:
   - gcc

--- a/src/restartscript.cpp
+++ b/src/restartscript.cpp
@@ -27,6 +27,7 @@
 
 #include <fcntl.h>
 #include <libgen.h>  // for basename()
+#include <limits.h>  // for PATH_MAX
 #include <stdio.h>
 
 #include <sys/stat.h>
@@ -606,10 +607,14 @@ writeScript(const string &ckptDir,
       (filename) (dirname) (uniqueFilename);
 
     // FIXME:  Handle error case of symlink()
-    // FIXME:  basename() modifies uniqueFilename.c_str()
-    //         Is there a cleaner way to do this?
-    JWARNING(symlinkat(basename((char *)uniqueFilename.c_str()), dirfd,
-                       filename.c_str()) == 0) (JASSERT_ERRNO);
+    unlink(filename.c_str());
+    JTRACE("linking \"dmtcp_restart_script.sh\" filename to uniqueFilename")
+          (filename) (dirname) (uniqueFilename);
+    char uniq_fname_str[PATH_MAX];
+    strncpy(uniq_fname_str, uniqueFilename.c_str(), PATH_MAX);
+    JASSERT(uniq_fname_str[PATH_MAX-1] == '\0'); // orig str less than PATH_MAX     // FIXME:  Handle error case of symlink()
+    JWARNING(symlinkat(basename(uniq_fname_str), dirfd, filename.c_str()) == 0)
+            (JASSERT_ERRNO);
     JASSERT(close(dirfd) == 0);
   }
   return uniqueFilename;


### PR DESCRIPTION
When libgen.h is included, then glibc uses POSIX `basename()` instead of GNU `basename()`.  The GNU version takes a `const char *` argument.  But the POSIX version takes a `char *` as its argument, since it may choose to destructively alter its string argument.  So, we make a `char *`  local copy of the string to pass to GNU `basename()`.