### PR TITLE
Shm hugetlb

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -1359,6 +1359,9 @@ remapMtcpRestartToReservedArea(RestoreInfo *rinfo)
     }
   }
 
+  mtcp_sys_close(mtcp_restart_fd);
+  mtcp_restart_fd = -1;
+
   // Create a guard page without read permissions and use the remaining region
   // for the stack.
 

--- a/src/mtcp/mtcp_util.c
+++ b/src/mtcp/mtcp_util.c
@@ -831,14 +831,17 @@ void* mmap_fixed_noreplace(void *addr, size_t len, int prot, int flags,
   }
   void *addr2 = mtcp_sys_mmap(addr, len, prot, flags, fd, offset);
   if (addr == addr2) {
+    DPRINTF("Mapped %p bytes at %p\n", len, addr);
     return addr2;
   } else if (addr2 != MAP_FAILED) {
     // undo the mmap
+    MTCP_PRINTF("error mapping %p bytes at %p; mapped at %p instead\n", len, addr, addr2);
     mtcp_sys_munmap(addr2, len);
     mtcp_sys_errno = EEXIST;
     return MAP_FAILED;
   } else {
     // the mmap really did fail
+    MTCP_PRINTF("error %d mapping %p bytes at %p, flags: %p, prot :%p\n", mtcp_sys_errno, len, addr, flags, prot);
     return MAP_FAILED;
   }
 }

--- a/src/procselfmaps.cpp
+++ b/src/procselfmaps.cpp
@@ -239,7 +239,9 @@ ProcSelfMaps::getNextArea(ProcMapsArea *area)
   if (sflag == 'p') {
     area->flags |= MAP_PRIVATE;
   }
-  if (area->name[0] == '\0') {
+
+  if (area->name[0] == '\0' ||
+      area->name[0] == '[') { // [heap], [stack], etc.
     area->flags |= MAP_ANONYMOUS;
   }
 

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -74,7 +74,7 @@ vector<ProcMapsArea> *nscdAreas = NULL;
 /* Internal routines */
 
 // static void sync_shared_mem(void);
-static void writememoryarea(int fd, Area *area, int stack_was_seen);
+static void writememoryarea(int fd, Area *area);
 
 static void remap_nscd_areas(const vector<ProcMapsArea> &areas);
 
@@ -99,9 +99,6 @@ void
 mtcp_writememoryareas(int fd)
 {
   Area area;
-
-  // DeviceInfo dev_info;
-  int stack_was_seen = 0;
 
   if (getenv(ENV_VAR_SKIP_WRITING_TEXT_SEGMENTS) != NULL) {
     skipWritingTextSegments = true;
@@ -329,17 +326,8 @@ mtcp_writememoryareas(int fd)
       area.flags |= MAP_ANONYMOUS;
     }
 
-    /* Only write this image if it is not CS_RESTOREIMAGE.
-     * Skip any mapping for this image - it got saved as CS_RESTOREIMAGE
-     * at the beginning.
-     */
-
-    if (strstr(area.name, "[stack]")) {
-      stack_was_seen = 1;
-    }
-
     // the whole thing comes after the restore image
-    writememoryarea(fd, &area, stack_was_seen);
+    writememoryarea(fd, &area);
   }
 
   // Release the memory.
@@ -478,7 +466,7 @@ mtcp_write_non_rwx_and_anonymous_pages(int fd, Area *orig_area)
 }
 
 static void
-writememoryarea(int fd, Area *area, int stack_was_seen)
+writememoryarea(int fd, Area *area)
 {
   int rc = 0;
   void *addr = area->addr;

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -1308,7 +1308,7 @@ if HAS_OPENMPI == "yes":
     del os.environ['PATH']
 
 # Test DMTCP utilities:
-runTest("nocheckpoint",        1, ["./test/nocheckpoint"])
+runTest("nocheckpoint",        [1,2], ["./test/nocheckpoint"])
 
 print("== Summary ==")
 print("%s: %d of %d tests passed" % (socket.gethostname(), stats[0], stats[1]))

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -1019,6 +1019,7 @@ os.environ['DMTCP_GZIP'] = GZIP
 S=10*DEFAULT_S
 runTest("shared-memory1", 2, ["./test/shared-memory1"])
 runTest("shared-memory2", 2, ["./test/shared-memory2"])
+#runTest("shared-memory3", 2, ["./test/shared-memory3"])
 S=DEFAULT_S
 
 runTest("sysv-shm1",     2, ["./test/sysv-shm1"])

--- a/test/shared-memory3.c
+++ b/test/shared-memory3.c
@@ -1,0 +1,65 @@
+// _DEFAULT_SOURCE for mkstemp  (WHY?)
+#define _DEFAULT_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+// For open()
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#define ATOMIC_SHARED volatile __attribute((aligned))
+
+int *sharedMemory;
+void reader();
+void writer();
+
+int
+main()
+{
+  sharedMemory = mmap(0, 4096, PROT_READ | PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0);
+  if (sharedMemory == MAP_FAILED) {
+    perror("mmap");
+    exit(1);
+  }
+
+  *sharedMemory = -1;
+
+  if (fork()) {
+    writer();
+  } else {
+    reader();
+  }
+
+  return 0;
+}
+
+void
+reader()
+{
+  ATOMIC_SHARED int val;
+  int i = 0;
+
+  while (1) {
+    val = *sharedMemory;
+    if (val != i) {
+      i = *sharedMemory;
+      printf("reader %d \n", i);
+      fflush(stdout);
+    }
+    sleep(1);
+  }
+}
+
+void
+writer()
+{
+  for (int i = 0;; i++) {
+    *sharedMemory = i;
+    printf("writer: %d \n", i);
+    sleep(2);
+  }
+}


### PR DESCRIPTION
Previously, checkpoint-restart was not properly preserving zero pages in the case of SysV shared memory (SYSV000XXX memory segments), when hugepages were enabled.  As a result, on restart, the memory being used by the process would grow because those zero pages would be replaced by actual pages of zeroes.

This is code from @karya0 and based on his branch.  He asked me to create the PR.  This should fix a case where MANA was using excessive RAM  on restart.