### PR TITLE
Fix for commit ad90917: unable to reset ckpt timer

### DIFF
--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -499,7 +499,7 @@ DmtcpCoordinator::releaseBarrier(const string &barrier)
     broadcastMessage(DMT_BARRIER_RELEASED,
                      prevBarrier.length() + 1,
                      prevBarrier.c_str());
-    if (status.minimumState == WorkerState::RUNNING) {
+    if (status.minimumState == WorkerState::CHECKPOINTED) {
       JNOTE("Checkpoint complete; all workers running");
       resetCkptTimer();
     }


### PR DESCRIPTION
In commit ad90917, the Resume_resume barrier is removed. Therefore, the minimum state when the checkpoint is complete is no longer WorkerState:RUNNING, it's WorkerState:CHECKPOINTED. So releaseBarrier will never reset the checkpoint timer.