### PR TITLE
Various logging improvements.

### DIFF
--- a/include/shareddata.h
+++ b/include/shareddata.h
@@ -162,12 +162,10 @@ struct Header {
 bool initialized();
 
 void initialize(const char *tmpDir = NULL,
-                const char *installDir = NULL,
                 DmtcpUniqueProcessId *compId = NULL,
                 CoordinatorInfo *coordInfo = NULL,
                 struct in_addr *localIPAddr = NULL);
 void initializeHeader(const char *tmpDir,
-                      const char *installDir,
                       DmtcpUniqueProcessId *compId,
                       CoordinatorInfo *coordInfo,
                       struct in_addr *localIP);

--- a/include/util.h
+++ b/include/util.h
@@ -148,9 +148,7 @@ int readLine(int fd, char *buf, int count);
 
 void writeCoordPortToFile(int port, const char *portFile);
 char *calcTmpDir(const char *tmpDir);
-void initializeLogFile(const char *tmpDir,
-                       const char *procname = "",
-                       const char *preLogPath = "");
+void initializeLogFile(const char *tmpDir, const char *prefix = "dmtcpworker");
 
 void adjustRlimitStack();
 

--- a/jalib/jalib.cpp
+++ b/jalib/jalib.cpp
@@ -219,6 +219,12 @@ readAll(int fd, void *buf, size_t count)
   REAL_FUNC_PASSTHROUGH(ssize_t, readAll) (fd, buf, count);
 }
 
+pid_t
+gettid()
+{
+  REAL_FUNC_PASSTHROUGH(pid_t, gettid) ();
+}
+
 bool
 strEndsWith(const char *str, const char *pattern)
 {

--- a/jalib/jalib.h
+++ b/jalib/jalib.h
@@ -50,6 +50,7 @@ typedef struct JalibFuncPtrs {
                     socklen_t optlen);
   ssize_t (*writeAll)(int fd, const void *buf, size_t count);
   ssize_t (*readAll)(int fd, void *buf, size_t count);
+  pid_t (*gettid)();
 } JalibFuncPtrs;
 
 namespace jalib
@@ -82,6 +83,8 @@ int setsockopt(int s,
 
 ssize_t writeAll(int fd, const void *buf, size_t count);
 ssize_t readAll(int fd, void *buf, size_t count);
+
+pid_t gettid();
 
 bool strEndsWith(const char *str, const char *pattern);
 }

--- a/jalib/jassert.cpp
+++ b/jalib/jassert.cpp
@@ -28,7 +28,9 @@
 #include <unistd.h>
 
 #include <execinfo.h>  /* For backtrace() */
+#include <chrono>
 #include <fstream>
+#include <iomanip>
 
 #include "jalib.h"
 #include "jassert.h"
@@ -72,10 +74,19 @@ jassert_internal::JAssert::JAssert(bool exitWhenDone)
   , JASSERT_CONT_B(*this)
   , _exitWhenDone(exitWhenDone)
 {
+  using namespace std::chrono;
+
   if (exitWhenDone) {
     Print(redEscapeStr);
     Print("\n");
   }
+
+  time_point<system_clock> now = system_clock::now();
+  std::time_t ts = system_clock::to_time_t(now);
+  uint64_t ms = duration_cast<milliseconds>(now.time_since_epoch()).count() % 1000;
+
+  ss << "[" << std::put_time(std::localtime(&ts), "%F, %T.") << ms << ", "
+     << getpid() << ", " << jalib::gettid() << "] ";
 }
 
 jassert_internal::JAssert::~JAssert()

--- a/jalib/jassert.h
+++ b/jalib/jassert.h
@@ -139,7 +139,7 @@ class JAssert
 
 
 const char *jassert_basename(const char *str);
-dmtcp::ostream &jassert_output_stream();
+dmtcp::ostream &output_stream();
 void jassert_init();
 void close_stderr();
 
@@ -147,11 +147,7 @@ template<typename T>
 inline JAssert&
 JAssert::Print(const T &t)
 {
-#ifdef JASSERT_FAST
-  jassert_output_stream() << t;
-#else // ifdef JASSERT_FAST
   ss << t;
-#endif // ifdef JASSERT_FAST
   return *this;
 }
 
@@ -159,11 +155,7 @@ inline JAssert&
 JAssert::Print(const char *t)
 {
   if (t != NULL) {
-#ifdef JASSERT_FAST
-    jassert_output_stream() << *t;
-#else // ifdef JASSERT_FAST
     ss << t;
-#endif // ifdef JASSERT_FAST
   }
   return *this;
 }
@@ -206,8 +198,7 @@ void open_log_file();
 #define JASSERT_LINE JASSERT_STRINGIFY(__LINE__)
 #define JASSERT_FILE jassert_internal::jassert_basename(__FILE__)
 #define JASSERT_CONTEXT(type, reason)                                           \
-  Print('[').Print(getpid()).Print(                                             \
-    "] " type " at ").Print(JASSERT_FILE).Print(":" JASSERT_LINE " in ").Print( \
+  Print(type " at ").Print(JASSERT_FILE).Print(":" JASSERT_LINE " in ").Print(  \
     JASSERT_FUNC).Print("; REASON='" reason "'\n")
 
 #ifdef LOGGING

--- a/jalib/jassert.h
+++ b/jalib/jassert.h
@@ -104,10 +104,6 @@ class JAssert
     JAssert &Text(const char *msg);
 
     ///
-    /// prints stack backtrace and always returns true
-    JAssert &jbacktrace();
-
-    ///
     /// constructor: sets members
     JAssert(bool exitWhenDone);
 
@@ -128,6 +124,13 @@ class JAssert
     { Print(t); return *this; }
 
   private:
+    void PrintFileContents(int fd);
+    void PrintProcMaps();
+    void PrintBacktrace();
+
+    void writeToConsole(const char *);
+    void writeToLog(const char *);
+
     ///
     /// if set true (on construction) call exit() on destruction
     bool _exitWhenDone;
@@ -137,7 +140,6 @@ class JAssert
 
 const char *jassert_basename(const char *str);
 dmtcp::ostream &jassert_output_stream();
-void jassert_safe_print(const char *);
 void jassert_init();
 void close_stderr();
 
@@ -176,15 +178,13 @@ JAssert::Print(const dmtcp::vector<T> &t)
   return *this;
 }
 
-void set_log_file(const dmtcp::string &path,
-                  const dmtcp::string tmpDir,
-                  const dmtcp::string &uniquePidStr);
+void set_log_file(const dmtcp::string &path);
+void open_log_file();
 }// jassert_internal
 
 #define JASSERT_INIT(p) (jassert_internal::jassert_init());
 
-#define JASSERT_SET_LOG(log, tmpdir, uniquePidStr) \
-  (jassert_internal::set_log_file(log, tmpdir, uniquePidStr));
+#define JASSERT_SET_LOG(log) (jassert_internal::set_log_file(log));
 
 #define JASSERT_CLOSE_STDERR() (jassert_internal::close_stderr());
 

--- a/jalib/jconvert.h
+++ b/jalib/jconvert.h
@@ -71,7 +71,7 @@ XToString(const X &x, bool hexOutput = false)
   dmtcp::ostringstream tmp;
 
   if (hexOutput) {
-    tmp << "0x" << std::hex << x;
+    tmp << std::hex << x;
   } else {
     tmp << x;
   }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -196,7 +196,7 @@ __d_bindir__dmtcp_coordinator_SOURCES = dmtcp_coordinator.cpp 	\
 __d_bindir__dmtcp_coordinator_LDADD = libdmtcpinternal.a 	\
 				      libjalib.a 		\
 				      libnohijack.a		\
-				      -lpthread -lrt
+				      -lpthread -lrt -ldl
 
 __d_bindir__dmtcp_launch_SOURCES = dmtcp_launch.cpp
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -696,7 +696,7 @@ __d_bindir__dmtcp_coordinator_SOURCES = dmtcp_coordinator.cpp 	\
 					restartscript.cpp
 
 __d_bindir__dmtcp_coordinator_LDADD = libdmtcpinternal.a libjalib.a \
-	libnohijack.a -lpthread -lrt $(am__append_2)
+	libnohijack.a -lpthread -lrt -ldl $(am__append_2)
 __d_bindir__dmtcp_launch_SOURCES = dmtcp_launch.cpp
 __d_bindir__dmtcp_launch_LDADD = libdmtcpinternal.a libjalib.a \
 	libnohijack.a -lpthread -lrt -ldl $(am__append_3)

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -1756,7 +1756,7 @@ main(int argc, char **argv)
   }
 
   tmpDir = Util::calcTmpDir(tmpdir_arg);
-  Util::initializeLogFile(tmpDir, NULL, NULL);
+  Util::initializeLogFile(tmpDir, "dmtcp_coordinator");
 
   JTRACE("New DMTCP coordinator starting.")
     (UniquePid::ThisProcess());
@@ -1844,7 +1844,7 @@ main(int argc, char **argv)
       JASSERT(dup2(fd, STDIN_FILENO) == STDIN_FILENO);
     } else {
       fd = open(logFilename.c_str(), O_CREAT | O_WRONLY | O_APPEND, 0666);
-      JASSERT_SET_LOG(logFilename, "", "");
+      JASSERT_SET_LOG(logFilename);
       int nullFd = open("/dev/null", O_RDWR);
       JASSERT(dup2(nullFd, STDIN_FILENO) == STDIN_FILENO);
       close(nullFd);

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -137,55 +137,13 @@ DmtcpWorker::determineCkptSignal()
   return sig;
 }
 
-static string
-getLogFilePath()
-{
-#ifdef LOGGING
-  ostringstream o;
-  o << "/proc/self/fd/" << PROTECTED_JASSERTLOG_FD;
-  return jalib::Filesystem::ResolveSymlink(o.str());
-
-#else // ifdef LOGGING
-  return "";
-#endif // ifdef LOGGING
-}
-
-static void
-writeCurrentLogFileNameToPrevLogFile(string &path)
-{
-#ifdef LOGGING
-  ostringstream o;
-  o << "========================================\n"
-    << "This process exec()'d into a new program\n"
-    << "Program Name: " << jalib::Filesystem::GetProgramName() << "\n"
-    << "New JAssertLog Path: " << getLogFilePath() << "\n"
-    << "========================================\n";
-
-  int fd = open(path.c_str(), O_WRONLY | O_APPEND, 0);
-  if (fd != -1) {
-    Util::writeAll(fd, o.str().c_str(), o.str().length());
-  }
-  _real_close(fd);
-#endif // ifdef LOGGING
-}
-
 static void
 prepareLogAndProcessdDataFromSerialFile()
 {
   if (Util::isValidFd(PROTECTED_LIFEBOAT_FD)) {
-    // This process was under ckpt-control and exec()'d into a new program.
-    // Find out path of previous log file so that later, we can write the name
-    // of the new log file into that one.
-    string prevLogFilePath = getLogFilePath();
-
     jalib::JBinarySerializeReaderRaw rd("", PROTECTED_LIFEBOAT_FD);
     rd.rewind();
     UniquePid::serialize(rd);
-    Util::initializeLogFile(SharedData::getTmpDir(),
-                            NULL,
-                            prevLogFilePath.c_str());
-
-    writeCurrentLogFileNameToPrevLogFile(prevLogFilePath);
 
     DmtcpEventData_t edata;
     edata.postExec.serializationFd = PROTECTED_LIFEBOAT_FD;
@@ -193,8 +151,9 @@ prepareLogAndProcessdDataFromSerialFile()
     _real_close(PROTECTED_LIFEBOAT_FD);
   } else {
     // Brand new process (was never under ckpt-control),
+
     // Initialize the log file
-    Util::initializeLogFile(SharedData::getTmpDir(), NULL, NULL);
+    Util::initializeLogFile(SharedData::getTmpDir());
 
     JTRACE("Root of processes tree");
     ProcessInfo::instance().setRootOfProcessTree();

--- a/src/execwrappers.cpp
+++ b/src/execwrappers.cpp
@@ -109,12 +109,12 @@ dmtcp_atfork_child()
 {
   ThreadSync::resetLocks();
 
+  // Initialize the log file
+  Util::initializeLogFile(SharedData::getTmpDir());
+
   // Some plugins might make calls that require wrapper locks, etc.
   // Therefore, it is better to call this hook after we reset all locks.
   PluginManager::eventHook(DMTCP_EVENT_ATFORK_CHILD, NULL);
-
-  string child_name = jalib::Filesystem::GetProgramName() + "_(forked)";
-  Util::initializeLogFile(dmtcp_get_tmpdir(), child_name.c_str(), NULL);
 
   DmtcpWorker::resetOnFork();
 }
@@ -283,9 +283,7 @@ vfork()
   } else if (vforkPid == 0) { /* child process */
     PluginManager::eventHook(DMTCP_EVENT_VFORK_CHILD, NULL);
 
-    string child_name =
-      jalib::Filesystem::GetProgramName() + "_(forked)";
-    Util::initializeLogFile(dmtcp_get_tmpdir(), child_name.c_str(), NULL);
+    Util::initializeLogFile(SharedData::getTmpDir());
 
     WorkerState::setCurrentState(WorkerState::RUNNING);
 

--- a/src/execwrappers.cpp
+++ b/src/execwrappers.cpp
@@ -109,9 +109,6 @@ dmtcp_atfork_child()
 {
   ThreadSync::resetLocks();
 
-  // Initialize the log file
-  Util::initializeLogFile(SharedData::getTmpDir());
-
   // Some plugins might make calls that require wrapper locks, etc.
   // Therefore, it is better to call this hook after we reset all locks.
   PluginManager::eventHook(DMTCP_EVENT_ATFORK_CHILD, NULL);

--- a/src/jalibinterface.cpp
+++ b/src/jalibinterface.cpp
@@ -58,6 +58,8 @@ initializeJalib()
   INIT_JALIB_FPTR(accept);
   INIT_JALIB_FPTR(setsockopt);
 
+  jalibFuncPtrs.gettid = dmtcp_gettid;
+
   jalib_init(jalibFuncPtrs,
              ELF_INTERPRETER,
              PROTECTED_STDERR_FD,

--- a/src/plugin/ipc/event/eventwrappers.cpp
+++ b/src/plugin/ipc/event/eventwrappers.cpp
@@ -212,7 +212,7 @@ epoll_create1(int flags)
   DMTCP_PLUGIN_DISABLE_CKPT();
   int ret = _real_epoll_create1(flags);
   if (ret != -1) {
-    JNOTE("epoll fd created1") (ret) (flags);
+    JTRACE("epoll fd created1") (ret) (flags);
     EventConnList::instance().add(ret, new EpollConnection(0, flags));
   }
   DMTCP_PLUGIN_ENABLE_CKPT();

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -395,6 +395,9 @@ ProcessInfo::postExec()
 void
 ProcessInfo::resetOnFork()
 {
+  // Initialize the log file
+  Util::initializeLogFile(SharedData::getTmpDir());
+
   DmtcpMutexInit(&tblLock, DMTCP_MUTEX_NORMAL);
   _ppid = _pid;
   _pid = getpid();

--- a/src/signalwrappers.cpp
+++ b/src/signalwrappers.cpp
@@ -148,13 +148,12 @@ sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
   if (signum == bannedSignalNumber() && act != NULL) {
     static int alreadyWarned = 0;
     if (!alreadyWarned) {
-      JWARNING(false)(
+      JWARNING(false) (stopSignal) .Text(
         "Application trying to use DMTCP's signal for it's own use.\n"
         "  You should employ a different signal by setting the\n"
         "  environment variable DMTCP_SIGCKPT to the number\n"
         "  of the signal that DMTCP should use for checkpointing.\n"
-        "  (Further warnings will be suppressed.)")
-        (stopSignal);
+        "  (Further warnings will be suppressed.)");
       alreadyWarned = 1;
     }
     act = NULL;

--- a/src/signalwrappers.cpp
+++ b/src/signalwrappers.cpp
@@ -146,12 +146,17 @@ EXTERNC int
 sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
 {
   if (signum == bannedSignalNumber() && act != NULL) {
-    JWARNING(false)(
-      "Application trying to use DMTCP's signal for it's own use.\n"
-      "  You should employ a different signal by setting the\n"
-      "  environment variable DMTCP_SIGCKPT to the number\n"
-      "  of the signal that DMTCP should use for checkpointing.")
-      (stopSignal);
+    static int alreadyWarned = 0;
+    if (!alreadyWarned) {
+      JWARNING(false)(
+        "Application trying to use DMTCP's signal for it's own use.\n"
+        "  You should employ a different signal by setting the\n"
+        "  environment variable DMTCP_SIGCKPT to the number\n"
+        "  of the signal that DMTCP should use for checkpointing.\n"
+        "  (Further warnings will be suppressed.)")
+        (stopSignal);
+      alreadyWarned = 1;
+    }
     act = NULL;
   }
   return _real_sigaction(signum, act, oldact);


### PR DESCRIPTION
Here are some of the improvements:
* File names:
  * One file per process (an exec will not create a new file)
  * Separate files for dmtcp_* commands.
  * Worker files named $TMP/dmtcpworker.<Timestamp>.<UniquePid>.log.
* Logs messages:
  * Add timestamp along with pid, tid and type (error, warning, etc.).
  * Always add a backtrace on JAssert failure;
  * Add /proc/self/maps contents to log on Jassert failure
 
Other code cleanup.