### PR TITLE
Update configure.ac: subdir-objects, no version.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,9 +5,10 @@ AC_INIT([DMTCP],
         [http://dmtcp.sourceforge.net])
 
 AC_PREREQ([2.60])
-# TODO(kapil): Add 'subdir-objects after automake 1.16 has been released.
-AM_INIT_AUTOMAKE([foreign])
+AM_INIT_AUTOMAKE([foreign subdir-objects])
 AM_MAINTAINER_MODE
+# If you modify configure.ac, automake may complain: missing .deps/*.Po file
+# For: '.deps/*.Po: No such file or directory'; try:  'make -k'(--keep-going)
 AC_CANONICAL_HOST
 AC_PROG_INSTALL
 # Automake uses 'ar cru' by default.  The 'ar' program then issues a warning.


### PR DESCRIPTION
This updates `configure.ac`.  It's time to add the `subdir-objects` option as mentioned in the TODO.
  * adding 'subdir-objects' option for AUTOMAKE, to be compatible with the upcoming automake-2.0

This has been tested on CentOS-7, where `autoreconf`, using automake-1.13 still works.  On automake-1.14 and later, we get repeated warnings that this will fail in automake-2.0 without `subdir-objects`.  The warnings go away with this fix.

I also added a comment in `configure.ac` about using `make -k' to overcome transient 'make' errors like:
`Makefile:804: ../jalib/.deps/jalib.Po: No such file or directory`