### PR TITLE
Removed stale JNOTE from Fileconnection.

### DIFF
--- a/src/plugin/ipc/file/fileconnection.h
+++ b/src/plugin/ipc/file/fileconnection.h
@@ -90,10 +90,7 @@ class FileConnection : public Connection
                    int type = FILE_REGULAR)
       : Connection(type)
       , _path(path)
-      , _fileAlreadyExists(false)
-    {
-      JNOTE("*****") (_path);
-    }
+      , _fileAlreadyExists(false) {}
 
     virtual void doLocking() override;
     virtual void drain() override;


### PR DESCRIPTION
The JNOTE was leftover from an earlier commit.