### PR TITLE
Removed volatile from StackHead definition.

### DIFF
--- a/jalib/jalloc.cpp
+++ b/jalib/jalloc.cpp
@@ -271,7 +271,7 @@ class JFixedAllocStack
     };
     struct StackHead {
       uintptr_t counter;
-      FreeItem* ATOMIC_SHARED node;
+      FreeItem* node;
     };
 
   private:


### PR DESCRIPTION
The __attribute((aligned)) causes the struct to grow beyond double-word,
causing CAS to fail. Since this field is updated safely, we don't need it to be
volatile.