### PR TITLE
volatile -> volatile __attribute((aligned))

### DIFF
--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -48,7 +48,10 @@
 extern "C" {
 #endif // ifdef __cplusplus
 
-#define LIB_PRIVATE              __attribute__((visibility("hidden")))
+#define LIB_PRIVATE __attribute__((visibility("hidden")))
+#define ATOMIC_SHARED_GLOBAL volatile __attribute((aligned))
+// Same as global macro, but by convnetion, use this for local variables:
+#define ATOMIC_SHARED volatile __attribute((aligned))
 
 typedef enum eDmtcpEvent {
   DMTCP_EVENT_INIT,

--- a/jalib/jalloc.cpp
+++ b/jalib/jalloc.cpp
@@ -28,6 +28,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#define ATOMIC_SHARED volatile __attribute((aligned))
+
 // Make highest chunk size large; avoid a raw_alloc calling mmap()
 // during /proc/self/maps
 #define MAX_CHUNKSIZE (4 * 1024)
@@ -269,14 +271,14 @@ class JFixedAllocStack
     };
     struct StackHead {
       uintptr_t counter;
-      FreeItem* volatile node;
+      FreeItem* ATOMIC_SHARED node;
     };
 
   private:
     StackHead _top;
     size_t _blockSize = 0;
     char padding[128];
-    int volatile _numExpands;
+    ATOMIC_SHARED int _numExpands;
 };
 } // namespace jalib
 

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -46,7 +46,7 @@ EXTERNC void *ibv_get_device_list(void *) __attribute__((weak));
 /* The following instance of the DmtcpWorker is just to trigger the constructor
  * to allow us to hijack the process
  */
-static volatile bool exitInProgress = false;
+static ATOMIC_SHARED_GLOBAL bool exitInProgress = false;
 static bool exitAfterCkpt = 0;
 
 /* NOTE:  Please keep this function in sync with its copy at:

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -45,7 +45,7 @@
 using namespace dmtcp;
 
 // Globals
-volatile bool restoreInProgress = false;
+ATOMIC_SHARED_GLOBAL bool restoreInProgress = false;
 Thread *motherofall = NULL;
 void **motherofall_saved_sp = NULL;
 ThreadTLSInfo *motherofall_tlsInfo = NULL;

--- a/test/plugin/presuspend/presuspend.c
+++ b/test/plugin/presuspend/presuspend.c
@@ -38,8 +38,8 @@ extern void dmtcp_get_libc_dlsym_add(void)
 
 // Older versions of GCC support __thread.
 // So, for portability, we won't use the newer C11 keyword, thread_local.
-volatile static int total_num_tasks = 0;
-volatile int in_presuspend = 0;
+ATOMIC_SHARED_GLOBAL static int total_num_tasks = 0;
+ATOMIC_SHARED_GLOBAL  int in_presuspend = 0;
 
 // This information is local to this file (and hence to this library):
 static pid_t plugin_childpid = -1;

--- a/test/shared-memory1.c
+++ b/test/shared-memory1.c
@@ -11,6 +11,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#define ATOMIC_SHARED volatile __attribute((aligned))
 
 void reader(int fd);
 void writer(int fd);
@@ -53,7 +54,7 @@ void
 reader(int fd)
 {
   int *sharedMemory;
-  volatile int val;
+  ATOMIC_SHARED int val;
   int i;
 
   sharedMemory = mmap(0, sizeof(int), PROT_READ, MAP_SHARED, fd, 0);


### PR DESCRIPTION
 * ISO C does not guarantee that an int is aligned.  So, it won't be
   atomic if it crosses a cache boundary.  This adds ATOMIC_SHARED macro.

@gourryinverse convinced me that the ISO C standard says that C doesn't have to respect a 4-byte int (e.g., on x86_64) as atomic, and that it can still be misaligned.  ISO C says that a struct must respect the chosen alignments of its fields, but it doesn't seem to say what is the "natural" alignment of an int.

As an interesting example, consider this partial evidence provided by him.  An 8-byte pointer turns out to be only 2-byte aligned.  So, maybe the compiler normally aligns 4-byte int's correctly, but we can't depend on that.  This is all about evidence, since we have no way of directly proving what a compiler is required to do.

```
#include <assert.h>

int g_x;
int* g_x_p = &g_x;

int func(int a, int b, int c, int d)
{ return a + b + c + d; }

int main(void) {
  int l_x;
  int* l_x_p = &l_x;

  l_x = 2;
  *l_x_p = 3;
  g_x = 4;
  *g_x_p = 5;

  assert(func(l_x, *l_x_p, g_x, *g_x_p) == 16);
}
```

Note that `g_x_p` is only 2-byte alligned, when you run this, and print addresses with GDB.