### PR TITLE
Replaced std::puttime with Util::getTimestampStr().

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -169,6 +169,8 @@ char *findExecutable(char *executable, const char *path_env, char *exec_path);
 char *getPath(const char *cmd, bool is32bit = false);
 char **getDmtcpArgs();
 void allowGdbDebug(int currentDebugLevel);
+
+string getTimestampStr();
 }
 }
 #endif // ifdef __cplusplus

--- a/jalib/jalib.cpp
+++ b/jalib/jalib.cpp
@@ -219,6 +219,12 @@ readAll(int fd, void *buf, size_t count)
   REAL_FUNC_PASSTHROUGH(ssize_t, readAll) (fd, buf, count);
 }
 
+dmtcp::string
+getTimestampStr()
+{
+  REAL_FUNC_PASSTHROUGH(string, getTimestampStr) ();
+}
+
 pid_t
 gettid()
 {

--- a/jalib/jalib.h
+++ b/jalib/jalib.h
@@ -27,8 +27,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <string>
 
 #include <fstream>
+#include "dmtcpalloc.h"
 
 typedef struct JalibFuncPtrs {
   int (*open)(const char *pathname, int flags, ...);
@@ -50,6 +52,7 @@ typedef struct JalibFuncPtrs {
                     socklen_t optlen);
   ssize_t (*writeAll)(int fd, const void *buf, size_t count);
   ssize_t (*readAll)(int fd, void *buf, size_t count);
+  dmtcp::string (*getTimestampStr)();
   pid_t (*gettid)();
 } JalibFuncPtrs;
 
@@ -83,6 +86,7 @@ int setsockopt(int s,
 
 ssize_t writeAll(int fd, const void *buf, size_t count);
 ssize_t readAll(int fd, void *buf, size_t count);
+dmtcp::string getTimestampStr();
 
 pid_t gettid();
 

--- a/jalib/jassert.cpp
+++ b/jalib/jassert.cpp
@@ -75,27 +75,13 @@ jassert_internal::JAssert::JAssert(const char* type, bool exitWhenDone)
   , JASSERT_CONT_B(*this)
   , _exitWhenDone(exitWhenDone)
 {
-  struct timeval tv;
-  struct tm localTime;
-
-  gettimeofday(&tv, NULL);
-  localtime_r(&tv.tv_sec, &localTime);
-  uint64_t ms = tv.tv_usec % 1000;
-
   if (exitWhenDone) {
     Print(redEscapeStr);
     Print("\n");
   }
 
-  ss << "[" 
-#if __GCC__ > 4
-    // put_time introduced in commit b2823e39 (July, 2022)
-    // In CentOS 7 using gcc/g++ 4.8.5, this fails with:
-    //      error: ‘put_time’ is not a member of ‘std’ 
-     << std::put_time(&localTime, "%F, %T.")
-#endif
-     << ms << ", "
-     << getpid() << ", " << jalib::gettid() << ", " << type << "] ";
+  ss << "[" << jalib::getTimestampStr() << ", "
+     << getpid() << ", " << jalib::gettid() << ", " << type << "]";
 }
 
 jassert_internal::JAssert::~JAssert()
@@ -302,7 +288,8 @@ void jassert_internal::open_log_file()
   if (theLogFileFd != -1) {
     dmtcp::ostringstream a;
 
-    a << "[" << getpid() << "] INFO at " << JASSERT_FILE << ":" << JASSERT_LINE
+    a << "[" << jalib::getTimestampStr() << ", " << getpid() << ", "
+      << jalib::gettid() << ", INFO] at " << JASSERT_FILE << ":" << JASSERT_LINE
       << " in " << JASSERT_FUNC << "; REASON='Program: " << Filesystem::GetProgramName()
       << "'\n  Environment:";
 

--- a/src/jalibinterface.cpp
+++ b/src/jalibinterface.cpp
@@ -25,6 +25,7 @@
 #include "../jalib/jassert.h"
 #include "../jalib/jbuffer.h"
 #include "dmtcp.h"
+#include "dmtcpalloc.h"
 #include "protectedfds.h"
 #include "syscallwrappers.h"
 #include "util.h"
@@ -40,6 +41,7 @@ initializeJalib()
 
   jalibFuncPtrs.writeAll = Util::writeAll;
   jalibFuncPtrs.readAll = Util::readAll;
+  jalibFuncPtrs.getTimestampStr = Util::getTimestampStr;
 
   INIT_JALIB_FPTR(open);
   INIT_JALIB_FPTR(fopen);

--- a/src/util_init.cpp
+++ b/src/util_init.cpp
@@ -121,20 +121,9 @@ Util::calcTmpDir(const char *tmpdirenv)
 void
 Util::initializeLogFile(const char *tmpDir, const char *prefix)
 {
-  struct timeval tv;
-  struct tm localTime;
-
-  gettimeofday(&tv, NULL);
-  localtime_r(&tv.tv_sec, &localTime);
-
   ostringstream o;
   o << tmpDir << "/" << prefix
-#if __GCC__ > 4
-    // put_time introduced in commit b2823e39 (July, 2022)
-    // In CentOS 7 using gcc/g++ 4.8.5, this fails with:
-    //      error: ‘put_time’ is not a member of ‘std’
-    << "." << std::put_time(&localTime, "%FT%T%z")
-#endif
+    << "." << Util::getTimestampStr()
     << "." << UniquePid::ThisProcess()
     << ".log";
   JASSERT_SET_LOG(o.str().c_str());

--- a/src/util_misc.cpp
+++ b/src/util_misc.cpp
@@ -24,6 +24,7 @@
 #include <limits.h>  // for PATH_MAX
 #include <stdlib.h>
 #include <string.h>
+#include <sys/time.h>
 #include "../jalib/jassert.h"
 #include "../jalib/jfilesystem.h"
 #include "dmtcp.h"
@@ -685,4 +686,20 @@ Util::allowGdbDebug(int currentDebugLevel)
       sleep(3);
     }
   }
+}
+
+string
+Util::getTimestampStr()
+{
+  struct timeval tv;
+  struct tm localTime;
+  char buf1[128] = {0};
+  char buf2[128] = {0};
+
+  gettimeofday(&tv, NULL);
+  localtime_r(&tv.tv_sec, &localTime);
+  strftime(buf1, sizeof(buf1), "%FT%T", &localTime);
+  sprintf(buf2, "%s.%03d", buf1, tv.tv_usec / 1000);
+
+  return buf2;
 }


### PR DESCRIPTION
It resolves the issue related to missing std::put_time on older compilers.