### PR TITLE
Add --timeout param to coord; use it in autotest

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -192,6 +192,9 @@ REQUIRE_MB=50
 #Binaries
 BIN="./bin/"
 
+# cmdline string to launch coord: times out after 3 hours to prevent runaways
+coordinator_cmdline = BIN+"dmtcp_coordinator --timeout 10800"
+
 #Checkpoint command to send to coordinator
 CKPT_CMD=b'c'
 
@@ -404,7 +407,7 @@ else:
     os.environ['LD_LIBRARY_PATH'] = os.getenv("PWD")+"/lib"
 
 #run the coordinator
-coordinator = runCmd(BIN+"dmtcp_coordinator")
+coordinator = runCmd(coordinator_cmdline)
 
 #send a command to the coordinator process
 def coordinatorCmd(cmd):
@@ -546,7 +549,7 @@ def runTestRaw(name, numProcs, cmds):
       coordinatorCmd(b'q')
       os.system("kill -9 %d" % coordinator.pid)
       print("Trying to kill old coordinator, and run new one on same port")
-      coordinator = runCmd(BIN+"dmtcp_coordinator")
+      coordinator = runCmd(coordinator_cmdline)
     for x in procs:
       #cleanup proc
       try:


### PR DESCRIPTION
`dmtcp_coordinator.cpp` now takes a `--timeout <seconds>` flag.  If the timeout occurs, then the coordinator exits.

This is useful in `autotest.py`.  This was now changed to call `./bin/dmtcp_coordinator --timeout 10800` (a timeout of 3 hours).  This should get rid of the frequent runaway coordinator processes that occur when `make check` is interrupted.