### PR TITLE
Fix for commit 073e69a, to support gcc-4.8

### DIFF
--- a/src/mtcp/sysdep/sysdep-x86_64.h
+++ b/src/mtcp/sysdep/sysdep-x86_64.h
@@ -258,7 +258,7 @@
 
 # undef INTERNAL_SYSCALL_ERROR_P
 # define INTERNAL_SYSCALL_ERROR_P(val, err) \
-  ((long)(val) >= -4095L)
+  ((unsigned long)(val) >= -4095UL)
 
 # undef INTERNAL_SYSCALL_ERRNO
 # define INTERNAL_SYSCALL_ERRNO(val, err) (-(val))


### PR DESCRIPTION
The original code `(unsigned long)(val) >= -4095L) ` produces a warning on recent gcc compilers.  And `(long)(val) >= -4095L) ` (used in commit 073e69a) is fine on recent compilers, but it compiles to incorrect semantics in gcc-4.8  So, this commit now changes it to:  `(unsigned long)(val) >= -4095L) `, which seems to satisfy both versions of gcc compilers.