### PR TITLE
Add DMTCP_RESTART_PAUSE={6,7}: to stop at a plugin using the DMTCP_RESTART_EVENT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -519,7 +519,7 @@ AC_TRY_RUN([
            }
            ], [has_pr_set_ptracer='yes'], [has_pr_set_ptracer='no'])
 if test "$has_pr_set_ptracer" == "yes"; then
-  AC_DEFINE([HAS_PR_SET_PTRACER],[1],[Allow 'gdb attach' when DMTCP_RESTART_PAUSE is defined.])
+  AC_DEFINE([HAS_PR_SET_PTRACER],[1],[Allow 'gdb attach' when DMTCP_RESTART_PAUSE_WHILE is defined.])
 fi
 AC_MSG_RESULT([$has_pr_set_ptracer])
 

--- a/doc/README
+++ b/doc/README
@@ -1,0 +1,3 @@
+Many of these files date from 2015, and can be obsolete.
+
+debugging-dmtcp.txt was revised in 2023.

--- a/doc/debugging-dmtcp.txt
+++ b/doc/debugging-dmtcp.txt
@@ -38,6 +38,8 @@ Note that a DMTCP application returns 'return code' 99 or else
 'getenv("DMTCP_FAIL_RC")' when DMTCP fails an assertion.
 If the 'DMTCP_ABORT_ON_FAILURE' environment variable is set, DMTCP attempts
 to create a core dump on a JASSERT failure.
+If the 'DMTCP_SLEEP_ON_FAILURE' environment variable is set, DMTCP goes into
+an infinite loop, and a user can attach to a live process with GDB.
 
 ===
 C. LAUNCHING A PROCESS UNDER DMTCP CONTROL USING GDB

--- a/doc/debugging-dmtcp.txt
+++ b/doc/debugging-dmtcp.txt
@@ -16,7 +16,7 @@ A. PRINT DEBUGGING
 
 There are several ways to debug.  If you want "print debugging", with
 a trace of the major operations, do:
-  ./configure --enable-debug
+  ./configure --enable-logging
   make -j clean
   make -j check-dmtcp1
 and look in /tmp/dmtcp-USER@HOST for files of the form jassertlog.*,
@@ -31,9 +31,13 @@ B. STOPPING GDB BEFORE JASSERT CAUSES PROCESS EXIT
 
 If debugging under GDB, and the process exits before you can examine
 the cause, try:
- (gdb) break FNC
- [ for FNC among:  exit, _exit, _Exit, mtcp_abort ;
-   The function _exit is used when Jassert() exits. ]
+ (gdb) break _exit
+   [ The function _exit is used when JASSERT() exits. ]
+
+Note that a DMTCP application returns 'return code' 99 or else
+'getenv("DMTCP_FAIL_RC")' when DMTCP fails an assertion.
+If the 'DMTCP_ABORT_ON_FAILURE' environment variable is set, DMTCP attempts
+to create a core dump on a JASSERT failure.
 
 ===
 C. LAUNCHING A PROCESS UNDER DMTCP CONTROL USING GDB
@@ -84,79 +88,26 @@ debugging support.  A convenient recipe from the root directory of DMTCP is:
   make -j clean
   make -j
 
-There are four methods available.  Most users will prefer the first,
-or possibly the second method.  The methods are in order of increasing
-interest for developers of DMTCP.  Make sure that you compiled DMTCP
-with debugging support if you want to also see symbols for DMTCP functions.
-
-1. DMTCP_GDB_ATTACH_ON_RESTART:
-2. DMTCP_RESTART_PAUSE2:
-3. DMTCP_RESTART_PAUSE:
-4. USING GDB WITH MTCP (primarily for developers):
-
-The four methods follow:
-
-1. DMTCP_GDB_ATTACH_ON_RESTART:
 In the past, using 'gdb attach' was as easy as:
        dmtcp_restart ckpt_a.out_*.dmtcp &
        gdb a.out `pgrep -n a.out`
 
+DMTCP ATTACH RESTART:
 Unfortunately, recent Linux distros have forbidden this type of
 'gdb attach' because it can expose security holes.  To get around
 this on a per-process basis, DMTCP provides the special
-environment variable DMTCP_GDB_ATTACH_ON_RESTART:
-       DMTCP_GDB_ATTACH_ON_RESTART=1 dmtcp_restart ckpt_a.out_*.dmtcp &
-       gdb a.out `pgrep -n a.out`
+environment variable DMTCP_RESTART_PAUSE:
+       DMTCP_RESTART_PAUSE=<NUM> dmtcp_restart ckpt_a.out_*.dmtcp &
+       ps uxw  # To find pid of target.
+       gdb -p <PID>
+       (gdb) source gdb-dmtcp-utils
+       (gdb) frame 0
+       (gdb) load-symbols-library <ADDRESS>
+An alternative invocation is:
+       dmtcp_restart --debug-restart-pause ckpt_a.out_*.dmtcp &
 
-2. DMTCP_RESTART_PAUSE2:
-If it's important to attach with GDB early in the restart process, then
-DMTCP provides this and the following alternatives.  First,
-MTCP_RESTART_PAUSE2 pauses DMTCP immediately after all the threads
-(including the checkpoint thread) have been restored:
-       DMTCP_RESTART_PAUSE2=1 bin/dmtcp_launch a.out
-       bin/dmtcp_command --checkpoint
-       dmtcp_restart ckpt_a.out_*.dmtcp &
-       # DMTCP will then pause for 15 seconds, and wait for a GDB attach.
-
-3. DMTCP_RESTART_PAUSE:
-Next, if you need to attach with GDB _very_ early in the restart process
-(usually needed only by DMTCP developers), do:
-       DMTCP_RESTART_PAUSE=1 bin/dmtcp_launch a.out
-       # Continue as above.
-In this case, you will attach at a time when only the primary thread
-exists, and the DMTCP checkpoint thread is not yet distinguished from
-the original user thread executing main().
-
-Note that to attach early, you must set the environment variable during
-dmtcp_launch.  This is needed in order to embed the environment variable
-in the memory that is then saved in ckpt_a.out_*.dmtcp.  If you set the
-environment variable only during restart, then the memory overlay
-of dmtcp_restart will overwrite the environment variable that you set.
-
-*** NOTE:  The above restriction for DMTCP_RESTART_PAUSE / DMTCP_RESTART_PAUSE2
-***        may be relaxed in the future, to allow setting before dmtcp_restart.
-
-4. USING GDB WITH MTCP (primarily for developers):
-For developers only, 'gdb attach' can be useful _very_, _very_ early ---
-during the initial control of MTCP, the lowest layer of DMTCP.
-Here are some instructions for this case.
-
-For low-level debugging on restart, try:
-  cd src/mtcp
-  make tidy
-  // Optionally modify a file in the mtcp directory
-  make -f Makefile.debug
-  make gdb
-  // Follow instructions:  e.g., paste 'add-symbol-file ...' msg into GDB
-  // If the bug is still further, then use the 'hang or crash' trick.  Add:
-  {int x=1; while(x);}
-  // and look for whether it hangs (reaches this far) or crashes
-  // Move the while loop until you locate the bug.
-  // If GDB is fragile, a trick that may work is to run without GDB,
-  //    and then attach at the 'while' loop.  Alternatively, if in GDB:
-  (gdb) detach
-  gdb test/dmtcp1 PID    # for the appropriate pid
-  // GDB should be more robust after this.
+You can set <NUM> from 1 through 7, to stop early or late.
+In GDB, change the restartPauseLevel variable to a later value to continue.
 
 ===
 E. TRICKS FOR DEBUGGING WHILE INSIDE GDB
@@ -168,7 +119,7 @@ before you can attach.  One trick to stop GDB there is to add a line of code
   { int x = 1; while (x) {}; }
 After that, use one of the above techniques for attaching with GDB, and:
   (gdb) where
-  (gdb) print x = 0
+  (gdb) print x = 0 # or: (gdb) set x=0
   (gdb) next
 
     Most of DMTCP is written in C++.  If you want to list or set a breakpoint

--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -47,6 +47,13 @@
 #define DMTCP_PLUGIN_API_VERSION "3"
 
 #ifdef __cplusplus
+namespace dmtcp {
+// Used by 'DMTCP_RESTART_PAUSE_WHILE(cond)', below; Defined in threadlist.cpp.
+extern volatile int restartPauseLevel;
+}
+#endif // ifdef __cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif // ifdef __cplusplus
 
@@ -589,12 +596,12 @@ typedef void (*dmtcp_fnptr_t)(void);
 #define DMTCP_SETUP_PTRACE()
 #endif // ifdef HAS_PR_SET_PTRACER
 
-#define DMTCP_RESTART_PAUSE(level)                                             \
+// Usage:  DMTCP_RESTART_PAUSE_WHILE(restartPauseLevel == <LEVEL>);
+#define DMTCP_RESTART_PAUSE_WHILE(condition)                                   \
   do {                                                                         \
-    if (restartPauseLevel == level) {                                          \
+    if (condition) {                                                           \
       DMTCP_SETUP_PTRACE();                                                    \
-      volatile int dummy = 1;                                                  \
-      while (dummy);                                                           \
+      while (condition);                                                       \
     }                                                                          \
   } while (0)
 

--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -111,8 +111,9 @@ static const char *theUsage =
   "              Skip NOTE messages; if given twice, also skip WARNINGs\n"
   "  --coord-logfile PATH (environment variable DMTCP_COORD_LOG_FILENAME\n"
   "              Coordinator will dump its logs to the given file\n"
-  "  --debug-restart-pause (or set env. var. DMTCP_RESTART_PAUSE =1,2,3 or 4)\n"
+  "  --debug-restart-pause (or set env var DMTCP_RESTART_PAUSE=1,2,... or 7)\n"
   "              dmtcp_restart will pause early to debug with:  GDB attach\n"
+  "              Levels 6 and 7 valid only with DMTCP_EVENT_RESTART in plugin\n"
   "  --help\n"
   "              Print this message and exit.\n"
   "  --version\n"
@@ -371,7 +372,7 @@ char *get_pause_param()
     return NULL;
   }
 
-  if (pause_param[0] < '1' || pause_param[0] > '4' || pause_param[1] != '\0') {
+  if (pause_param[0] < '1' || pause_param[0] > '7' || pause_param[1] != '\0') {
     return NULL;
   }
 
@@ -744,9 +745,9 @@ main(int argc, char **argv)
       setenv(ENV_VAR_COORD_LOGFILE, argv[1], 1);
       shift; shift;
     } else if (s == "--debug-restart-pause") {
-      JASSERT(argv[1] && argv[1][0] >= '1' && argv[1][0] <= '4'
+      JASSERT(argv[1] && argv[1][0] >= '1' && argv[1][0] <= '7'
                       && argv[1][1] == '\0')
-        .Text("--debug-restart-pause requires arg. of '1', '2', '3' or '4'");
+        .Text("--debug-restart-pause requires arg. of '1' or '2' or ...` '7'");
       setenv("DMTCP_RESTART_PAUSE", argv[1], 1);
       shift; shift;
     } else if (argv[0][0] == '-' && argv[0][1] == 'i' &&

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -212,7 +212,11 @@ main(int argc, char *argv[], char **environ)
 
   compute_vdso_vvar_addr(&rinfo);
 
-  DMTCP_RESTART_PAUSE(&rinfo, 1);
+  if (rinfo.restart_pause == 1) {
+    MTCP_PRINTF("*** (gdb) set rinfo.restart_pause=2 # to go to next stmt\n");
+  }
+  // In GDB, 'set rinfo.restart_pause=2' to continue to next statement.
+  DMTCP_RESTART_PAUSE_WHILE(rinfo.restart_pause == 1);
 
   if (!simulate) {
     mtcp_plugin_hook(&rinfo);
@@ -554,6 +558,7 @@ restorememoryareas(RestoreInfo *rinfo_ptr)
           "But we may be lucky if the strings have been cached by the O/S\n"
           "or if compiler uses relative addressing for rodata with -fPIC\n");
 
+  // OBSOLETE:  Remove this when no longer used.
   if (rinfo_ptr->use_gdb) {
     MTCP_PRINTF("Called with --use-gdb.  A useful command is:\n"
                 "    (gdb) info proc mapping\n"
@@ -632,9 +637,9 @@ restorememoryareas(RestoreInfo *rinfo_ptr)
       "  where PROGRAM_NAME is the original target application:\n"
       "(This won't work well unless you configure DMTCP with --enable-debug)\n"
       "  gdb PROGRAM_NAME %d\n"
-      "You will then be in 'ThreadList::postRestart()'\n"
+      "You will then be in 'ThreadList::postRestart()' or later\n"
       "  (gdb) list\n"
-      "  (gdb) p dummy = 0\n"
+      "  (gdb) p restartPauseLevel = 0  # Or set it to next higher level.\n"
       "  # In some recent Linuxes/glibc/gdb, you may also need to do:\n"
       "  (gdb) source DMTCP_ROOT/util/gdb-add-symbol-files-all\n"
       "  (gdb) add-symbol-files-all\n",

--- a/src/mtcp/mtcp_restart.h
+++ b/src/mtcp/mtcp_restart.h
@@ -74,7 +74,7 @@ typedef struct RestoreInfo {
 #ifdef TIMING
   struct timeval startValue;
 #endif
-  int restart_pause;  // Used by env. var. DMTCP_RESTART_PAUSE
+  volatile int restart_pause;  // Used by env. var. DMTCP_RESTART_PAUSE_WHILE
 
   // Set to the value of DMTCP_DEBUG_MTCP_RESTART env var.
   int skipMremap;
@@ -92,12 +92,10 @@ typedef struct RestoreInfo {
 
 void mtcp_check_vdso(char **environ);
 
-#define DMTCP_RESTART_PAUSE(rinfo, level)                                      \
+// Usage: DMTCP_RESTART_PAUSE_WHILE(*&rinfo)->restart_pause == <LEVEL>);
+#define DMTCP_RESTART_PAUSE_WHILE(condition)                                   \
   do {                                                                         \
-    if ((rinfo)->restart_pause == (level)) {                                   \
-      volatile int dummy = 1;                                                  \
-      while (dummy);                                                           \
-    }                                                                          \
+    while (condition);                                                         \
   } while (0)
 
 #endif // #ifndef MTCP_RESTART_H

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -124,6 +124,10 @@ PluginManager::eventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
   case DMTCP_EVENT_RESTART:
   case DMTCP_EVENT_THREAD_RESUME:
 
+    if (event == DMTCP_EVENT_RESTART) {
+      DMTCP_RESTART_PAUSE_WHILE(restartPauseLevel == 5);
+    }
+
     // The plugins are invoked in _reverse_ order during resume/restart.  This
     // is required to support layered software.  See the related comment, above.
     for (int i = pluginManager->pluginInfos.size() - 1; i >= 0; i--) {
@@ -132,6 +136,10 @@ PluginManager::eventHook(DmtcpEvent_t event, DmtcpEventData_t *data)
       }
     }
     break;
+
+    if (event == DMTCP_EVENT_RESTART) {
+      DMTCP_RESTART_PAUSE_WHILE(restartPauseLevel == 6);
+    }
 
   default:
     JASSERT(false) (event).Text("Not Reachable");


### PR DESCRIPTION
When using DMTCP_RESTART_EVENT, it's useful to stop in an application's plugin at the time of restart.  Level 6 is before the restart event is handled and 7 is after the restart event is handled.

 * This pauses at beginning of restart event before all plugins (5), or the end of restart event after all plugins (6).
     The previous PAUSE=5 is now PAUSE=7, since it occurs after PAUSE=5,6. 
 * This also fixes a bug in commit 7bc9fddf0 (two DMTCP_RESTART_PAUSE's at level 1: inside mtcp_restart.c and inside threadlist.cpp).

Finally, this PR has been updated to stop at a macro, `DMTCP_RESTART_PAUSE_WHILE(restartPauseLevel==3)`, rather than `DMTCP_RESTART_PAUSE(3)`.  The user can then modify `restartPauseLevel` and even change it to the next larger integer.  This is clearer than using hidden variables like `dummy` and `restartPauseLevel`.