### PR TITLE
Comp. warn's: dmtcp_coordinator.cpp, modify-env.c

### DIFF
--- a/plugin/modify-env/modify-env.c
+++ b/plugin/modify-env/modify-env.c
@@ -72,7 +72,7 @@ restart()
       printf("***** WARNING: pathname of DMTCP_DEFAULT_ENV_FILE"
              " exceeds PATH_MAX *****\n");
     }
-    strncpy(env_file, DMTCP_DEFAULT_ENV_FILE, sizeof DMTCP_DEFAULT_ENV_FILE);
+    strncpy(env_file, DMTCP_DEFAULT_ENV_FILE, sizeof env_file);
   }
 
   int size = 12288;

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -57,7 +57,6 @@
  *   DmtcpCoordinator::broadcastMessage                                     *
  ****************************************************************************/
 
-#include "dmtcp_coordinator.h"
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <limits.h>  // for HOST_NAME_MAX
@@ -73,6 +72,7 @@
 #include <unistd.h>
 #include <algorithm>
 #include <iomanip>
+#include "dmtcp_coordinator.h"
 #include "../jalib/jassert.h"
 #include "../jalib/jconvert.h"
 #include "../jalib/jfilesystem.h"
@@ -159,7 +159,7 @@ static bool killAfterCkpt = false;
 static bool killAfterCkptOnce = false;
 static int blockUntilDoneRemote = -1;
 static time_t timeout = 0;
-static size_t start_time; // used with timeout
+static time_t start_time; // used with timeout
 
 static DmtcpCoordinator prog;
 
@@ -1588,12 +1588,8 @@ DmtcpCoordinator::addDataSocket(CoordClient *client)
 // Copy name+suffix into short_buf of length len, and truncate name to fit.
 // This keeps only the last component of name (after last '/')
 char *short_name(char short_buf[], char *name, unsigned int len, char *suffix) {
-  // char *name_copy = malloc(strlen(name)+1);
   char name_copy[strlen(name)+1];
-#pragma GCC diagnostic ignored "-Wstringop-overflow"
-  // gcc bad warning: complains 'sizeof(name_copy)' depends on 'strlen(name)'
-  strncpy(name_copy, name, sizeof(name_copy));
-#pragma GCC diagnostic pop
+  memcpy(name_copy, name, strlen(name)+1);
   char *base_name = strrchr(name_copy, '/') == NULL ?
                     name_copy : strrchr(name_copy, '/') + 1;
   int suffix_len = strlen(suffix);


### PR DESCRIPTION
gcc-9.3 issued a warning about signed and unsigned for:
 `(time(NULL) - start_time) >= (timeout - 1))`

clang++-3.4 issues a warning for dmtcp_cooordinator.cpp.
So, `sttrncpy()` and `#pragma` are being replaced by `memcpy()`

STYLE:
`#include "dmtcp_coordinator.h"` moved after system includes
