### PR TITLE
Fix 5e05c37 format error: autotest.py:printError()

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -748,7 +748,7 @@ def runTestRaw(name, numProcs, cmds):
     try:
       testKill()
     except CheckFailed as e:
-      printError("CLEANUP ERROR:", e.value)
+      printError("CLEANUP ERROR:" + str(e.value))
       SHUTDOWN()
       saveResultsNMI()
       sys.exit(1)


### PR DESCRIPTION
The title says it all: fixing commit 5e05c37