### PR TITLE
readdmtcp.sh: Prefer mtcp_restart of same dir tree

### DIFF
--- a/util/readdmtcp.sh
+++ b/util/readdmtcp.sh
@@ -16,13 +16,13 @@ fi
 
 dir=`dirname $0`
 
-if which mtcp_restart > /dev/null 2> /dev/null; then
-  mtcp_restart --simulate $1 2>&1
-  exit 0
-fi
-
 # This next one assumes that this script resides in DMTCP_ROOT/util/
 if test -x $dir/../bin/mtcp_restart; then
   $dir/../bin/mtcp_restart --simulate $1 2>&1
+  exit 0
+fi
+
+if which mtcp_restart > /dev/null 2> /dev/null; then
+  mtcp_restart --simulate $1 2>&1
   exit 0
 fi


### PR DESCRIPTION
Some sites might have an old system-wide copy of mtcp_restart in `/usr/bin/mtcp_restart`.

When invoking `DMTCP_ROOT/util/readdmtcp.sh`, the script now checks for a relative binary in `DMTCP_ROOT/util/../bin/mtcp_restart`, instead of blindly trying `which mtcp_restart` first.