### PR TITLE
WIP: Reclaim the restore buffer region before anyone can allocate in the reserved area

### DIFF
--- a/src/processinfo.h
+++ b/src/processinfo.h
@@ -58,6 +58,7 @@ class ProcessInfo
     void restoreProcessGroupInfo();
     void restoreHeap();
     void growStack();
+    void reclaimRestoreBufRegion();
 
     bool beginPthreadJoin(pthread_t thread);
     void endPthreadJoin(pthread_t thread);


### PR DESCRIPTION
 A jalloc allocation can result in an mmap call. Although it is rare, the kernel can place the new region in the free space between the heap and stack of mtcp_restart i.e., in the restoreBuf region. It is better to reclaim the restore buffer before it's too late.
