### PR TITLE
Adding clone1 test (emulating child thread)

### DIFF
--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -180,6 +180,9 @@ gettid: gettid.c
 pthread%: pthread%.c
 	-$(CC) -o $@ $< $(CFLAGS) -lpthread
 
+clone%: clone%.c
+	-$(CC) -o $@ $< $(CFLAGS) -lpthread
+
 mutex%: mutex%.c
 	-$(CC) -o $@ $< $(CFLAGS) -lpthread
 

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -944,6 +944,8 @@ S=DEFAULT_S
 runTest("pthread4",      1, ["./test/pthread4"])
 runTest("pthread5",      1, ["./test/pthread5"])
 
+runTest("clone1",      1, ["./test/clone1"])
+
 if HAS_MUTEX_WRAPPERS == "yes":
   runTest("mutex1",        1, ["./test/mutex1"])
   runTest("mutex2",        1, ["./test/mutex2"])

--- a/test/clone1.c
+++ b/test/clone1.c
@@ -1,0 +1,65 @@
+/* Compile with:  gcc THIS_FILE -lpthread */
+
+#define _GNU_SOURCE
+#include <sched.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+int start_routine(void *);
+
+sem_t sem;
+
+
+int
+main()
+{
+  void *arg;
+  void *stack;
+
+  sem_init(&sem, 0, 0);
+
+  while (1) {
+    arg = malloc(10);
+    *(int *)arg = 42;
+    stack = malloc(2 << 20 /* 2 MB */);
+
+    // Emulate a true thread, but return a SIGCHLD to parent's sig. handler
+    pid_t tid = clone(start_routine, stack + 4096 - 8 /* top of stack */,
+           CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SYSVSEM | CLONE_SIGHAND |
+           CLONE_THREAD, arg);
+
+    if (tid == -1) {
+      perror("clone");
+      return 1;
+    }
+
+    // A child thread is _not_ a child process.  We can't use waitpid(),
+    // and we can't look at the thread's exit status.;
+    //    int status;
+    //    int res = waitpid(tid, &status, __WCLONE);
+    sem_wait(&sem);
+
+    free(arg);
+    free(stack);
+  }
+}
+
+int
+start_routine(void *arg)
+{
+  printf("Child thread executing.\n");
+  if (*(int *)arg != 42) {
+    fprintf(stderr, "child threqd received arg %d instead of 42.\n",
+                    *(int *)arg);
+    return -1;
+  }
+  sleep(1);
+  sem_post(&sem);
+  return 99;
+}


### PR DESCRIPTION
@karya0,
    This `test/clone.c` segfaults on `bin/dmtcp_launch test/clone1`.  This has been the case since PR #932 .  Admittedly, prior to PR #932, we could launch, checkpoint, and resume clone1, but we were failing to restart clone1.
    Nevertheless, even if we comment out 'clone' in `atuotest.py`, this seems like a good test to have in reserve for the future.
    If we need to, we can simply check it in, with this test commented out.

But I'm hoping that this will help you to analyze your PR #932.  Maybe there's something simple there that you can easily fix.  To test, just do:
&nbsp;&nbsp;&nbsp;&nbsp; `make -j check-clone1 && bin/dmtcp_launch test/clone1`