### PR TITLE
Fix foreground process group on restart

### DIFF
--- a/src/nosyscallsreal.c
+++ b/src/nosyscallsreal.c
@@ -282,11 +282,13 @@ _real_tcgetpgrp(int fd)
   REAL_FUNC_PASSTHROUGH_PID_T(tcgetpgrp) (fd);
 }
 
+#if 0
 pid_t
 _real_getpgrp(void)
 {
   REAL_FUNC_PASSTHROUGH_PID_T(getpgrp) ();
 }
+#endif
 
 pid_t
 _real_setpgrp(void)

--- a/src/nosyscallsreal.c
+++ b/src/nosyscallsreal.c
@@ -276,10 +276,10 @@ _real_tcsetpgrp(int fd, pid_t pgrp)
   REAL_FUNC_PASSTHROUGH(tcsetpgrp) (fd, pgrp);
 }
 
-int
+pid_t
 _real_tcgetpgrp(int fd)
 {
-  REAL_FUNC_PASSTHROUGH(tcgetpgrp) (fd);
+  REAL_FUNC_PASSTHROUGH_PID_T(tcgetpgrp) (fd);
 }
 
 pid_t

--- a/src/plugin/pid/pid_syscallsreal.c
+++ b/src/plugin/pid/pid_syscallsreal.c
@@ -28,6 +28,7 @@
 #include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/ioctl.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 #include "dmtcp.h"
@@ -137,8 +138,8 @@ _real_dlsym(void *handle, const char *symbol)
   return (void *)(*_libc_dlsym_fnptr)(handle, symbol);
 }
 
-// Also copied into src/threadlist.cpp, so that libdmtcp.sp
-//   won't depend on libdmtcp_pid.sp
+// Also copied into src/threadlist.cpp, so that libdmtcp.so
+//   won't depend on libdmtcp_pid.so
 LIB_PRIVATE
 pid_t
 _real_getpid(void)
@@ -175,7 +176,11 @@ LIB_PRIVATE
 pid_t
 _real_tcgetpgrp(int fd)
 {
-  REAL_FUNC_PASSTHROUGH(tcgetpgrp) (fd);
+  // REAL_FUNC_PASSTHROUGH(tcgetpgrp) (fd);
+  // SYS_tcgetpgrp doesn't exist; use _real_ioctl, not _real_syscall
+  pid_t arg;
+  _real_ioctl(fd, TIOCGPGRP, &arg);
+  return arg;
 }
 
 LIB_PRIVATE

--- a/src/syscallwrappers.h
+++ b/src/syscallwrappers.h
@@ -380,6 +380,8 @@ int _real_socketpair(int d, int type, int protocol, int sv[2]);
 void _real_openlog(const char *ident, int option, int facility);
 void _real_closelog(void);
 
+int _real_tcgetpgrp(int fd);
+
 // Despite what 'man signal' says, signal.h already defines sighandler_t
 // But signal.h defines this only because we define GNU_SOURCE (or __USE_GNU_
 typedef void (*sighandler_t)(int);    /* POSIX has user define this type */

--- a/src/syscallwrappers.h
+++ b/src/syscallwrappers.h
@@ -157,6 +157,7 @@ LIB_PRIVATE extern __thread int thread_performing_dlopen_dlsym;
   MACRO(tcgetpgrp)                    \
   MACRO(tcsetpgrp)                    \
   MACRO(getpgrp)                      \
+  MACRO(_libc_getpgrp) /* src/plugin/pid/pid_syscallsreal.c */    \
   MACRO(setpgrp)                      \
                                       \
   MACRO(getpgid)                      \
@@ -381,6 +382,7 @@ void _real_openlog(const char *ident, int option, int facility);
 void _real_closelog(void);
 
 int _real_tcgetpgrp(int fd);
+int _libc_getpgrp(void);
 
 // Despite what 'man signal' says, signal.h already defines sighandler_t
 // But signal.h defines this only because we define GNU_SOURCE (or __USE_GNU_

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -80,7 +80,7 @@ static void Thread_SaveSigState(Thread *th);
 static void Thread_RestoreSigState(Thread *th);
 
 // Copied from src/plugin/pid/pid_syscallsreal.c
-// Without this, libdmtcp.so will depend on libdmtcp_plugin.so being loaded
+// Without this, libdmtcp.so will depend on libdmtcp_pid.so being loaded
 static pid_t _real_getpid(void)
 {
   JWARNING("_real_getpid")

--- a/test/misc/README
+++ b/test/misc/README
@@ -4,11 +4,15 @@ Some of these special cases could be combined into autotest.py, and
 
 Examples of special cases are:
 * All CPU architectures:  x86, x86_64, arm, aarch64
-* The three major branches of distros:  Debian/Ubuntu, and
-                                          RedHat/Fedora/CoreOS, OpenSUSE/SUSE
+* The two major branches of distros:  Debian/Ubuntu and
+                                          RedHat/Fedora/CoreOS
 * 32-bit Linux:  native, --enable-m32, and multi-arch  (see multi-arch.sh)
+* Builds of DMTCP with other compilers:  icc LLVM/clang
+* musl libc (and Alpine Linux) (?)
 * 'make install' for native 64-bit and each of the 32-bit Linux combinations
 * for file in test/plugin/*; do (cd $file && make check); done
+* dmtcp_launch invoked in extra shell:  #!/bin/sh / dmtcp_launth test/dmtcp1
+                                        [ and test restart: foreground issue ]
 * forked checkpointing
 * fast restart
 * --no-gzip
@@ -26,10 +30,9 @@ Examples of special cases are:
   *  Network:  InfiniBand (CM and UD), TCP
   +  Shared filesystems:  NFS, Lustre
 * openmp and Intel TBB
-* MIC
-* SOON:  OpenGL
+* MANA for MPI and CRAC for CUDA
+* SOON:  OpenGL (?)
 * Widely used commercial software:  Matlab, ...
 * Non-default plugins:
-  --ptrace, modify-env
+  modify-env, path-virt
   test/plugin/{applic-inititated-ckdpt,applic-delayed-ckpt}
-* Builds of DMTCP with other compilers:  icc LLVM/Clang

--- a/test/misc/README
+++ b/test/misc/README
@@ -4,15 +4,11 @@ Some of these special cases could be combined into autotest.py, and
 
 Examples of special cases are:
 * All CPU architectures:  x86, x86_64, arm, aarch64
-* The two major branches of distros:  Debian/Ubuntu and
-                                          RedHat/Fedora/CoreOS
+* The three major branches of distros:  Debian/Ubuntu, and
+                                          RedHat/Fedora/CoreOS, OpenSUSE/SUSE
 * 32-bit Linux:  native, --enable-m32, and multi-arch  (see multi-arch.sh)
-* Builds of DMTCP with other compilers:  icc LLVM/clang
-* musl libc (and Alpine Linux) (?)
 * 'make install' for native 64-bit and each of the 32-bit Linux combinations
 * for file in test/plugin/*; do (cd $file && make check); done
-* dmtcp_launch invoked in extra shell:  #!/bin/sh / dmtcp_launth test/dmtcp1
-                                        [ and test restart: foreground issue ]
 * forked checkpointing
 * fast restart
 * --no-gzip
@@ -30,9 +26,10 @@ Examples of special cases are:
   *  Network:  InfiniBand (CM and UD), TCP
   +  Shared filesystems:  NFS, Lustre
 * openmp and Intel TBB
-* MANA for MPI and CRAC for CUDA
-* SOON:  OpenGL (?)
+* MIC
+* SOON:  OpenGL
 * Widely used commercial software:  Matlab, ...
 * Non-default plugins:
-  modify-env, path-virt
+  --ptrace, modify-env
   test/plugin/{applic-inititated-ckdpt,applic-delayed-ckpt}
+* Builds of DMTCP with other compilers:  icc LLVM/Clang

--- a/util/gdb-dmtcp-utils
+++ b/util/gdb-dmtcp-utils
@@ -169,7 +169,7 @@ class ShowFilenameAtAddress(gdb.Command):
         if getpid() == 0:
           gdb.execute('print "Process not yet started"', False, False)
         else:
-          memory_region = "%s (r-x): 0x%x-0x%x" % \
+          memory_region = "%s (r[-w]x): 0x%x-0x%x" % \
                           memory_region_at_address(memory_address)
           gdb.execute('print "' + memory_region + '"', False, False)
 # This will add the new gdb command: show-filename-at-address MEMORY_ADDRESS
@@ -352,6 +352,7 @@ def procmap_filename_address(line):
   return (triple[-1],) + \
          tuple([int("0x"+elt, 16) for elt in triple[0].split("-")])
 def is_text_segment(procmap_line):
+  print(procmap_line)
   return "r-x" in procmap_line and \
          (procmap_line == "" or procmap_line.isspace() or '/' in procmap_line)
 def memory_regions():


### PR DESCRIPTION
**[ There's still a bug during restart in this PR.  I'll fix that later.   It's not yet ready for final review.  the script test is failing to restart.  ]**
'
The key to reviewing this is to read the changes in `src/terminal.cpp` (i.e., the most recent commit: "Fix foreground process group on restart").

Without this PR, we have the bug described in Issue #903.  The problem occurs when `dmtcp_launch` is called from a shell script instead of from the command line.  On restart, the restarted process acts as if it's in background, and ^C (and other input?) does not reach the restarted process.

Sometimes 'dmtcp_launch' is called from inside a shell script (e.g., for a batch job).  In this case, on restart, the foreground process group leader is the restarted process, and yet the process group leader is the parent (presumably the login shell).  So, the foreground process group leader is not the leader of a process group.  To fix this, we set the process group leader to also be the leader of the foreground process group.
