### PR TITLE
Fix coord. hangs if a process exit before barrier

### DIFF
--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -757,10 +757,13 @@ DmtcpCoordinator::onDisconnect(CoordClient *client)
         (theCheckpointInterval);
     }
   } else {
-    // If all other workers are at currentBarrier, release it.
-    if (!currentBarrier.empty() &&
-        (client->barrier().empty() || client->barrier() == currentBarrier)) {
-      --workersAtCurrentBarrier;
+    // If the coordinator waits at currentBarrier, try to release it.
+    if (!currentBarrier.empty()) {
+      // If already registered as a worker at current barrier,
+      // decrement the worker counter before try to release the barrier.
+      if (client->barrier() == currentBarrier) {
+        --workersAtCurrentBarrier;
+      }
       releaseBarrier(currentBarrier);
     }
   }


### PR DESCRIPTION
  The coordinator incorrectly decrements the workersAtBarrier counter
  when a process disconnect from the coordinator.