### PR TITLE
Return success for the valid options

### DIFF
--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -1685,10 +1685,10 @@ main(int argc, char **argv)
     string s = argv[0];
     if (s == "-h" || s == "--help") {
       printf("%s", theUsage);
-      return 1;
+      return 0;
     } else if ((s == "--version") && argc == 1) {
       printf("%s", DMTCP_VERSION_AND_COPYRIGHT_INFO);
-      return 1;
+      return 0;
     } else if (s == "-q" || s == "--quiet") {
       quiet = true;
       jassert_quiet++;

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -244,10 +244,10 @@ processArgs(int *orig_argc, const char ***orig_argv)
     string s = argc > 0 ? argv[0] : "--help";
     if ((s == "--help") && argc <= 1) {
       printf("%s", theUsage);
-      exit(DMTCP_FAIL_RC);
+      exit(0);
     } else if ((s == "--version") && argc == 1) {
       printf("%s", DMTCP_VERSION_AND_COPYRIGHT_INFO);
-      exit(DMTCP_FAIL_RC);
+      exit(0);
     } else if (s == "-j" || s == "--join-coordinator" || s == "--join") {
       allowedModes = COORD_JOIN;
       shift;

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -741,10 +741,10 @@ main(int argc, char **argv)
     string s = argc > 0 ? argv[0] : "--help";
     if (s == "--help" && argc == 1) {
       printf("%s", theUsage);
-      return DMTCP_FAIL_RC;
+      return 0;
     } else if ((s == "--version") && argc == 1) {
       printf("%s", DMTCP_VERSION_AND_COPYRIGHT_INFO);
-      return DMTCP_FAIL_RC;
+      return 0;
     } else if (s == "-j" || s == "--join-coordinator" || s == "--join") {
       allowedModes = COORD_JOIN;
       shift;


### PR DESCRIPTION
Option "--help" and "--version" are valid options for dmtcp_launch, dmtcp_restart and dmtcp_coordinator. The command should return value should be "0" when the valid option is present.