### PR TITLE
Extend util/gdb-dmtcp-utils to work w/ core files

### DIFF
--- a/util/gdb-dmtcp-utils
+++ b/util/gdb-dmtcp-utils
@@ -66,6 +66,8 @@ def print_dmtcp_commands():
 
 
 def is_executable(filename):
+  if not os.path.exists(filename):
+    return False
   # 16 bytes for ELF magic number; then 2 bytes (short) for ELF type
   header = open(filename, "rb")
   elf_magic_number = header.read(16)
@@ -135,7 +137,10 @@ class AddSymbolFileFromSubstring(gdb.Command):
 
   def invoke(self, filename_substring, from_tty):
     (filename, base_addr, _, _) = memory_region(filename_substring)
-    add_symbol_files_from_filename(filename, base_addr)
+    if filename and base_addr:
+      add_symbol_files_from_filename(filename, base_addr)
+    else:
+      print("Memory segment not found")
 # This will add the new gdb command: add-symbol-file-from-substring FILENAME
 AddSymbolFileFromSubstring()
 
@@ -196,8 +201,10 @@ class AddSymbolFileAtAddress(gdb.Command):
       gdb.execute('print "Process not yet started"', False, False)
     else:
       (filename, base_addr, _, _) = memory_region_at_address(address)
-      if filename == "NOT_FOUND":
-        gdb.execute('print "Memory address not found"', False, False)
+      print(filename, base_addr)
+      if filename.startswith("NOT_FOUND"):
+        gdb.execute('print "*** Memory address ' + address + ' not found"',
+                    False, False)
       else:
         add_symbol_files_from_filename(filename, base_addr)
 # This will add the new gdb command: add-symbol-file-at-address MEMORY_ADDRESS
@@ -225,6 +232,8 @@ AddSymbolFilesAll()
 
 
 def add_symbol_files_from_filename(filename, base_addr):
+  if not os.path.exists(filename):
+    return
   if is_executable(filename):
     base_addr = 0  # ELF executables already hard-wired absolute address
   (textaddr, sections) = relocatesections(filename)
@@ -249,9 +258,14 @@ class Procmaps(gdb.Command):
   def invoke(self, dummy_args, from_tty):
     if getpid() == 0:
       gdb.execute('print "Process not yet started; type \'run\'"', False, False)
+    elif (os.path.exists("/proc/" + str(getpid()) + "/maps") and
+          getpid() != 1):
+      # In Linux 4.12, gdb 8.3, our getpid()==1,
+      #   /proc/1/maps has read permission, but "Permission denied"
+      rc = gdb.execute("shell cat /proc/" + str(getpid()) + "/maps | less",
+                       False, True)
     else:
-      gdb.execute("shell cat /proc/" + str(getpid()) + "/maps | less",
-                  False, True)
+      gdb.execute("info proc mappings")
 Procmaps()
 
 class Procfd(gdb.Command):
@@ -351,14 +365,23 @@ Signals()
 #   Returns (FILE, ADDR1, ADDR2, PERMISSIONS)
 def procmap_filename_address(line):
   quad = line.split()
-  if '/' in quad[-2]:  # if procmaps line ends in "/tmp/a.out (deleted)"
-    quad[-1] = quad[-2] + ' ' + quad[-1]
+  if line[0] == ' ':  # if this came from (gdb) info proc mapping
+    if quad[-1] == "0x0":
+      quad[-1] = "[NO_LABEL]"
+    if '/' in quad[-1]:
+      return (quad[-1],) + (int(quad[0], 16),) + (int(quad[1], 16),) + \
+             (quad[1],)
+    else:
+      return ("NO_LABEL",) + (int(quad[0], 16),) + (int(quad[1], 16),) + \
+             (quad[1],)
   if quad[-1] == "0":
     quad[-1] = "[NO_LABEL]"
+  if '/' in quad[-2]:  # if procmaps line ends in "/tmp/a.out (deleted)"
+    quad[-1] = quad[-2] + ' ' + quad[-1]
   return (quad[-1],) + \
          tuple([int("0x"+elt, 16) for elt in quad[0].split("-")]) + (quad[1],)
 def is_text_segment(procmap_line):
-  return "r-x" in procmap_line and \
+  return "/dev/" not in procmap_line and "r-x" in procmap_line and \
          (procmap_line == "" or procmap_line.isspace() or '/' in procmap_line)
 def procmap_lines():
   if getpid() == 0:
@@ -366,17 +389,37 @@ def procmap_lines():
     sys.exit(1)
   p = subprocess.Popen(["cat", "/proc/"+str(getpid())+"/maps"],
                        stdout = subprocess.PIPE)
-  return (line.decode("utf-8").strip() for line in p.stdout.readlines())
+  lines = (line.decode("utf-8").strip()
+                   for line in p.stdout.readlines())
+  if not lines:
+    lines = gdb.execute("info proc mappings", False, True).split('\n')
+    lines = [procmap_filename_address(memory) for memory in lines
+                                  if " 0x" in memory and "/dev/" not in memory]
+  return lines
+
+  # unique_filenames = []
+  # unique_regions = []
+  # for memory in lines:
+  #   print(memory)
+  #   print("\n")
+  #   if memory[0] not in unique_filenames:
+  #     unique_filenames.append(memory[0])
+  #     unique_regions.append(memory)
+  # return unique_regions
 def memory_regions():
   return (procmap_filename_address(memory) for memory in procmap_lines())
 def memory_regions_executable():
   return (procmap_filename_address(memory) for memory in procmap_lines()
                                            if is_text_segment(memory))
 
-# Returns triple:  (filename, base_address, end_address)
+# Returns quad:  (filename, base_address, end_address, permissions)
 def memory_region(filename_substring):
   regions = memory_regions_executable()
-  return [region for region in regions if filename_substring in region[0]][0]
+  tmp = [region for region in regions if filename_substring in region[0]]
+  if tmp:
+    return tmp[0]
+  else:
+    return ("", 0, 0, "")
 
 
 def memory_region_at_address(memory_address):
@@ -395,7 +438,7 @@ def memory_region_at_address(memory_address):
   if match:
     return match[0]
   else:
-    return ("NOT_FOUND (Did you intend the address in hex?)", 0, 0)
+    return ("NOT_FOUND (Did you intend the address in hex?)", 0, 0, "????")
 
 def print_signals():
   signals_x86_arm = [


### PR DESCRIPTION
This extension supports `(gdb) procmaps`, etc., when GDB is sued to debug a core file.  It relies on `(gdb) info proc mapping` here, in addition to the usual `(gdb) shell cat /proc/PID/maps`.