### PR TITLE
Polish configure.ac/configure

### DIFF
--- a/configure
+++ b/configure
@@ -7037,7 +7037,7 @@ else $as_nop
            #include <stdio.h>
            #include <elf.h>
            int main() {
-             printf("DT_GNU_HASH: %d\n", DT_GNU_HASH);
+             printf("(DT_GNU_HASH: %d) ", DT_GNU_HASH);
              return 0;
            }
 
@@ -7192,8 +7192,6 @@ else
   HAS_EPOLL_CREATE1=no
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $epoll_create1" >&5
-printf "%s\n" "$epoll_create1" >&6; }
 
 #check for -lreadline -lhistory v5; does not require curses
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for readline in -lreadline" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -486,7 +486,7 @@ AC_TRY_RUN([
            #include <stdio.h>
            #include <elf.h>
            int main() {
-             printf("DT_GNU_HASH: %d\n", DT_GNU_HASH);
+             printf("(DT_GNU_HASH: %d) ", DT_GNU_HASH);
              return 0;
            }
            ], [has_gnu_hash='yes'], [has_gnu_hash='no'])
@@ -509,13 +509,13 @@ if test "$has_pr_set_ptracer" == "yes"; then
 fi
 AC_MSG_RESULT([$has_pr_set_ptracer])
 
-dnl CMA brought in with  Linux 3.2.0 and glibc 2.15
-dnl Around Feb., 2018, docker forbids process_vm_readv even though it's in
+dnl CMA (Cross Memory Attach) brought in with  Linux 3.2.0 and glibc 2.15
+dnl Around Feb., 2018, Docker forbids process_vm_readv even though it's in
 dnl   libc.so.  So, AC_CHECK_FUNC is not sufficient.  Use AC_TRY_RUN.
 AC_MSG_CHECKING([if process_vm_readv/process_vm_writev (CMA) available])
 dnl AC_CHECK_FUNC(process_vm_readv, [has_cma='yes'], [has_cma='no'])
 AC_TRY_RUN([
-       #define _GNU_SOURCE 
+       #define _GNU_SOURCE
        #include <sys/types.h>
        #include <unistd.h>
        #include <sys/wait.h>
@@ -569,7 +569,6 @@ if test "$has_epoll_create1" == "yes"; then
 else
   AC_SUBST([HAS_EPOLL_CREATE1], [no])
 fi
-AC_MSG_RESULT([$epoll_create1])
 
 #check for -lreadline -lhistory v5; does not require curses
 AC_CHECK_LIB([readline], [readline], [linksReadline=yes], [linksReadline=no], [-lhistory -lcurses])


### PR DESCRIPTION
Local,  minor changes to configure.ac:
1. OUTPUT: `checking whether GNU_HASH is supported for ELF... (DT_GNU_HASH: 1879047925) yes`
    (Added '(' and ')' around `DT_GNU_HASH` for clarity.
2. configure.ac:  `#define _GNU_SOURCE ` -- remove extra space at end of line
3. configure.ac:  remove:  `AC_MSG_RESULT([$epoll_create1])`
    (This causes an extra blank line to appear after `checking if epoll_create1 available... checking for epoll_create1... yes`;
     when the previous `AC_MSG_CHECKING([if epoll_create1 available])` already emitted `yes`.)