### PR TITLE
Fix "stale timeout" (commit 0f58657 from PR #1064)

### DIFF
--- a/src/dmtcp_restart.cpp
+++ b/src/dmtcp_restart.cpp
@@ -452,7 +452,8 @@ runMtcpRestart(int fd, RestoreTarget *restoreTarget)
       char cpid[11]; // XXX: Is 10 digits for long PID plus a terminating null
       snprintf(cpid, 11, "%ld", (long unsigned)pid);
       char* const command[] = {const_cast<char*>("gdb"),
-                               const_cast<char*>(restoreTarget->procSelfExe().c_str()),
+                               const_cast<char*>(restoreTarget->
+                                                 procSelfExe().c_str()),
                                cpid,
                                NULL};
       execvp(command[0], command);
@@ -740,7 +741,7 @@ main(int argc, char **argv)
 
   // process args
   shift;
-  while (argc > 0) { // ... -restartdir ./ OR ... ckptImg
+  while (argc > 0) { // ... --restartdir ./ OR ... ckptImg
     string s = argc > 0 ? argv[0] : "--help";
     if (s == "--help" && argc == 1) {
       printf("%s", theUsage);
@@ -879,7 +880,7 @@ main(int argc, char **argv)
     ckptImages.push_back(argv[0]);
   }
 
-  // Can't specify ckpt images with --restart-dir flag.
+  // Can't specify ckpt images with --restartdir flag.
   if (restartDir.empty() ^ (ckptImages.size() > 0)) {
     JASSERT_STDERR << theUsage;
     exit(DMTCP_FAIL_RC);


### PR DESCRIPTION
Fixing several bugs, and some minor fixing of formats/comments in dmtcp_restart.cpp

Without this fix, things like `mana_launch -i5 mpi-proxy-split/test/wave_mpi.mana.exe` were failing to create a checkpoint.
Also, without this fix, the initial default stale timeout of 7 hours wasn't taking effect.

The original PR $1064 was pushed in on Sunday, Sept. 17, creating these bugs.