### PR TITLE
Cherry-pick 2 fixes for `gdb-dmtcp-utils`

### DIFF
--- a/util/gdb-dmtcp-utils
+++ b/util/gdb-dmtcp-utils
@@ -179,7 +179,11 @@ class ShowFilenameAtAddress(gdb.Command):
         else:
           memory_region = "%s 0x%x-0x%x (%s)" % \
                           memory_region_at_address(memory_address)
-          gdb.execute('print "' + memory_region + '"', False, False)
+          #GDB-8:  For some unknown reason (e.g., after: 'bt' and 'frame 4' in MANA),
+          #  the 'gdb.execute' reports '"' not allowed, and (') doesn't work.
+          #  Perhaps it's an interaction between GDB and the Python API.
+          #WAS: gdb.execute('print "' + memory_region + '"', False, False)
+          print(memory_region)
 # This will add the new gdb command: show-filename-at-address MEMORY_ADDRESS
 ShowFilenameAtAddress()
 try:

--- a/util/gdb-dmtcp-utils
+++ b/util/gdb-dmtcp-utils
@@ -255,8 +255,8 @@ def getpid():
 def usingCore():
   # In Linux 4.12, gdb 8.3, our getpid()==1,
   #   /proc/1/maps has read permission, but "Permission denied"
-  return (not os.path.exists("/proc/" + str(getpid()) + "/maps" or
-          getpid() != 1))
+  return (not os.path.exists("/proc/" + str(getpid()) + "/maps") or
+          getpid() == 1)
 
 class Procmaps(gdb.Command):
   """procmaps (same as:  shell cat /proc/INFERIOR_PID/maps)"""


### PR DESCRIPTION
- Doesn't work with coredump file with getpid() == 1
- Minor fix from MANA 0f8b15eb8