### PR TITLE
update travis yaml: remove sudo and added os tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Allow containerized builds.
-sudo: false
+os: linux
 dist: focal
 
 addons:


### PR DESCRIPTION
## Warning and info message from Travis
```
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: missing os, using the default linux
```
## Steps to see the above messages
1. Go to the build summary page for any recent build at travis.ci.
2. Click on `View config`
3. Expand `Build config validation — 1 warning, 1 info`