### PR TITLE
JTRACE: (a.addr) -> ((void *)a.addr); WAS 'char *'

### DIFF
--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -427,7 +427,7 @@ mtcp_write_anonymous_pages(int fd, Area area)
     } else {
       if (madvise(a.addr, a.size, MADV_DONTNEED) == -1) {
         JTRACE("error doing madvise(..., MADV_DONTNEED)")
-          (JASSERT_ERRNO) (a.addr) ((int)a.size);
+          (JASSERT_ERRNO) ((void *)a.addr) ((int)a.size);
       }
     }
     area.addr += size;


### PR DESCRIPTION
`JTRACE("...")(a.addr);` is being called on `a.addr`, which is a `char *`.  So, it tries to print a string, and will crash if it doesn't find a null character within a certain distance.