### PR TITLE
Minor: dlopen[12] now works from any dmtcp_launch

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# NOTE: .travis.yml at DMTCP_ROOT calls autotest.py for github/travis
+# NOTE: .github/workflows/make-check.yml at DMTCP_ROOT calls autotest.py
 
 from random import randint
 from time   import sleep
@@ -17,7 +17,7 @@ import pwd
 import stat
 import re
 
-# FIX for bad path for Java:  Travis prepended
+# FIX for bad path for Java:  Previously, Travis prepended
 #     "/usr/bin:/opt/pyenv/libexec:/opt/pyenv/plugins/python-build/bin:/"
 # to os.environ['PATH'] on July 31, 2019.  It does this, even though
 # "/usr/bin" occurs later in the path.  /usr/bin/java exists as Java-8.
@@ -1294,9 +1294,10 @@ runTest("nocheckpoint",        [1,2], ["./test/nocheckpoint"])
 
 print("== Summary ==")
 print("%s: %d of %d tests passed" % (socket.gethostname(), stats[0], stats[1]))
-print("Failed Tests:")
-for f in failed_tests:
-  printError("  " + f)
+if failed_tests:
+  print("Failed Tests:")
+  for f in failed_tests:
+    printError("  " + f)
 
 saveResultsNMI()
 

--- a/test/dlopen1.c
+++ b/test/dlopen1.c
@@ -8,6 +8,8 @@
 #include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 int (*fnc)(int result[2]);
 
@@ -19,6 +21,15 @@ main(int argc, char *argv[])
   int result[2] = { 0, 0 };
   int i, answer;
   int cnt1 = 0, cnt2 = 0;
+
+  // chdir to DMTCP root dir
+  char *char1 = strrchr(argv[0], '/');
+  *char1 = '\0';
+  char *char2 = strrchr(argv[0], '/');
+  *char2 = '\0';
+  int rc = chdir(argv[0]);
+  if (rc != 0) {fprintf(stderr, "Failed to chdir to %s\n", argv[0]); exit(1);}
+  *char1 = *char2 = '/';
 
   printf("0: "); fflush(stdout);
   while (1) {

--- a/test/dlopen2.cpp
+++ b/test/dlopen2.cpp
@@ -7,6 +7,7 @@
 #include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #if !defined(LIB3) && !defined(LIB4)
@@ -20,6 +21,15 @@ main(int argc, char *argv[])
   int result[2] = { 0, 0 };
   int i, answer;
   int cnt1 = 0, cnt2 = 0;
+
+  // chdir to DMTCP root dir
+  char *char1 = strrchr(argv[0], '/');
+  *char1 = '\0';
+  char *char2 = strrchr(argv[0], '/');
+  *char2 = '\0';
+  int rc = chdir(argv[0]);
+  if (rc != 0) {fprintf(stderr, "Failed to chdir to %s\n", argv[0]); exit(1);}
+  *char1 = *char2 = '/';
 
   printf("0: "); fflush(stdout);
   while (1) {


### PR DESCRIPTION
`dlopen[12].c` now does chdir to DMTCP root in beginning.  This makes it work even when doing something like:
```
/usr/local/bin dmtcp_launch ./test/dlopen1
```
since the required `./test/libdlopen[12].so` is in the same directory as `./test/dlopen1`.   It should also work with `./dlopen1` providing the current directory is in a directory, `test`, which contains `dlopen1`.

 * Also, some very minor polishing of `autotext.py` is included here.