### PR TITLE
For gcc-4.8, std::put_time was failing

### DIFF
--- a/jalib/jassert.cpp
+++ b/jalib/jassert.cpp
@@ -87,7 +87,14 @@ jassert_internal::JAssert::JAssert(const char* type, bool exitWhenDone)
     Print("\n");
   }
 
-  ss << "[" << std::put_time(&localTime, "%F, %T.") << ms << ", "
+  ss << "[" 
+#if __GCC__ > 4
+    // put_time introduced in commit b2823e39 (July, 2022)
+    // In CentOS 7 using gcc/g++ 4.8.5, this fails with:
+    //      error: ‘put_time’ is not a member of ‘std’ 
+     << std::put_time(&localTime, "%F, %T.")
+#endif
+     << ms << ", "
      << getpid() << ", " << jalib::gettid() << ", " << type << "] ";
 }
 

--- a/src/util_init.cpp
+++ b/src/util_init.cpp
@@ -129,7 +129,12 @@ Util::initializeLogFile(const char *tmpDir, const char *prefix)
 
   ostringstream o;
   o << tmpDir << "/" << prefix
+#if __GCC__ > 4
+    // put_time introduced in commit b2823e39 (July, 2022)
+    // In CentOS 7 using gcc/g++ 4.8.5, this fails with:
+    //      error: ‘put_time’ is not a member of ‘std’
     << "." << std::put_time(&localTime, "%FT%T%z")
+#endif
     << "." << UniquePid::ThisProcess()
     << ".log";
   JASSERT_SET_LOG(o.str().c_str());


### PR DESCRIPTION
std::put_time was introduced in commit b2823e39 (July, 2022)

Apparently, gcc-4.8 (and therefore CentOS 7) doesn't support it.  I added a conditional around it: `#if __GCC__ > 4`