### PR TITLE
Remove SYSV segments from bookeeping when detached from all processes…

### DIFF
--- a/src/plugin/svipc/sysvipc.h
+++ b/src/plugin/svipc/sysvipc.h
@@ -98,6 +98,7 @@ class SysVIPC
     int virtualToRealId(int virtId);
     int realToVirtualId(int realId);
     void updateMapping(int virtId, int realId);
+    void removeMappingsByVirtualId(int virtId);
     int getNewVirtualId();
     void serialize(jalib::JBinarySerializer &o);
 
@@ -156,6 +157,7 @@ class SysVShm : public SysVIPC
                           int shmflg,
                           void *newaddr) override;
     virtual void on_shmdt(const void *shmaddr) override;
+    void pre_shmdt(const void *shmaddr);
 
     virtual SysVIPC* cloneInstance() override { return new SysVShm(*this); }
 
@@ -272,6 +274,7 @@ class ShmSegment : public SysVObj
     virtual void postRestart() override;
     virtual void refill() override;
     virtual void preResume() override;
+    void pre_shmdt();
 
     virtual SysVObj* clone() override
     {

--- a/src/plugin/svipc/sysvipcwrappers.cpp
+++ b/src/plugin/svipc/sysvipcwrappers.cpp
@@ -169,6 +169,7 @@ shmdt(const void *shmaddr)
 {
   DMTCP_PLUGIN_DISABLE_CKPT();
   inside_shmdt = true;
+  SysVShm::instance().pre_shmdt(shmaddr);
   int ret = _real_shmdt(shmaddr);
   if (ret != -1) {
     SysVShm::instance().on_shmdt(shmaddr);


### PR DESCRIPTION
1. Before shmdt call, update the SHM Segment's local flags on number of attached process and if it is marked for deletion
2. If shmdt is successful, the previous nattch=1, and it is marked from deletion, remove from SysVIPC bookeeping

This ensures we don't try to restore any segments that have been deleted already.