### PR TITLE
Bugfix - abort() is being called before jalib_init() because of DMTCP_FAIL_RC macro evaluation.

### DIFF
--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -690,12 +690,15 @@ uint64_t dmtcp_dlsym_lib_fnc_offset(const char *libname, const char *symbol);
  * TYPICAL USAGE:  exit(DMTCP_FAIL_RC)
  * Use this to distinguish DMTCP failing versus the target application failing.
  */
+#define DMTCP_FAIL_RC_PARAM                                      \
+   (getenv("DMTCP_FAIL_RC") && atoi(getenv("DMTCP_FAIL_RC"))     \
+      ? atoi(getenv("DMTCP_FAIL_RC"))                            \
+      : 99)
+
 #define DMTCP_FAIL_RC                                            \
   (getenv("DMTCP_ABORT_ON_FAILURE")                              \
      ? abort(), 99 /* not reached */                             \
-     : (getenv("DMTCP_FAIL_RC") && atoi(getenv("DMTCP_FAIL_RC")) \
-          ? atoi(getenv("DMTCP_FAIL_RC"))                        \
-          : 99))
+     : DMTCP_FAIL_RC_PARAM)
 
 /// Pointer to a "void foo();" function
 typedef void (*dmtcp_fnptr_t)(void);

--- a/src/jalibinterface.cpp
+++ b/src/jalibinterface.cpp
@@ -62,7 +62,7 @@ initializeJalib()
              ELF_INTERPRETER,
              PROTECTED_STDERR_FD,
              PROTECTED_JASSERTLOG_FD,
-             DMTCP_FAIL_RC);
+             DMTCP_FAIL_RC_PARAM);
 
   // To force linkage of jbuffer.cpp
   static jalib::JBuffer *buf = new jalib::JBuffer(0);


### PR DESCRIPTION
The definition of DMTCP_FAIL_RC is changed in [this](https://github.com/dmtcp/dmtcp/commit/14932be2ab71fc0bc5b700b618c3f12e0d128b62) commit. If getenv(DMTCP_ABORT_ON_FAILURE) returns 1, DMTCP_FAIL_RC will call abort() immediately. However, DMTCP_FAIL_RC is used as the last parameter of the function jalib_init. Therefore, before calling jalib_init, DMTCP_FAIL_RC is expanded and evaluated in order to get the value of the parameter. Then because the environment variable DMTCP_ABORT_ON_FAILURE is defined as 1, the program will call abort() immediately.