### PR TITLE
Moved static members from dmtcpplugin to ProcessInfo.

### DIFF
--- a/include/shareddata.h
+++ b/include/shareddata.h
@@ -185,8 +185,9 @@ void getCoordAddr(struct sockaddr *addr, uint32_t *len);
 void setCoordHost(struct in_addr *in);
 uint64_t getCoordTimeStamp();
 
-string getTmpDir();
 char *getTmpDir(char *buf, uint32_t len);
+const char *getTmpDir();
+
 string getInstallDir();
 uint32_t getCkptInterval();
 void updateGeneration(uint32_t generation);

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -225,7 +225,7 @@ RestoreTarget::initialize()
   SharedData::initialize(tmpDir.c_str(), installDir.c_str(), &compId,
                          &coordInfo, &localIPAddr);
 
-  Util::initializeLogFile(SharedData::getTmpDir().c_str(),
+  Util::initializeLogFile(SharedData::getTmpDir(),
                           _pInfo.procname().c_str(), NULL);
 
   if (ckptdir_arg.empty()) {

--- a/src/dmtcp_restart.h
+++ b/src/dmtcp_restart.h
@@ -37,8 +37,8 @@ class RestoreTarget
 
     int fd() const { return _fd; }
 
-    const UniquePid &upid() const { return _pInfo.upid(); }
-    const UniquePid &uppid() const { return _pInfo.uppid(); }
+    const UniquePid &upid() { return _pInfo.upid(); }
+    const UniquePid &uppid() { return _pInfo.uppid(); }
 
     pid_t pid() const { return _pInfo.pid(); }
 

--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -160,10 +160,7 @@ dmtcp_get_ckpt_signal(void)
 EXTERNC const char *
 dmtcp_get_tmpdir(void)
 {
-  static char tmpdir[PATH_MAX];
-
-  JASSERT(SharedData::getTmpDir(tmpdir, sizeof(tmpdir)) != NULL);
-  return tmpdir;
+  return SharedData::getTmpDir();
 }
 
 // EXTERNC void dmtcp_set_tmpdir(const char* dir)
@@ -176,8 +173,7 @@ dmtcp_get_tmpdir(void)
 EXTERNC const char *
 dmtcp_get_ckpt_dir()
 {
-  static string *tmpdir = new string(ProcessInfo::instance().getCkptDir());
-  return tmpdir->c_str();
+  return ProcessInfo::instance().getCkptDir().c_str();
 }
 
 EXTERNC int
@@ -198,17 +194,13 @@ dmtcp_set_ckpt_file(const char *filename)
 EXTERNC const char *
 dmtcp_get_ckpt_filename(void)
 {
-  static string *filename =
-    new string(ProcessInfo::instance().getCkptFilename());
-  return filename->c_str();
+  return ProcessInfo::instance().getCkptFilename().c_str();
 }
 
 EXTERNC const char *
 dmtcp_get_ckpt_files_subdir(void)
 {
-  static string *tmpdir =
-    new string(ProcessInfo::instance().getCkptFilesSubDir());
-  return tmpdir->c_str();
+  return ProcessInfo::instance().getCkptFilesSubDir().c_str();
 }
 
 EXTERNC int
@@ -232,33 +224,25 @@ dmtcp_get_executable_path(void)
 EXTERNC const char *
 dmtcp_get_uniquepid_str(void)
 {
-  static string *uniquepid_str =
-    new string(UniquePid::ThisProcess(true).toString());
-  return uniquepid_str->c_str();
+  return ProcessInfo::instance().upidStr().c_str();
 }
 
 EXTERNC DmtcpUniqueProcessId
 dmtcp_get_uniquepid(void)
 {
-  return UniquePid::ThisProcess().upid();
+  return ProcessInfo::instance().upid().upid();
 }
 
 EXTERNC DmtcpUniqueProcessId
 dmtcp_get_computation_id(void)
 {
-  return SharedData::getCompId();
+  return ProcessInfo::instance().compGroup().upid();
 }
 
 EXTERNC const char *
 dmtcp_get_computation_id_str(void)
 {
-  static string *compid_str = NULL;
-
-  if (compid_str == NULL) {
-    UniquePid compId = SharedData::getCompId();
-    compid_str = new string(compId.toString());
-  }
-  return compid_str->c_str();
+  return ProcessInfo::instance().compGroupStr().c_str();
 }
 
 EXTERNC DmtcpUniqueProcessId

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -181,7 +181,7 @@ prepareLogAndProcessdDataFromSerialFile()
     jalib::JBinarySerializeReaderRaw rd("", PROTECTED_LIFEBOAT_FD);
     rd.rewind();
     UniquePid::serialize(rd);
-    Util::initializeLogFile(SharedData::getTmpDir().c_str(),
+    Util::initializeLogFile(SharedData::getTmpDir(),
                             NULL,
                             prevLogFilePath.c_str());
 
@@ -194,7 +194,7 @@ prepareLogAndProcessdDataFromSerialFile()
   } else {
     // Brand new process (was never under ckpt-control),
     // Initialize the log file
-    Util::initializeLogFile(SharedData::getTmpDir().c_str(), NULL, NULL);
+    Util::initializeLogFile(SharedData::getTmpDir(), NULL, NULL);
 
     JTRACE("Root of processes tree");
     ProcessInfo::instance().setRootOfProcessTree();

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -398,6 +398,11 @@ ProcessInfo::resetOnFork()
   DmtcpMutexInit(&tblLock, DMTCP_MUTEX_NORMAL);
   _ppid = _pid;
   _pid = getpid();
+
+  _upid = UniquePid();
+  _uppid = UniquePid();
+  _upidStr.clear();
+
   _isRootOfProcessTree = false;
   _pthreadJoinId.clear();
   _ckptFileName.clear();

--- a/src/processinfo.h
+++ b/src/processinfo.h
@@ -70,10 +70,6 @@ class ProcessInfo
 
     void serialize(jalib::JBinarySerializer &o);
 
-    UniquePid compGroup() { return _compGroup; }
-
-    void compGroup(UniquePid cg) { _compGroup = cg; }
-
     uint32_t numPeers() { return _numPeers; }
 
     void numPeers(uint32_t np) { _numPeers = np; }
@@ -106,9 +102,40 @@ class ProcessInfo
 
     const string &hostname() const { return _hostname; }
 
-    const UniquePid &upid() const { return _upid; }
+    const UniquePid &upid() {
+      // Temporary fix until we remove the static members from UniquePid.cpp.
+      if (_upid == UniquePid()) {
+        _upid = UniquePid::ThisProcess(true);
+      }
+      return _upid;
+    }
 
-    const UniquePid &uppid() const { return _uppid; }
+    const string &upidStr() {
+      if (_upidStr.empty()) {
+        _upidStr = upid().toString();
+      }
+      return _upidStr;
+    }
+
+    const UniquePid &uppid() {
+      // Temporary fix until we remove the static members from UniquePid.cpp.
+      if (_uppid == UniquePid()) {
+        _uppid = UniquePid::ParentProcess();
+      }
+      return _uppid;
+    }
+
+    UniquePid compGroup() const { return _compGroup; }
+
+    const string &compGroupStr() {
+      if (_compGroupStr.empty()) {
+        _compGroupStr = _compGroup.toString();
+      }
+      return _compGroupStr;
+    }
+
+    void compGroup(UniquePid cg) { _compGroup = cg; }
+
 
     bool isOrphan() const { return _ppid == 1; }
 
@@ -138,12 +165,12 @@ class ProcessInfo
                             uint64_t f3, uint64_t f4);
     uint64_t endOfStack(void) const { return _endOfStack; }
 
-    string getCkptFilename() const { return _ckptFileName; }
+    string const& getCkptFilename() const { return _ckptFileName; }
     string getTempCkptFilename() const { return _ckptFileName + ".temp"; }
 
-    string getCkptFilesSubDir() const { return _ckptFilesSubDir; }
+    string const& getCkptFilesSubDir() const { return _ckptFilesSubDir; }
 
-    string getCkptDir() const { return _ckptDir; }
+    string const& getCkptDir() const { return _ckptDir; }
 
     void setCkptDir(const char *);
     void setCkptFilename(const char *);
@@ -193,6 +220,9 @@ class ProcessInfo
     UniquePid _upid;
     UniquePid _uppid;
     UniquePid _compGroup;
+
+    string _upidStr;
+    string _compGroupStr;
 
     uint64_t _restoreBufAddr;
     uint64_t _restoreBufLen;

--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -340,14 +340,14 @@ SharedData::coordPort()
   return ntohs(sin->sin_port);
 }
 
-string
+const char *
 SharedData::getTmpDir()
 {
   if (sharedDataHeader == NULL) {
     initialize();
   }
   JASSERT(sharedDataHeader->tmpDir[0] != '\0');
-  return string(sharedDataHeader->tmpDir);
+  return sharedDataHeader->tmpDir;
 }
 
 char *


### PR DESCRIPTION
Initializing static members relied on untimely usage of new, causing deadlock due to malloc wrappers, etc..