### PR TITLE
Handle workers that exec after PRESUSPEND.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -123,6 +123,7 @@ libdmtcpinternal_a_SOURCES = coordinatorapi.cpp 		\
 			     procselfmaps.cpp			\
 			     rwlock.cpp 			\
 			     shareddata.cpp 			\
+			     threadsync.cpp			\
 			     tokenize.cpp			\
 			     uniquepid.cpp			\
 			     util_exec.cpp			\
@@ -153,7 +154,7 @@ __d_libdir__libdmtcp_so_SOURCES = alarm.cpp			\
 				  dmtcpworker.cpp 		\
 				  execwrappers.cpp 		\
 				  glibcsystem.cpp 		\
-				  kvdb.cpp              \
+				  kvdb.cpp			\
 				  miscwrappers.cpp 		\
 				  plugininfo.cpp 		\
 				  pluginmanager.cpp		\
@@ -164,7 +165,6 @@ __d_libdir__libdmtcp_so_SOURCES = alarm.cpp			\
 				  syslogwrappers.cpp 		\
 				  terminal.cpp 			\
 				  threadlist.cpp 		\
-				  threadsync.cpp 		\
 				  threadwrappers.cpp 		\
 				  wrappers.cpp 			\
 				  writeckpt.cpp

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -135,8 +135,9 @@ am_libdmtcpinternal_a_OBJECTS = coordinatorapi.$(OBJEXT) \
 	dmtcpmessagetypes.$(OBJEXT) dmtcp_dlsym.$(OBJEXT) \
 	jalibinterface.$(OBJEXT) mutex.$(OBJEXT) processinfo.$(OBJEXT) \
 	procselfmaps.$(OBJEXT) rwlock.$(OBJEXT) shareddata.$(OBJEXT) \
-	tokenize.$(OBJEXT) uniquepid.$(OBJEXT) util_exec.$(OBJEXT) \
-	util_init.$(OBJEXT) util_misc.$(OBJEXT) workerstate.$(OBJEXT)
+	threadsync.$(OBJEXT) tokenize.$(OBJEXT) uniquepid.$(OBJEXT) \
+	util_exec.$(OBJEXT) util_init.$(OBJEXT) util_misc.$(OBJEXT) \
+	workerstate.$(OBJEXT)
 libdmtcpinternal_a_OBJECTS = $(am_libdmtcpinternal_a_OBJECTS)
 libjalib_a_AR = $(AR) $(ARFLAGS)
 libjalib_a_LIBADD =
@@ -194,9 +195,8 @@ am___d_libdir__libdmtcp_so_OBJECTS = alarm.$(OBJEXT) \
 	plugininfo.$(OBJEXT) pluginmanager.$(OBJEXT) popen.$(OBJEXT) \
 	rlimitfloatenv.$(OBJEXT) signalwrappers.$(OBJEXT) \
 	siginfo.$(OBJEXT) syslogwrappers.$(OBJEXT) terminal.$(OBJEXT) \
-	threadlist.$(OBJEXT) threadsync.$(OBJEXT) \
-	threadwrappers.$(OBJEXT) wrappers.$(OBJEXT) \
-	writeckpt.$(OBJEXT)
+	threadlist.$(OBJEXT) threadwrappers.$(OBJEXT) \
+	wrappers.$(OBJEXT) writeckpt.$(OBJEXT)
 __d_libdir__libdmtcp_so_OBJECTS =  \
 	$(am___d_libdir__libdmtcp_so_OBJECTS)
 __d_libdir__libdmtcp_so_DEPENDENCIES = libdmtcpinternal.a libjalib.a \
@@ -612,6 +612,7 @@ libdmtcpinternal_a_SOURCES = coordinatorapi.cpp 		\
 			     procselfmaps.cpp			\
 			     rwlock.cpp 			\
 			     shareddata.cpp 			\
+			     threadsync.cpp			\
 			     tokenize.cpp			\
 			     uniquepid.cpp			\
 			     util_exec.cpp			\
@@ -643,7 +644,7 @@ __d_libdir__libdmtcp_so_SOURCES = alarm.cpp			\
 				  dmtcpworker.cpp 		\
 				  execwrappers.cpp 		\
 				  glibcsystem.cpp 		\
-				  kvdb.cpp              \
+				  kvdb.cpp			\
 				  miscwrappers.cpp 		\
 				  plugininfo.cpp 		\
 				  pluginmanager.cpp		\
@@ -654,7 +655,6 @@ __d_libdir__libdmtcp_so_SOURCES = alarm.cpp			\
 				  syslogwrappers.cpp 		\
 				  terminal.cpp 			\
 				  threadlist.cpp 		\
-				  threadsync.cpp 		\
 				  threadwrappers.cpp 		\
 				  wrappers.cpp 			\
 				  writeckpt.cpp

--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -501,7 +501,16 @@ bool waitForBarrier(const string& barrier,
     return false;
   }
 
-  msg.assertValid();
+  // Coordinator sends a duplicate DMTCP_DO_CHECKPOINT msg if we reconnected
+  // after exec. It's safe to ignore. We'll wait again for the Barrier msg.
+  if (msg.type == DMT_DO_CHECKPOINT) {
+    recvMsgFromCoordinator(&msg, (void**)&extraData);
+
+    // Before validating message; make sure we are not exiting.
+    if (!msg.isValid()) {
+      return false;
+    }
+  }
 
   JASSERT(msg.type == DMT_BARRIER_RELEASED) (msg.type);
   JASSERT(extraData != NULL);

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -202,7 +202,7 @@ static string currentBarrier;
 static string prevBarrier;
 
 static UniquePid compId;
-static int numPeers = -1;
+static int numRestartPeers = -1;
 static time_t curTimeStamp = -1;
 static time_t ckptTimeStamp = -1;
 
@@ -457,9 +457,9 @@ DmtcpCoordinator::releaseBarrier(const string &barrier)
   ComputationStatus status = getStatus();
 
   if (workersAtCurrentBarrier == status.numPeers) {
-    if (numPeers > 0 && status.numPeers != numPeers) {
+    if (numRestartPeers > 0 && status.numPeers != numRestartPeers) {
       JNOTE("Waiting for all restarting processes to connect.")
-        (numPeers) (status.numPeers);
+        (numRestartPeers) (status.numPeers);
       return;
     }
 
@@ -684,6 +684,30 @@ DmtcpCoordinator::onData(CoordClient *client)
     client->setState(msg.state);
     client->progname(progname);
     client->identity(msg.from);
+    if (workersRunningAndSuspendMsgSent) {
+      // If we received this message from the worker _after_ we broadcasted
+      // DMT_DO_CHECKPOINT message to workers, there are two possible scenarios:
+      // 1. User thread called exec before ckpt-thread had a chance to read the
+      //    DMT_DO_CHECKPOINT message from the coordinator-socket. In this case,
+      //    once the exec completes and a new ckpt-thread is created, that
+      //    thread will read the pending DMT_DO_CHECKPOINT message and proceed
+      //    as expected.
+      // 2. The ckpt-thread read the DMT_DO_CHECKPOINT message, but before it
+      //    could quiesce user threads, one of them called exec. After
+      //    completing exec, the new ckpt-thread won't know that the coordinator
+      //    had requested a checkpoint via DMT_DO_CHECKPOINT message. The
+      //    ckpt-thread will block until it gets a DMT_DO_CHECKPOINT message
+      //    while the coordinator is waiting for this process to respond to the
+      //    earlier DMT_DO_CHECKPOINT message, leading to a deadlocked
+      //    computation.
+      //
+      // In order to handle case (2) above, we send a second DMT_DO_CHECKPOINT
+      // message to this worker. If this worker already processed the previous
+      // DMT_DO_CHECKPOINT message as in case (1) above, it will ignore this
+      // duplicate message.
+
+      ResendDoCheckpointMsgToWorker(client);
+    }
     break;
   }
 
@@ -798,7 +822,7 @@ DmtcpCoordinator::initializeComputation()
   // drop current computation group to 0
   compId = UniquePid(0, 0, 0);
   curTimeStamp = 0; // Drop timestamp to 0
-  numPeers = -1; // Drop number of peers to unknown
+  numRestartPeers = -1; // Drop number of peers to unknown
   blockUntilDone = false;
   killAfterCkptOnce = false;
   workersAtCurrentBarrier = 0;
@@ -1001,10 +1025,10 @@ DmtcpCoordinator::validateRestartingWorkerProcess(
 
     // Coordinator is free at this moment - set up all the things
     compId = hello_remote.compGroup;
-    numPeers = hello_remote.numPeers;
+    numRestartPeers = hello_remote.numPeers;
     curTimeStamp = getCurrTimestamp();
-    JNOTE("FIRST dmtcp_restart connection.  Set numPeers. Generate timestamp")
-      (numPeers) (curTimeStamp) (compId);
+    JNOTE("FIRST restart connection. Set numRestartPeers. Generate timestamp")
+      (numRestartPeers) (curTimeStamp) (compId);
     JTIMER_START(restart);
   } else if (minimumState() != WorkerState::RESTARTING) {
     JNOTE("Computation not in RESTARTING state."
@@ -1058,6 +1082,28 @@ DmtcpCoordinator::validateRestartingWorkerProcess(
   return true;
 }
 
+void
+DmtcpCoordinator::ResendDoCheckpointMsgToWorker(CoordClient *client)
+{
+  JASSERT(workersRunningAndSuspendMsgSent);
+  /* Worker trying to connect after SUSPEND message has been sent.
+    * This happens if the worker process is executing a fork() or exec() system
+    * call when the DMT_DO_SUSPEND is broadcast. We need to make sure that the
+    * child process is allowed to participate in the current checkpoint.
+    */
+  ComputationStatus s = getStatus();
+  JASSERT(s.numPeers > 0) (s.numPeers);
+  JASSERT(s.minimumState != WorkerState::SUSPENDED) (s.minimumState);
+
+  JNOTE("Sending DMT_DO_CHECKPOINT msg to worker") (client->identity());
+
+  // Now send DMT_DO_CHECKPOINT message so that this process can also
+  // participate in the current checkpoint
+  DmtcpMessage suspendMsg(DMT_DO_CHECKPOINT);
+  suspendMsg.compGroup = compId;
+  client->sock() << suspendMsg;
+}
+
 bool
 DmtcpCoordinator::validateNewWorkerProcess(
   DmtcpMessage &hello_remote,
@@ -1077,25 +1123,11 @@ DmtcpCoordinator::validateNewWorkerProcess(
           hello_remote.state == WorkerState::UNKNOWN) (hello_remote.state);
 
   if (workersRunningAndSuspendMsgSent == true) {
-    /* Worker trying to connect after SUSPEND message has been sent.
-     * This happens if the worker process is executing a fork() system call
-     * when the DMT_DO_SUSPEND is broadcast. We need to make sure that the
-     * child process is allowed to participate in the current checkpoint.
-     */
-    JASSERT(s.numPeers > 0) (s.numPeers);
-    JASSERT(s.minimumState != WorkerState::SUSPENDED) (s.minimumState);
-
     // Handshake
     hello_local.compGroup = compId;
     remote << hello_local;
 
-    // Now send DMT_DO_CHECKPOINT message so that this process can also
-    // participate in the current checkpoint
-    // TODO(Kapil): Make sure to walk the new worker through all the
-    // already-processed pre-suspend barriers.
-    DmtcpMessage suspendMsg(DMT_DO_CHECKPOINT);
-    suspendMsg.compGroup = compId;
-    remote << suspendMsg;
+    ResendDoCheckpointMsgToWorker(client);
   } else if (s.numPeers > 0 && s.minimumState != WorkerState::RUNNING &&
              s.minimumState != WorkerState::UNKNOWN) {
     // If some of the processes are not in RUNNING state
@@ -1127,7 +1159,7 @@ DmtcpCoordinator::validateNewWorkerProcess(
 
       // Get the resolution down to 100 mili seconds.
       curTimeStamp = getCurrTimestamp();
-      numPeers = -1;
+      numRestartPeers = -1;
       JTRACE("First process connected.  Creating new computation group.")
         (compId);
     } else {
@@ -1156,6 +1188,7 @@ DmtcpCoordinator::startCheckpoint()
     time(&ckptTimeStamp);
     JTIMER_START(checkpoint);
     _numRestartFilenames = 0;
+    numRestartPeers = -1;
     _restartFilenames.clear();
     _rshCmdFileNames.clear();
     _sshCmdFileNames.clear();
@@ -1235,9 +1268,10 @@ DmtcpCoordinator::getStatus() const
   status.minimumStateUnanimous = unanimous;
   status.minimumState = (min == INITIAL_MIN ? WorkerState::UNKNOWN
                          : (WorkerState::eWorkerState)min);
-  if (status.minimumState == WorkerState::RESTARTING && count < numPeers) {
+  if (status.minimumState == WorkerState::RESTARTING &&
+      count < numRestartPeers) {
     JTRACE("minimal state counted as RESTARTING but not all processes"
-           " are connected yet.  So we wait.") (numPeers) (count);
+           " are connected yet.  So we wait.") (numRestartPeers) (count);
     status.minimumState = WorkerState::RESTARTING;
     status.minimumStateUnanimous = false;
   }

--- a/src/dmtcp_coordinator.h
+++ b/src/dmtcp_coordinator.h
@@ -132,6 +132,7 @@ class DmtcpCoordinator
                                          jalib::JSocket &remote,
                                          const struct sockaddr_storage *addr,
                                          socklen_t len);
+    void ResendDoCheckpointMsgToWorker(CoordClient *client);
 
     ComputationStatus getStatus() const;
     WorkerState::eWorkerState minimumState() const

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -413,14 +413,14 @@ DmtcpWorker::waitForCheckpointRequest()
   JTRACE("Procesing pre-suspend barriers");
   PluginManager::eventHook(DMTCP_EVENT_PRESUSPEND);
 
+  JTRACE("Preparing to acquire locks before DMT:SUSPEND barrier");
+  ThreadSync::acquireLocks();
+
   JTRACE("Waiting for DMT:SUSPEND barrier");
   if (!CoordinatorAPI::waitForBarrier("DMT:SUSPEND")) {
     JASSERT(exitInProgress);
     ckptThreadPerformExit();
   }
-
-  JTRACE("DMT:SUSPEND barrier lifted, preparing to acquire locks");
-  ThreadSync::acquireLocks();
 
   JTRACE("Starting checkpoint, suspending threads...");
 }

--- a/src/execwrappers.cpp
+++ b/src/execwrappers.cpp
@@ -231,6 +231,8 @@ vfork()
 
   JASSERT (!isPerformingCkptRestart());
 
+  ThreadSync::presuspendEventHookLockLock();
+
   /* Acquire all locks here. */
   ThreadSync::acquireLocks();
 
@@ -269,7 +271,7 @@ vfork()
     JALLOC_FREE(newStackAddr);
   }
 
-  ThreadSync::resetLocks();
+  ThreadSync::resetLocks(false);
 
   if (vforkPid == -1) {
     PluginManager::eventHook(DMTCP_EVENT_VFORK_FAILED, NULL);
@@ -290,6 +292,7 @@ vfork()
   }
 
   if (vforkPid != 0) {
+    ThreadSync::presuspendEventHookLockUnlock();
     ThreadList::vforkResumeThreads();
   }
   return vforkPid;

--- a/src/threadsync.h
+++ b/src/threadsync.h
@@ -56,7 +56,7 @@ namespace ThreadSync
 {
 void acquireLocks();
 void releaseLocks();
-void resetLocks();
+void resetLocks(bool resetPresuspendEventHookLock = true);
 void initThread();
 void initMotherOfAll();
 
@@ -80,6 +80,9 @@ void waitForThreadsToFinishInitialization();
 void incrementUninitializedThreadCount();
 void decrementUninitializedThreadCount();
 void threadFinishedInitialization();
+
+void presuspendEventHookLockLock();
+void presuspendEventHookLockUnlock();
 
 bool isOkToGrabLock();
 void setOkToGrabLock();

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -919,8 +919,19 @@ runTest("environ",       1, ["./test/environ"])
 
 runTest("forkexec",      2, ["./test/forkexec"])
 
-runTest("vfork1",        [1,2,3] , ["./test/vfork1"])
-runTest("vfork2",        [2,3,4] , ["./test/vfork1 \"sh -c 'while true; do date; sleep 1; done'\" "])
+# vfork1 test creates a child process using vfork. The child executes the
+# command passed via command line using "sh -c".
+
+# The child process will exit and a new child process will be forked at the end
+# of each "ls | wc" execution. Thus, at the time of checkpoint, either:
+# a. only vfork1 process is active, or
+# b. vfork1 and sh processes are active, or
+# c. vfork1, sh, and either or both of ls and wc processes are active.
+runTest("vfork1",        [1,2,3,4] , ["./test/vfork1 'ls | wc'"])
+
+# The sh process is permanent, but the number of sh's child processes active at
+# the time of checkpoint varies. Either or both of date and sleep might be active.
+runTest("vfork2",        [2,3,4] , ["./test/vfork1 'while true; do date; sleep 1; done' "])
 
 runTest("realpath",      1, ["./test/realpath"])
 runTest("pthread1",      1, ["./test/pthread1"])

--- a/test/vfork1.c
+++ b/test/vfork1.c
@@ -86,6 +86,7 @@ int main(int argc, char *argv[])
       printf("%c", buf);
       fflush(stdout);
     }
+    sn_simple_pclose_r(fp);
     sleep(1);
   }
 


### PR DESCRIPTION
Since user threads are not quiesced until after processing
DMTCP_PRESUSPEND event, a user thread might exec after receiving
DMT_DO_CHECKPOINT msg from the coordinator. After exec completes, the
process will wait for a new DMT_DO_CHECKPOINT msg while the coordinator
is waiting for all workers to reach the DMT:SUSPEND barrier.

The fix is to send a duplicate DMT_DO_CHECKPOINT message if a checkpoint
is in progress when a worker reconnects to the coordinator after exec.

We also handle the possibility of doing an exec even before receiving
DMT_DO_CHECKPOINT message. In that case, the worker will receive two
DMT_DO_CHECKPOINT messages and will safely ignore the second one.