### PR TITLE
Removed statically allocated strings.

### DIFF
--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -169,10 +169,8 @@ dmtcp_get_tmpdir(void)
 EXTERNC const char *
 dmtcp_get_ckpt_dir()
 {
-  static string tmpdir;
-
-  tmpdir = ProcessInfo::instance().getCkptDir();
-  return tmpdir.c_str();
+  static string *tmpdir = new string(ProcessInfo::instance().getCkptDir());
+  return tmpdir->c_str();
 }
 
 EXTERNC int
@@ -187,8 +185,8 @@ dmtcp_set_ckpt_dir(const char *dir)
 EXTERNC const char *
 dmtcp_get_coord_ckpt_dir(void)
 {
-  static string dir = CoordinatorAPI::getCoordCkptDir();
-  return dir.c_str();
+  static string *dir = new string(CoordinatorAPI::getCoordCkptDir());
+  return dir->c_str();
 }
 
 EXTERNC int
@@ -209,19 +207,17 @@ dmtcp_set_ckpt_file(const char *filename)
 EXTERNC const char *
 dmtcp_get_ckpt_filename(void)
 {
-  static string filename;
-
-  filename = ProcessInfo::instance().getCkptFilename();
-  return filename.c_str();
+  static string *filename =
+    new string(ProcessInfo::instance().getCkptFilename());
+  return filename->c_str();
 }
 
 EXTERNC const char *
 dmtcp_get_ckpt_files_subdir(void)
 {
-  static string tmpdir;
-
-  tmpdir = ProcessInfo::instance().getCkptFilesSubDir();
-  return tmpdir.c_str();
+  static string *tmpdir =
+    new string(ProcessInfo::instance().getCkptFilesSubDir());
+  return tmpdir->c_str();
 }
 
 EXTERNC void
@@ -309,9 +305,7 @@ dmtcp_get_executable_path(void)
 EXTERNC const char *
 dmtcp_get_uniquepid_str(void)
 {
-  static string *uniquepid_str = NULL;
-
-  uniquepid_str =
+  static string *uniquepid_str =
     new string(UniquePid::ThisProcess(true).toString());
   return uniquepid_str->c_str();
 }

--- a/src/execwrappers.cpp
+++ b/src/execwrappers.cpp
@@ -277,7 +277,7 @@ vfork()
   } else if (vforkPid == 0) { /* child process */
     PluginManager::eventHook(DMTCP_EVENT_VFORK_CHILD, NULL);
 
-    static string child_name =
+    string child_name =
       jalib::Filesystem::GetProgramName() + "_(forked)";
     Util::initializeLogFile(dmtcp_get_tmpdir(), child_name.c_str(), NULL);
 

--- a/src/miscwrappers.cpp
+++ b/src/miscwrappers.cpp
@@ -74,6 +74,13 @@ using namespace dmtcp;
 
 EXTERNC int dmtcp_is_popen_fp(FILE *fp) __attribute((weak));
 
+extern "C" int
+on_exit(void (*function)(int, void *), void *arg)
+{
+  WrapperLock lock;
+  return NEXT_FNC(on_exit)(function, arg);
+}
+
 // Linux prlimit() could also be wrapped for protected fd, but it's a rare case.
 extern "C" int
 setrlimit (int resource, const struct rlimit *rlim) {

--- a/src/syslogwrappers.cpp
+++ b/src/syslogwrappers.cpp
@@ -85,9 +85,9 @@ dmtcp_Syslog_PluginDescr()
 static string&
 _ident()
 {
-  static string t;
+  static string *t = new string();
 
-  return t;
+  return *t;
 }
 
 void


### PR DESCRIPTION
Statically allocated string required at_exit/on_exit handlers to be
registered with libc. This can cause weird deadlocks because the
on_exit/at_exit handle registration requires manipulating libc-internal
linked lists with low-level libc locks and malloc/calloc/free calls.

If the static string is not getting initialized during checkpoint phase, a
deadlock is less likely. But during a checkpoint, the probability rises
significantly.

Added a wrapper for on_exit to ensure we don't checkpoint in the middle
of exit handler registration.