### PR TITLE
Better wrapper-lock mechanism

### DIFF
--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -198,6 +198,7 @@ int DmtcpMutexUnlock(DmtcpMutex *mutex);
 
 void DmtcpRWLockInit(DmtcpRWLock *rwlock);
 int DmtcpRWLockRdLock(DmtcpRWLock *rwlock);
+int DmtcpRWLockRdLockIgnoreQueuedWriter(DmtcpRWLock *rwlock);
 int DmtcpRWLockTryRdLock(DmtcpRWLock *rwlock);
 int DmtcpRWLockWrLock(DmtcpRWLock *rwlock);
 int DmtcpRWLockUnlock(DmtcpRWLock *rwlock);

--- a/include/dmtcpalloc.h
+++ b/include/dmtcpalloc.h
@@ -28,7 +28,6 @@
 #include <limits>
 #include <list>
 #include <map>
-#include <memory>
 #include <set>
 #include <sstream>
 #include <string>

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -153,7 +153,6 @@ static void runMtcpRestart(int fd, ProcessInfo *pInfo);
 static int readCkptHeader(const string &path, ProcessInfo *pInfo);
 static int openCkptFileToRead(const string &path);
 static int processCkptImages();
-static int processMpiProxy();
 
 RestoreTarget::RestoreTarget(const string &path)
   : _path(path)
@@ -879,7 +878,7 @@ main(int argc, char **argv)
   }
 
   // Can't specify ckpt images with --restart-dir flag.
-  if (restartDir.empty() ^ ckptImages.size() > 0) {
+  if (restartDir.empty() ^ (ckptImages.size() > 0)) {
     JASSERT_STDERR << theUsage;
     exit(DMTCP_FAIL_RC);
   }

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -288,11 +288,15 @@ dmtcp_initialize_entry_point()
           "  Please use dmtcp_launch --ib ***\n");
   }
 
+  // Initialize data-structures related to motherofall thread.
+  ThreadSync::initMotherOfAll();
+  ThreadList::init();
+
   // In libdmtcp.so, notify this event for each plugin.
   PluginManager::eventHook(DMTCP_EVENT_INIT, NULL);
 
-  ThreadSync::initMotherOfAll();
-  ThreadList::init();
+  // Create checkpoint-thread at the very end of the initialization process.
+  ThreadList::createCkptThread();
 }
 
 void

--- a/src/miscwrappers.cpp
+++ b/src/miscwrappers.cpp
@@ -652,9 +652,7 @@ vprintf (const char *format, __gnuc_va_list arg)
 extern "C" int
 vfprintf (FILE *s, const char *format, va_list ap)
 {
-  WRAPPER_EXECUTION_DISABLE_CKPT();
   int retVal = _real_vfprintf ( s, format, ap );
-  WRAPPER_EXECUTION_ENABLE_CKPT();
   return retVal;
 }
 

--- a/src/threadinfo.h
+++ b/src/threadinfo.h
@@ -80,6 +80,7 @@ typedef struct Thread Thread;
 
 struct Thread {
   pid_t tid;
+  pid_t virtual_tid;
   int state;
 
   char procname[17];
@@ -90,7 +91,6 @@ struct Thread {
   pid_t *ptid;
   pid_t *ctid;
 
-  pid_t virtual_tid;
   sigset_t sigblockmask; // blocked signals
   sigset_t sigpending;   // pending signals
 
@@ -113,9 +113,15 @@ struct Thread {
    */
   double ckptReadTime;
 
+  uint32_t wrapperLockCount;
+
   Thread *next;
   Thread *prev;
 };
+
+extern __thread Thread *curThread;
+extern Thread *ckptThread;
+extern Thread *motherofall;
 
 int Thread_UpdateState(Thread *th, ThreadState newval, ThreadState oldval);
 

--- a/src/threadinfo.h
+++ b/src/threadinfo.h
@@ -71,7 +71,6 @@ typedef enum ThreadState {
   ST_SIGNALED,
   ST_SUSPINPROG,
   ST_SUSPENDED,
-  ST_ZOMBIE,
   ST_CKPNTHREAD,
   ST_THREAD_CREATE
 } ThreadState;
@@ -82,6 +81,7 @@ struct Thread {
   pid_t tid;
   pid_t virtual_tid;
   int state;
+  int exiting;
 
   char procname[17];
 

--- a/src/threadlist.h
+++ b/src/threadlist.h
@@ -36,6 +36,7 @@ pid_t _real_tid();
 int _real_tgkill(pid_t tgid, pid_t tid, int sig);
 
 void init();
+void createCkptThread();
 Thread *getNewThread(void *(*fn)(void *), void *arg);
 void initThread(Thread *);
 void resetOnFork();

--- a/src/threadwrappers.cpp
+++ b/src/threadwrappers.cpp
@@ -161,22 +161,10 @@ __clone(int (*fn)(void *arg),
       fn, child_stack, flags, arg, parent_tidptr, newtls, child_tidptr);
   }
 
-  JNOTE("__clone called without pthread_create");
-  bool threadCreationLockAcquired = prepareThreadCreate();
+  JASSERT(false)
+    .Text("Thread-creation with clone syscall isn't supported.");
 
-  Thread *thread = ThreadList::getNewThread((void*(*)(void*))fn, arg);
-  int retval = _real_clone(
-      (int(*)(void*))thread_start, child_stack, flags, thread, parent_tidptr,
-      newtls, child_tidptr);
-
-  postThreadCreate(threadCreationLockAcquired);
-
-  if (retval == -1) {
-    // if we failed to create new pthread
-    ThreadSync::decrementUninitializedThreadCount();
-  }
-
-  return retval;
+  return 0;
 }
 
 extern "C" long
@@ -186,24 +174,10 @@ clone3(struct clone_args *cl_args, size_t size)
     return NEXT_FNC(clone3)(cl_args, size);
   }
 
-  JNOTE("clone3() called without pthread_create");
-  bool threadCreationLockAcquired = prepareThreadCreate();
+  JASSERT(false)
+    .Text("Thread-creation with clone3 syscall isn't supported.");
 
-  Thread *thread = ThreadList::getNewThread(NULL, NULL);
-  int retval = NEXT_FNC(clone3)(cl_args, size);
-
-  if (retval == 0) {
-    // Child thread
-    processChildThread(thread);
-  } else {
-    postThreadCreate(threadCreationLockAcquired);
-    if (retval == -1) {
-      // if we failed to create new thread
-      ThreadSync::decrementUninitializedThreadCount();
-    }
-  }
-
-  return retval;
+  return 0;
 }
 
 extern "C" void

--- a/src/tls.cpp
+++ b/src/tls.cpp
@@ -207,8 +207,6 @@ STATIC_TLS_TID_OFFSET()
 /* Can remove the unused attribute when this __GLIBC_PREREQ is the only one. */
 static char *memsubarray(char *array, char *subarray, size_t len)
 __attribute__((unused));
-extern void **motherofall_saved_sp;
-extern ThreadTLSInfo *motherofall_tlsInfo;
 
 /*****************************************************************************
  *

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -65,8 +65,11 @@ stats = [0, 0]
 failed_tests = []
 
 disabled_tests = [
+  # Vfork is not currently supported.
   "vfork1",
-  "vfork2"
+  "vfork2",
+  # Raw thread creation using clone syscall directly isn't supported.
+  "clone1"
 ]
 
 # if 'autotest.py --parallel', then initialize tests and test_dict.

--- a/test/clone1.c
+++ b/test/clone1.c
@@ -21,16 +21,17 @@ main()
 {
   void *arg;
   void *stack;
+  size_t stack_size = 2 << 20; /* 2 MB */
 
   sem_init(&sem, 0, 0);
 
   while (1) {
     arg = malloc(10);
     *(int *)arg = 42;
-    stack = malloc(2 << 20 /* 2 MB */);
+    stack = malloc(stack_size);
 
     // Emulate a true thread, but return a SIGCHLD to parent's sig. handler
-    pid_t tid = clone(start_routine, stack + 4096 - 8 /* top of stack */,
+    pid_t tid = clone(start_routine, stack + stack_size /* top of stack */,
            CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SYSVSEM | CLONE_SIGHAND |
            CLONE_THREAD, arg);
 


### PR DESCRIPTION
Simplified wrapper-lock mechanism to use per-thread state to keep count of read-locks.

Further, this PR also removes support for raw clone calls. We currently can't support raw thread-creation calls to clone and clone3 due to TLS. DMTCP relies heavily on TLS for maintaining user-thread state. It includes the thread-local curThread struct as well as some other locks and variables maintained by pid plugin, etc.

Threads created using clone3/clone either shouldn't use TLS or should lay out TLS exactly the way libpthread expects. A thread without a properly laid out TLS segment would fail on calling any libc or libdmtcp functions that deal with TLS. Since a user-thread needs to call several functions within libdmtcp, a lack of TLS will result in random/hard-to-chase failures.

Since there are no known DMTCP-supported applications that use clone/clone3 directly, this PR intends to disable the usage until we  can find out a proper way to suppor such threads.