### PR TITLE
syscall-tester.c: revert BasicMknod test changes

### DIFF
--- a/configure
+++ b/configure
@@ -661,6 +661,7 @@ HAS_PYTHON3
 HAS_PS
 HAS_EPOLL_CREATE1
 HAS_CMA
+WSL
 AARCH64_HOST
 AARCH64_HOST_FALSE
 AARCH64_HOST_TRUE
@@ -6535,13 +6536,15 @@ fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking if this is WSL (Windows Subystem for Linux)" >&5
 $as_echo_n "checking if this is WSL (Windows Subystem for Linux)... " >&6; }
-if uname -r | grep Microsoft > /dev/null; then
+if uname -r | grep -i Microsoft > /dev/null; then
   is_wsl='yes'
   wsl_version=`uname -r`
 else
   is_wsl='no'
 fi
 if test "$is_wsl" == "yes"; then
+  WSL=yes
+
 
 cat >>confdefs.h <<_ACEOF
 #define WSL $wsl_version

--- a/configure.ac
+++ b/configure.ac
@@ -458,13 +458,14 @@ else
 fi
 
 AC_MSG_CHECKING([if this is WSL (Windows Subystem for Linux)])
-if uname -r | grep Microsoft > /dev/null; then
+if uname -r | grep -i Microsoft > /dev/null; then
   is_wsl='yes'
   wsl_version=`uname -r`
 else
   is_wsl='no'
 fi
 if test "$is_wsl" == "yes"; then
+  AC_SUBST([WSL], [yes])
   AC_DEFINE_UNQUOTED([WSL],[$wsl_version],[This is WSL (Windows Subsystem for Linux.])
 fi
 AC_MSG_RESULT([$is_wsl])

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -5,6 +5,7 @@ OPENMP_CXXFLAGS=@OPENMP_CXXFLAGS@
 CC = @CC@
 M32=@M32@
 MULTILIB=@MULTILIB@
+WSL=@WSL@
 # Unfortunately, there is a name clash for 'DEBUG'.
 # --enable-debug intends to set 'DEBUG' in src, but sets it everywhere.
 # Here in 'test', we use 'DEBUG' for one-off tests.  So, we unset 'DEBUG'.
@@ -117,7 +118,11 @@ else
 endif
 
 syscall-tester: syscall-tester.c
-	$(CC) -o $@ $< $(CFLAGS) -rdynamic
+	if test -n "${WSL}"; then \
+	  $(CC) -o $@ -DWSL $< $(CFLAGS) -rdynamic; \
+	else \
+	  $(CC) -o $@ $< $(CFLAGS) -rdynamic; \
+	fi
 
 timer%: timer%.c
 	$(CC) -o $@ $< $(CFLAGS) -lrt


### PR DESCRIPTION
The revision to the BasicMknod test of `syscall-tester.c` is failing on Suse Enterprise 15 (Linux 4.12, gcc-7.5, glibc-2.26).
This PR reverts the changes to BasicMknod that were made in PR #937, while keeping the other improvements.

```
--- Line 4154: BasicMknod() ---
 mknod(): path=/tmp/dmtcp-syscall-tester-FzrRG8, mode=0x21c0(020700), dev=0
                            ret = -1      
                Succeeded Phase 1
BasicMknod():4161
Failed Phase 2: This call did something unexpected.
BasicMknod():4161
Fail Phase 2: Aborting test because of catastrophic failure
Ending Test: [BasicMknod: Can I make pipes and not other stuff?]
------------------------------------------------------------- 
```

As a side comment, the previous PR #937 causes BasicMknod to always fail on Suse Enterprise 15.  On CentOS 7, _with this PR that reverts it_, it seems to always succeed on Suse Enterprise 15.  I have seen it fail once on CentOS 7 with this PR, but I can't reproduce that.  It usually passes on CentOS 7.