### PR TITLE
Updated zero-page restoration support.

### DIFF
--- a/include/procmapsarea.h
+++ b/include/procmapsarea.h
@@ -65,9 +65,8 @@ typedef char *VA;  /* VA = virtual address */
 
 typedef enum ProcMapsAreaProperties {
   DMTCP_ZERO_PAGE                  = 0x0001,
-  DMTCP_SKIP_WRITING_TEXT_SEGMENTS = 0x0002,
-  DMTCP_ZERO_PAGE_PARENT_HEADER    = 0x0004,
-  DMTCP_ZERO_PAGE_CHILD_HEADER     = 0x0008
+  DMTCP_ZERO_PAGE_PARENT_HEADER    = 0x0002,
+  DMTCP_ZERO_PAGE_CHILD_HEADER     = 0x0004
 } ProcMapsAreaProperties;
 
 typedef union ProcMapsArea {

--- a/include/procmapsarea.h
+++ b/include/procmapsarea.h
@@ -64,8 +64,10 @@ extern "C" {
 typedef char *VA;  /* VA = virtual address */
 
 typedef enum ProcMapsAreaProperties {
-  DMTCP_ZERO_PAGE = 0x0001,
-  DMTCP_SKIP_WRITING_TEXT_SEGMENTS = 0x0002
+  DMTCP_ZERO_PAGE                  = 0x0001,
+  DMTCP_SKIP_WRITING_TEXT_SEGMENTS = 0x0002,
+  DMTCP_ZERO_PAGE_PARENT_HEADER    = 0x0004,
+  DMTCP_ZERO_PAGE_CHILD_HEADER     = 0x0008
 } ProcMapsAreaProperties;
 
 typedef union ProcMapsArea {

--- a/src/constants.h
+++ b/src/constants.h
@@ -96,8 +96,6 @@
 
 // Keep in sync with plugin/batch-queue/rm_pmi.h
 #define ENV_VAR_EXPLICIT_SRUN       "DMTCP_EXPLICIT_SRUN"
-#define ENV_VAR_SKIP_WRITING_TEXT_SEGMENTS \
-                                    "DMTCP_SKIP_WRITING_TEXT_SEGMENTS"
 
 #define ENV_VAR_COORD_LOGFILE       "DMTCP_COORD_LOG_FILENAME"
 
@@ -141,7 +139,6 @@
   ENV_VAR_SIGCKPT,                    \
   ENV_VAR_SCREENDIR,                  \
   ENV_VAR_VIRTUAL_PID,                \
-  ENV_VAR_SKIP_WRITING_TEXT_SEGMENTS, \
   ENV_DELTACOMPRESSION
 
 #define DMTCP_RESTART_CMD       "dmtcp_restart"

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -1093,7 +1093,14 @@ read_one_memory_area(int fd, VA endOfStack)
                 area.size, area.addr, area.name, area.offset);
       }
 
-    /* Create the memory area */
+      /* Create the memory area */
+
+      // If the region is marked as private but without a backing file (i.e.,
+      // the file was deleted on ckpt), restore it as MAP_ANONYMOUS.
+      // TODO: handle huge pages by detecting and passing MAP_HUGETLB in flags.
+      if (imagefd == -1 && (area.flags & MAP_PRIVATE)) {
+        area.flags |= MAP_ANONYMOUS;
+      }
 
       /* POSIX says mmap would unmap old memory.  Munmap never fails if args
       * are valid.  Can we unmap vdso and vsyscall in Linux?  Used to use

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -988,7 +988,7 @@ read_one_memory_area(int fd, VA endOfStack)
   Area area;
 
   mtcp_readfile(fd, &area, sizeof area);
-  if (area.size == -1) {
+  if (area.size <= 0) {
     return -1;
   }
 

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -510,8 +510,10 @@ mtcp_simulateread(int fd, MtcpHeader *mtcpHdr)
     if (area.size == -1) {
       break;
     }
+
     if ((area.properties & DMTCP_ZERO_PAGE) == 0 &&
-        (area.properties & DMTCP_SKIP_WRITING_TEXT_SEGMENTS) == 0) {
+        (area.properties & DMTCP_SKIP_WRITING_TEXT_SEGMENTS) == 0 &&
+        (area.properties & DMTCP_ZERO_PAGE_PARENT_HEADER) == 0) {
 
       off_t seekLen = area.size;
       if (!(area.flags & MAP_ANONYMOUS) && area.mmapFileSize > 0) {
@@ -523,19 +525,20 @@ mtcp_simulateread(int fd, MtcpHeader *mtcpHdr)
       }
     }
 
-    mtcp_printf("%p-%p %c%c%c%c "
+    if ((area.properties & DMTCP_ZERO_PAGE_CHILD_HEADER) == 0) {
+      mtcp_printf("%p-%p %c%c%c%c %s          %s\n",
+                  area.addr, area.endAddr,
+                  ((area.prot & PROT_READ)  ? 'r' : '-'),
+                  ((area.prot & PROT_WRITE) ? 'w' : '-'),
+                  ((area.prot & PROT_EXEC)  ? 'x' : '-'),
+                  ((area.flags & MAP_SHARED)
+                    ? 's'
+                    : ((area.flags & MAP_PRIVATE) ? 'p' : '-')),
+                  ((area.flags & MAP_ANONYMOUS) ? "Anon" : "    "),
 
-                // "%x %u:%u %u"
-                "          %s\n",
-                area.addr, area.endAddr,
-                (area.prot & PROT_READ  ? 'r' : '-'),
-                (area.prot & PROT_WRITE ? 'w' : '-'),
-                (area.prot & PROT_EXEC  ? 'x' : '-'),
-                (area.flags & MAP_SHARED ? 's'
-                 : (area.flags & MAP_ANONYMOUS ? 'p' : '-')),
-
-                // area.offset, area.devmajor, area.devminor, area.inodenum,
-                area.name);
+                  // area.offset, area.devmajor, area.devminor, area.inodenum,
+                  area.name);
+    }
   }
 }
 

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -512,7 +512,6 @@ mtcp_simulateread(int fd, MtcpHeader *mtcpHdr)
     }
 
     if ((area.properties & DMTCP_ZERO_PAGE) == 0 &&
-        (area.properties & DMTCP_SKIP_WRITING_TEXT_SEGMENTS) == 0 &&
         (area.properties & DMTCP_ZERO_PAGE_PARENT_HEADER) == 0) {
 
       off_t seekLen = area.size;
@@ -1140,9 +1139,8 @@ read_one_memory_area(int fd, VA endOfStack)
       }
     }
 
-    if ((area.properties & DMTCP_SKIP_WRITING_TEXT_SEGMENTS) == 0 &&
         // Parent header doesn't have any follow on data.
-        (area.properties & DMTCP_ZERO_PAGE_PARENT_HEADER) == 0) {
+    if ((area.properties & DMTCP_ZERO_PAGE_PARENT_HEADER) == 0) {
       /* This mmapfile after prev. mmap is okay; use same args again.
        *  Posix says prev. map will be munmapped.
        */

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -988,7 +988,7 @@ read_one_memory_area(int fd, VA endOfStack)
   Area area;
 
   mtcp_readfile(fd, &area, sizeof area);
-  if (area.size <= 0) {
+  if (area.addr == NULL) {
     return -1;
   }
 

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -431,7 +431,7 @@ mtcp_write_anonymous_pages(int fd, Area area)
         .Text("writeAll failed during ckpt");
     } else {
       if (madvise(a.addr, a.size, MADV_DONTNEED) == -1) {
-        JNOTE("error doing madvise(..., MADV_DONTNEED)")
+        JTRACE("error doing madvise(..., MADV_DONTNEED)")
           (JASSERT_ERRNO) (a.addr) ((int)a.size);
       }
     }


### PR DESCRIPTION
Instead of mmapping zero-page segments in chunks, we now save a "parent" header in the ckpt-image followed by several "child" headers. The parent header is used only for making the appropriate mmap call. The data-restoration relies on child headers. Each child header is either marked as zero-page segment, in which case, there is no further action needed. For non-zero child segments, the restoration reads the saved data from ckpt image.