### PR TITLE
FIx dlopen tests: dlopen("libdlopenX.so") -> dlopen("test/libdlopenX.so")

### DIFF
--- a/src/dmtcp_dlsym.cpp
+++ b/src/dmtcp_dlsym.cpp
@@ -363,6 +363,11 @@ dlsym_default_internal_library_handler(void *handle,
       // If different symbol name
       continue;
     }
+    // In Ubuntu 22.04 (glibc-2.35), tags.versym can be NULL.  Check it.
+    if (tags.versym == NULL) {
+      default_symbol_index = i;
+      break;
+    }
     char *symversion = version_name(tags.versym[i], &tags);
     if (version && symversion && strcmp(symversion, version) == 0) {
       default_symbol_index = i;

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -275,7 +275,7 @@ def splitWithQuotes(string):
 def shouldRunTest(name):
   return args.tests == [] or name in args.tests
 
-#make sure we are in svn root
+#make sure we are in github root
 if not os.path.isfile('./bin/dmtcp_launch'):
   os.chdir("..")
 
@@ -1049,22 +1049,9 @@ runTest("timer1",   1, ["./test/timer1"])
 ## runTest("timer2",   1, ["./test/timer2"])
 runTest("clock",   1, ["./test/clock"])
 
-old_ld_library_path = os.getenv("LD_LIBRARY_PATH")
-if old_ld_library_path:
-  os.environ['LD_LIBRARY_PATH'] += ':' + os.getenv("PWD") + \
-                                   "/test:" + os.getenv("PWD")
-else:
-  os.environ['LD_LIBRARY_PATH'] = os.getenv("PWD") + "/test:" + os.getenv("PWD")
-runTest("dlopen1",        1, ["./test/dlopen1"])
-# Disable the dlopen2 test until we can figure out a way to handle calls to
-# fork/exec/wait during library intialization with dlopen().
-# This seems to affect Travis CI of github, but not Ubuntu-12.04
-#if not USE_M32:
-#  runTest("dlopen2",        1, ["./test/dlopen2"])
-if old_ld_library_path:
-  os.environ['LD_LIBRARY_PATH'] = old_ld_library_path
-else:
-  del os.environ['LD_LIBRARY_PATH']
+runTest("dlopen1",       1, ["./test/dlopen1"])
+if not USE_M32:
+  runTest("dlopen2",     1, ["./test/dlopen2"])
 
 # Most of the remaining tests are on 64-bit processes.
 if USE_M32:

--- a/test/dlopen1.c
+++ b/test/dlopen1.c
@@ -27,7 +27,7 @@ main(int argc, char *argv[])
     }
 
     if (lib == 1) {
-      handle = dlopen("libdlopen-lib1.so", RTLD_NOW);
+      handle = dlopen("test/libdlopen-lib1.so", RTLD_NOW);
       if (handle == NULL) {
         fprintf(stderr, "dlopen failed: %s\n", dlerror());
         exit(1);
@@ -38,7 +38,7 @@ main(int argc, char *argv[])
     }
 
     if (lib == 2) {
-      handle = dlopen("libdlopen-lib2.so", RTLD_LAZY);
+      handle = dlopen("test/libdlopen-lib2.so", RTLD_LAZY);
       if (handle == NULL) {
         fprintf(stderr, "dlopen failed: %s\n", dlerror());
         exit(1);

--- a/test/dlopen2.cpp
+++ b/test/dlopen2.cpp
@@ -28,7 +28,7 @@ main(int argc, char *argv[])
     }
 
     if (lib == 1) {
-      handle = dlopen("libdlopen-lib3.so", RTLD_NOW);
+      handle = dlopen("test/libdlopen-lib3.so", RTLD_NOW);
       if (handle == NULL) {
         fprintf(stderr, "dlopen failed: %s\n", dlerror());
         exit(1);
@@ -39,7 +39,7 @@ main(int argc, char *argv[])
     }
 
     if (lib == 2) {
-      handle = dlopen("libdlopen-lib4.so", RTLD_LAZY);
+      handle = dlopen("test/libdlopen-lib4.so", RTLD_LAZY);
       if (handle == NULL) {
         fprintf(stderr, "dlopen failed: %s\n", dlerror());
         exit(1);


### PR DESCRIPTION
`man dlopen` says 
> If filename contains a slash ("/"), then it is interpreted as a  (relative or absolute) pathname.  Otherwise,  ...

So, `dlopen("libdlopenX.so")` is changed to  `dlopen("test/libdlopenX.so")`.  The test always runs from `../test`.  We were previously using `LD_LIBRARY_PATH` in autotest.py, but doing this instead is simpler and more direct.

This seems good enough for Centos 7 (glibc-2.17) to work on dlopen1 and dlopen2 both.

The CI then uses Ubuntu 22.04.  On dlopen1, it launches, but does not checkpoint.  (Previously, it did not launch.)

In WSL/Ubuntu 22.04, I was able to reproduce the bug.  The commit `Fix dlsym_default_internal_library_handler()` then sufficed to fix the bug that was exposed for Ubuntu 22.04.