### PR TITLE
Fixed a bug in realToVirtualPath

### DIFF
--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -141,7 +141,7 @@ realToVirtualPath(char *path)
 
   PluginManager::eventHook(DMTCP_EVENT_REAL_TO_VIRTUAL_PATH, &data);
 
-  return path;
+  return data.realToVirtualPath.path;
 }
 
 static int


### PR DESCRIPTION
Previously, the return value is the same as the input. Also in many places, the return value of the realToVirtualPath is not used. 

For this family of functions, it passes in a pointer to char as a buffer. But there is no buflen. This design seems fragile. Sometimes a function overwrites the buffer without checking the buflen. The current code seems to depend on PATH_MAX, but it has no way to verify the path length.

@karya0, could you improve on this PR?