### PR TITLE
Check for env var DMTCP_ABORT_ON_FAILURE

### DIFF
--- a/doc/debugging-dmtcp.txt
+++ b/doc/debugging-dmtcp.txt
@@ -39,14 +39,14 @@ the cause, try:
 C. LAUNCHING A PROCESS UNDER DMTCP CONTROL USING GDB
 
 JASSERT doesn't generate a core dump by default (because it calls _exit()).
-Exporting the environment variable DMTCP_ABORT_ON_FAILED_ASSERT will cause
+Exporting the environment variable DMTCP_ABORT_ON_FAILURE will cause
 it to call abort(). This can be useful when debugging distributed processes.
 Example:
-  DMTCP_ABORT_ON_FAILED_ASSERT=1 bin/dmtcp_launch a.out
+  DMTCP_ABORT_ON_FAILURE=1 bin/dmtcp_launch a.out
   gdb a.out core
 
 When used with dmtcp_restart, it is important to embed
-DMTCP_ABORT_ON_FAILED_ASSERT in the checkpoint image by first using it with
+DMTCP_ABORT_ON_FAILURE in the checkpoint image by first using it with
 dmtcp_launch, as above. After that, a restarted process will also generate
 a core dump.
 

--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -655,10 +655,12 @@ uint64_t dmtcp_dlsym_lib_fnc_offset(const char *libname, const char *symbol);
  * TYPICAL USAGE:  exit(DMTCP_FAIL_RC)
  * Use this to distinguish DMTCP failing versus the target application failing.
  */
-#define DMTCP_FAIL_RC                                         \
-  (getenv("DMTCP_FAIL_RC") && atoi(getenv("DMTCP_FAIL_RC"))   \
-     ? atoi(getenv("DMTCP_FAIL_RC"))                          \
-     : 99)
+#define DMTCP_FAIL_RC                                            \
+  (getenv("DMTCP_ABORT_ON_FAILURE")                              \
+     ? abort(), 99 /* not reached */                             \
+     : (getenv("DMTCP_FAIL_RC") && atoi(getenv("DMTCP_FAIL_RC")) \
+          ? atoi(getenv("DMTCP_FAIL_RC"))                        \
+          : 99))
 
 /// Pointer to a "void foo();" function
 typedef void (*dmtcp_fnptr_t)(void);

--- a/jalib/jassert.cpp
+++ b/jalib/jassert.cpp
@@ -136,7 +136,7 @@ jassert_internal::JAssert::~JAssert()
 
   if (_exitWhenDone) {
     /* Generate core-dump for debugging */
-    if (getenv("DMTCP_ABORT_ON_FAILED_ASSERT")) {
+    if (getenv("DMTCP_ABORT_ON_FAILURE")) {
       abort();
     } else {
       _exit(jalib::dmtcp_fail_rc());

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -432,6 +432,14 @@ main(int argc, const char **argv)
 
   initializeJalib();
 
+  // FIXME:  This was changed in Mar., 2022.  We can remove this msg in 2 or 3 years.
+  if (getenv("DMTCP_ABORT_ON_FAILED_ASSERT")) {
+    JNOTE("\n\n*********************************************\n"
+              "* DMTCP_ABORT_ON_FAILED_ASSERT is obsolete. *\n"
+              "* Plesae use DMTCP_ABORT_ON_FAILURE instead.*\n"
+              "*********************************************\n");
+  }
+
   UniquePid::ThisProcess(true);
   Util::initializeLogFile(tmpDir.c_str(), NULL, NULL);
 


### PR DESCRIPTION
 * JASSERT had recognized DMTCP_ABORT_ON_FAILED_ASSERT
 * Change behavior to abort on all failures, change var. name

Previously, there was no easy way to ask DMTCP to abort on exit with failure.  This generalization helps us to debug DMTCP internal errors, and perhaps it's useful also when an end user hands DMTCP some improperly structured data, causing DMTCP to abort.

This PR should be easy to review.  It was motivated by a previous effort with @xuyao0127 to debug a DMTCP internal error.