### PR TITLE
3.0-fix-gcc-10-warnings

### DIFF
--- a/jalib/jalloc.cpp
+++ b/jalib/jalloc.cpp
@@ -234,7 +234,10 @@ class JFixedAllocStack
         // TODO: why is expand being called? If you see this message, raise lvl2
         // allocation level.
         char expand_msg[] = "\n\n\n******* EXPAND IS CALLED *******\n\n\n";
-        write(2, expand_msg, sizeof(expand_msg));
+        int rc = write(2, expand_msg, sizeof(expand_msg));
+        if (rc != sizeof(expand_msg)) {
+          perror("DMTCP(" __FILE__ "): write: ");
+        }
 
         // jalib::fflush(stderr);
         abort();
@@ -330,7 +333,10 @@ jalib::JAllocDispatcher::deallocate(void *ptr, size_t n)
 {
   if (!_initialized) {
     char msg[] = "***DMTCP INTERNAL ERROR: Free called before init\n";
-    write(2, msg, sizeof(msg));
+    int rc = write(2, msg, sizeof(msg));
+    if (rc != sizeof(msg)) {
+      perror("DMTCP(" __FILE__ "): write: ");
+    }
     abort();
   }
   if (n <= lvl1.N) {

--- a/plugin/batch-queue/rm_main.cpp
+++ b/plugin/batch-queue/rm_main.cpp
@@ -37,7 +37,7 @@ using namespace dmtcp;
 EXTERNC int
 dmtcp_batch_queue_enabled(void) { return 1; }
 
-int
+void
 patch_srun_cmdline(DmtcpEventData_t *data);
 
 static void

--- a/plugin/modify-env/modify-env.c
+++ b/plugin/modify-env/modify-env.c
@@ -37,18 +37,26 @@ int readAndSetEnv(char *buf, int size);
 int readall(int fd, char *buf, int maxCount);
 extern void warning(const char *warning_part1, const char *warning_part2);
 
+#ifdef STANDALONE
+int
+dmtcp_modify_env_enabled() { return 1; }
+#else
 EXTERNC int
 dmtcp_modify_env_enabled() { return 1; }
+#endif
 
 #ifdef STANDALONE
 int
-dmtcp_get_restart_env(char *envName, char *dest, size_t size)
+dmtcp_get_restart_env(char *envName, char dest[PATH_MAX], size_t size)
 {
   if (getenv(envName)) {
-    strncpy(dest, getenv(envName), size);
+    strncpy(dest, getenv(envName), PATH_MAX);
   }
   return getenv(envName) ? 0 : -1;
 }
+typedef int DmtcpGetRestartEnvErr_t;
+#define RESTART_ENV_SUCCESS 0
+#define EXTERNC 0
 #endif /* ifdef STANDALONE */
 
 #ifndef STANDALONE

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -156,7 +156,7 @@ static bool blockUntilDone = false;
 static bool killAfterCkpt = false;
 static bool killAfterCkptOnce = false;
 static int blockUntilDoneRemote = -1;
-static int timeout = 0;
+static time_t timeout = 0;
 static size_t start_time; // used with timeout
 
 static DmtcpCoordinator prog;
@@ -1507,16 +1507,19 @@ DmtcpCoordinator::addDataSocket(CoordClient *client)
 char *short_name(char short_buf[], char *name, unsigned int len, char *suffix) {
   // char *name_copy = malloc(strlen(name)+1);
   char name_copy[strlen(name)+1];
-  strncpy(name_copy, name, strlen(name)+1);
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+  // gcc bad warning: complains 'sizeof(name_copy)' depends on 'strlen(name)'
+  strncpy(name_copy, name, sizeof(name_copy));
+#pragma GCC diagnostic pop
   char *base_name = strrchr(name_copy, '/') == NULL ?
                     name_copy : strrchr(name_copy, '/') + 1;
+  int suffix_len = strlen(suffix);
   if (6 + strlen(suffix) > len) {
     return NULL;
   }
   memset(short_buf, '\0', len);
   int cmd_len = min(strlen(base_name)+1, len);
   memcpy(short_buf, base_name, cmd_len);
-  int suffix_len = strlen(suffix);
   int short_buf_len = min(strlen(base_name), len - suffix_len);
   strncpy(short_buf + short_buf_len, suffix, suffix_len);
   return short_buf;

--- a/src/dmtcp_get_libc_offset.c
+++ b/src/dmtcp_get_libc_offset.c
@@ -1,9 +1,8 @@
-#define _GNU_SOURCE 
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
-#include <assert.h>
 #include <dlfcn.h>
 #include <assert.h>
 
@@ -57,6 +56,6 @@ int main(int argc, char *argv[]) {
 #ifdef STANDALONE
   printf("Offset of %s from 'read': %ld", argv[1], fnc_offset);
 #endif
-  write(1, &fnc_offset, sizeof(fnc_offset));
+  assert(write(1, &fnc_offset, sizeof(fnc_offset)) == sizeof(fnc_offset));
   return 0;
 }

--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -260,7 +260,7 @@ dmtcp_get_libc_addr(const char*libc_fnc) {
   char *dmtcp_get_libc_offset = dmtcp_bin_dir;
 
   int pipefd[2];
-  pipe(pipefd);
+  JASSERT(pipe(pipefd) == 0)(JASSERT_ERRNO);
   // Use dmtcp_fork() instead of fork() in case a plugin is redefining
   //   fork() to call:  (*dmtcp_get_libc_addr("fork"))().
   extern int dmtcp_fork();

--- a/src/plugin/pid/pid.cpp
+++ b/src/plugin/pid/pid.cpp
@@ -130,7 +130,7 @@ pid_virtual_to_real_filepath(DmtcpEventData_t *data)
   char newPath[PATH_MAX];
   pid_t realPid = VIRTUAL_TO_REAL_PID(virtualPid);
   sprintf(newPath, "/proc/%d%s", realPid, rest);
-  strncpy(data->virtualToRealPath.path, newPath, sizeof(newPath));
+  strcpy(data->virtualToRealPath.path, newPath);
 }
 
 // FIXME:  This function needs third argument newpathsize, or assume PATH_MAX

--- a/src/util_exec.cpp
+++ b/src/util_exec.cpp
@@ -228,7 +228,7 @@ Util::getInterpreterType(const char *pathname, bool *isElf, bool *is32bitElf)
   }
 
   ssize_t ret = readLine(fd, argv_buf, sizeof(argv_buf));
-  if (ret < sizeof(magic_script)) {
+  if (ret < (int)sizeof(magic_script)) {
     close(fd);
     return -1;
   }


### PR DESCRIPTION
This fixes various compiler warnings from gcc/g++ version 10.0.