### PR TITLE
WIP: If GLIBC-2.30: support gettid(), add test/gettid.c

### DIFF
--- a/src/plugin/pid/pidwrappers.cpp
+++ b/src/plugin/pid/pidwrappers.cpp
@@ -129,6 +129,18 @@ getpid()
   return _dmtcp_pid;
 }
 
+// glibc-2.30 added support for gettid()
+#if !__GLIBC_PREREQ(2, 30)
+pid_t
+gettid(void)
+{
+  if (_dmtcp_thread_tid == -1) {
+    _dmtcp_thread_tid = dmtcp_gettid();
+  }
+  return _dmtcp_thread_tid;
+}
+#endif // if !__GLIBC_PREREQ(2, 30)
+
 extern "C" pid_t
 getppid()
 {

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -169,6 +169,9 @@ dmtcp4: dmtcp4.c
 dmtcp5: dmtcp5.c
 	-$(CC) -o $@ $< $(CFLAGS) -lpthread
 
+gettid: gettid.c
+	-$(CC) -o $@ $< $(CFLAGS) -lpthread
+
 pthread%: pthread%.c
 	-$(CC) -o $@ $< $(CFLAGS) -lpthread
 

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -829,6 +829,8 @@ resource.setrlimit(resource.RLIMIT_STACK, [newCurrLimit, oldLimit[1]])
 runTest("dmtcp5",        2, ["./test/dmtcp5"])
 resource.setrlimit(resource.RLIMIT_STACK, oldLimit)
 
+runTest("gettid",        1, ["./test/gettid"])
+
 # Test for a bunch of system calls. We want to use the 'Kc' mode for
 # (sets exitAfterCkptOnce in src/dmtcp_coordinator.cpp) for
 # checkpointing so that the process is killed right after checkpoint. Otherwise

--- a/test/gettid.c
+++ b/test/gettid.c
@@ -1,0 +1,28 @@
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+
+// glibc-2.30 added support for gettid()
+#if !__GLIBC_PREREQ(2, 30)
+pid_t
+gettid(void)
+{
+  return syscall(SYS_gettid);
+}
+#endif // if !__GLIBC_PREREQ(2, 30)
+
+int main() {
+  while(1) {
+    if (gettid() != getpid()) {
+      printf("\nERROR: 'gettid() != getpid()' in primary user thread.\n");
+      printf("gettid(): %d, getpid(): %d\n\n", gettid(), getpid());
+      return 1;
+    }
+    sleep(1);
+    printf(".");
+    fflush(stdout);
+  }
+  return 0;
+}


### PR DESCRIPTION
This is a first attempt at creating a DMTCP wrapper for gettid().  It also creates a test:  `test/gettid.c`

Note that gettid() was defined in GLIBC starting with GLIBC-2.30.