### PR TITLE
Support glibc:gettid(); fix for commit ae40d86

### DIFF
--- a/src/plugin/pid/pidwrappers.cpp
+++ b/src/plugin/pid/pidwrappers.cpp
@@ -130,7 +130,7 @@ getpid()
 }
 
 // glibc-2.30 added support for gettid()
-#if !__GLIBC_PREREQ(2, 30)
+#if __GLIBC_PREREQ(2, 30)
 pid_t
 gettid(void)
 {


### PR DESCRIPTION
This fixes PR #931 .  I had an extraneous '!' character.  :-(