### PR TITLE
Refactor pthread create

### DIFF
--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -223,7 +223,7 @@ ThreadList::initThread(Thread *th, int (*fn)(
                          void *), void *arg, int flags, int *ptid, int *ctid)
 {
   /* Save exactly what the caller is supplying */
-  th->fn = fn;
+  th->fn = fn; // NOT USED
   th->arg = arg;
   th->flags = flags;
   th->ptid = ptid;


### PR DESCRIPTION
Still a work-in-progress.

This wrapper for pthread_create() does not call clone().  This is important, since glibc-2.34 defines pthread_create to call clone3 instead of clone.   And the new pthread_create calls clone3 through an internal library-private symbol, instead of calling it through the general symbol "clone3".  So, we have no easy way to create a wrapper around clone3.

This should also produce a cleaner design, that will make it easier to manage the entanglement of libdmtcp.so and libdmtcp_pid.so in the future.

Right now, there's a bug that can be seen by:
[gdbinit.txt](https://github.com/dmtcp/dmtcp/files/7985326/gdbinit.txt)

and: `gdb -x gdbinit.txt --args bin/dmtcp_launch test/dmtcp1`

TODO:  We should create a wrapper around clone3(), and the wrapper should refuse to emulate clone() unless some environment variable like DMTCP_CLONE3 is defined.  Note that in dmtcp-2.6, there is a commit that provides a clone3 wrapper, and defines it in terms of clone, if we want a quick shortcut.
