### PR TITLE
Cherry-pick dmtcp change from commit a1583a "Deterministic p2p".

### DIFF
--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -356,7 +356,7 @@ FileConnection::refill(bool isRestart)
           // request with MPI_ANY_SOURCE is actually received. In order to deterministically
           // replay the uncompleted requests from the same source at restart, the requests
           // are also saved after checkpoint. The log file size at restart is larger than
-          // the its size saved in checkpoint image. Just give a warning here and continue. 
+          // its size saved in the checkpoint image. Just give a warning here and continue. 
           JWARNING(false) (_path) (_st_size) (statbuf.st_size)
           .Text("Setting saved size to the current file size");
 	  _st_size = statbuf.st_size;

--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -351,8 +351,9 @@ FileConnection::refill(bool isRestart)
         if (statbuf.st_size > _st_size &&
             ((_fcntlFlags & O_WRONLY) || (_fcntlFlags & O_RDWR))) {
           errno = 0;
-          JASSERT(truncate(_path.c_str(), _st_size) == 0)
-            (_path.c_str()) (_st_size) (JASSERT_ERRNO);
+          JWARNING(false) (_path) (_st_size) (statbuf.st_size)
+          .Text("Setting saved size to the current file size");
+	  _st_size = statbuf.st_size;
         } else if (statbuf.st_size < _st_size) {
           JWARNING(false).Text("Size of file smaller than what we expected");
         }

--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -351,6 +351,12 @@ FileConnection::refill(bool isRestart)
         if (statbuf.st_size > _st_size &&
             ((_fcntlFlags & O_WRONLY) || (_fcntlFlags & O_RDWR))) {
           errno = 0;
+          // MANA deterministic p2p saves the p2p requests in a log file.
+          // The log file is used to keep track the source rank from which the
+          // request with MPI_ANY_SOURCE is actually received. In order to deterministically
+          // replay the uncompleted requests from the same source at restart, the requests
+          // are also saved after checkpoint. The log file size at restart is larger than
+          // the its size saved in checkpoint image. Just give a warning here and continue. 
           JWARNING(false) (_path) (_st_size) (statbuf.st_size)
           .Text("Setting saved size to the current file size");
 	  _st_size = statbuf.st_size;


### PR DESCRIPTION
This change cherry-pick the warning for checkpoint file size change from commit a1583a "Deterministic p2p".