### PR TITLE
Changes from feature/mana

### DIFF
--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -40,7 +40,6 @@ static int testJava(const char **argv);
 static bool testSetuid(const char *filename);
 static void testStaticallyLinked(const char *filename);
 static bool testScreen(const char **argv, const char ***newArgv);
-static void setLDLibraryPathForMPI(bool is32bitElf);
 static void setLDPreloadLibs(bool is32bitElf);
 
 // gcc-4.3.4 -Wformat=2 issues false positives for warnings unless the format
@@ -147,8 +146,6 @@ static const char *theUsage =
   "              Skip NOTE messages; if given twice, also skip WARNINGs\n"
   "  --coord-logfile PATH (environment variable DMTCP_COORD_LOG_FILENAME\n"
   "              Coordinator will dump its logs to the given file\n"
-  "  --mpi\n"
-  "              Set it to enable MPI-specific flags.\n"
   "  --help\n"
   "              Print this message and exit.\n"
   "  --version\n"
@@ -219,8 +216,6 @@ static struct PluginInfo pluginInfo[] = {               // Default value
 };
 
 const size_t numLibs = sizeof(pluginInfo) / sizeof(struct PluginInfo);
-
-static bool mpiMode = false;
 
 static CoordinatorMode allowedModes = COORD_ANY;
 string tmpDir = "tmpDir is not set";
@@ -361,9 +356,6 @@ processArgs(int *orig_argc, const char ***orig_argv)
       // Just in case a non-standard version of setenv is being used:
       setenv(ENV_VAR_QUIET, getenv(ENV_VAR_QUIET), 1);
       shift;
-    } else if (s == "--mpi") {
-      mpiMode = true;
-      shift;
     } else if ((s.length() > 2 && s.substr(0, 2) == "--") ||
                (s.length() > 1 && s.substr(0, 1) == "-")) {
       printf("Invalid Argument\n%s", theUsage);
@@ -432,7 +424,8 @@ main(int argc, const char **argv)
 
   initializeJalib();
 
-  // FIXME:  This was changed in Mar., 2022.  We can remove this msg in 2 or 3 years.
+  // FIXME:  This was changed in Mar., 2022.
+  //         We can remove this msg in 2 or 3 years.
   if (getenv("DMTCP_ABORT_ON_FAILED_ASSERT")) {
     JNOTE("\n\n*********************************************\n"
               "* DMTCP_ABORT_ON_FAILED_ASSERT is obsolete. *\n"
@@ -623,10 +616,6 @@ main(int argc, const char **argv)
                          &coordInfo,
                          &localIPAddr);
 
-  if (mpiMode) {
-    setLDLibraryPathForMPI(is32bitElf);
-  }
-
   setLDPreloadLibs(is32bitElf);
 
   // run the user program
@@ -773,35 +762,6 @@ testScreen(const char **argv, const char ***newArgv)
     return true;
   }
   return false;
-}
-
-static void
-setLDLibraryPathForMPI(bool is32bitElf)
-{
-  // If libmpidummy.so found, add it to LD_LIBRARY_PATH and assume we're
-  // running with runMPI.  We don't need an explicit --mpi flag here.
-  // If this DMTCP was configured with libmpidummy.so and yet this is
-  // not running with the mpi-proxy-split plugin, then libmpidummy.so is
-  // never called, and so the extra library is harmless.
-  if (is32bitElf) return;  // exit if 32-bit applications; this shouldn't be MPI
-  string libmpidummy = Util::getPath("libmpidummy.so");
-  if (strcmp(libmpidummy.c_str(), "libmpidummy.so") == 0) {
-    return; // libmpidummy.so was not found.
-  }
-
-  char *last_slash = const_cast <char *>(strrchr(libmpidummy.c_str(), '/'));
-  if (last_slash) {
-    *last_slash = '\0'; // Modify the C string in place
-  }
-  // libmpidummy.so must appear before libmpi.so in library search order.
-  // Let's hope the MPI application is not running as root (no LD_LIBRARY_PATH),
-  // and is not using ELF's rpath.  (But ELF runpath is fine.)
-  string ld_library_path = libmpidummy.c_str(); // Using the modified C string.
-  if (getenv("LD_LIBRARY_PATH") != NULL) {
-    ld_library_path += ":";
-    ld_library_path += getenv("LD_LIBRARY_PATH");
-  }
-  setenv("LD_LIBRARY_PATH", ld_library_path.c_str(), 1);
 }
 
 static void

--- a/src/mtcp/Makefile.in
+++ b/src/mtcp/Makefile.in
@@ -88,7 +88,7 @@ ifneq ($(MANA_HELPER_DIR),)
   HEADERS += $(MANA_HELPER_DIR)/mtcp_split_process.h \
              $(MANA_HELPER_DIR)/ucontext_i.h
   OBJS += mtcp_restart_plugin.o mtcp_split_process.o getcontext.o
-  CFLAGS += -DMTCP_PLUGIN_H="<mtcp_restart_plugin.h>" -DMANA_USE_LH_FIXED_ADDRESS=1
+  CFLAGS += -DMTCP_PLUGIN_H="<mtcp_restart_plugin.h>"
   INCLUDES += -I$(MANA_HELPER_DIR)
 endif
 

--- a/src/plugin/ipc/file/fileconnlist.cpp
+++ b/src/plugin/ipc/file/fileconnlist.cpp
@@ -381,7 +381,6 @@ FileConnList::prepareShmList()
       if (strstr(area.name, "ptraceSharedInfo") != NULL ||
           strstr(area.name, "dmtcpPidMap") != NULL ||
           strstr(area.name, "dmtcpSharedArea") != NULL ||
-          strstr(area.name, "dmtcpSharedArea") != NULL ||
           strstr(area.name, "synchronization-log") != NULL ||
           strstr(area.name, "infiniband") != NULL ||
           strstr(area.name, "synchronization-read-log") != NULL) {
@@ -391,6 +390,11 @@ FileConnList::prepareShmList()
       if (Util::isNscdArea(area) ||
           Util::isIBShmArea(area) ||
           Util::isSysVShmArea(area)) {
+        continue;
+      }
+
+      if (dmtcp_skip_memory_region_ckpting &&
+          dmtcp_skip_memory_region_ckpting(&area)) {
         continue;
       }
 


### PR DESCRIPTION
@karya0 @gc00 There are three commits in the feature/mana branch now. We need to take a look at some of these commits before we can take them to the DMTCP.
1. 1df553b97f60608d46b40839b4fd793ed2ddc3b4: This commit added more keywords in the `FileConnList::prepareShmList()` function to skip some MANA related regions. I remember Kapil said he will work on a way that plugins can add more keywords without modifying DMTCP.
2. 08e4c8d2469f9bbe986744d94bafd2071c39847a: This commit revert a previous commit 764a55f917c7a4abaa0183cada8b9f1934bfab99 that added a compile option that is no longer needed.
3. 4bd4fa6dc3dbe9ceaa7ad9669d3fab7eaecb99dc: This commit is part of a commit in MANA's master branch that renames `libmpidummy.so` to `libmpistub.so`. `dmtcp_launch.cpp` is also modified because if dmtcp_launch is run with the `--mpi` option, the function `setLDLibraryPathForMPI()` will be called to setup the `LD_LIBRARY_PATH` environment variable. If DMTCP was not compiled with MANA, but a user added the `--mpi` option, should we print some warning messages? Like the restart plugin issue I mentioned in our previous meeting, how can we distinguish if DMTCP was built with or without MANA? What should we do if a wrong build or flag is used?