### PR TITLE
Simplified restore-buf map/unmap handling.

### DIFF
--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -325,6 +325,8 @@ const char *dmtcp_get_ckpt_files_subdir(void);
 int dmtcp_should_ckpt_open_files(void);
 int dmtcp_allow_overwrite_with_ckpted_files(void);
 int dmtcp_skip_truncate_file_at_restart(const char* path);
+void dmtcp_set_restore_buf_addr(void *new_addr);
+uint64_t dmtcp_restore_buf_len();
 
 int dmtcp_get_ckpt_signal(void);
 const char *dmtcp_get_uniquepid_str(void) __attribute__((weak));

--- a/src/dmtcpplugin.cpp
+++ b/src/dmtcpplugin.cpp
@@ -472,3 +472,15 @@ dmtcp_add_to_ckpt_header(const char *key, const char *value)
 {
   ProcessInfo::instance().addKeyValuePairToCkptHeader(key, value);
 }
+
+EXTERNC void
+dmtcp_set_restore_buf_addr(void *new_addr)
+{
+  ProcessInfo::instance().updateRestoreBufAddr(new_addr);
+}
+
+EXTERNC uint64_t
+dmtcp_restore_buf_len()
+{
+  ProcessInfo::instance().restoreBufLen();
+}

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -301,30 +301,29 @@ ProcessInfo::init()
   // Reserve space for restoreBuf
   _restoreBufLen = RESTORE_TOTAL_SIZE;
 
-  int pagesize = getpagesize();
-  _restoreBufAddr = (uint64_t) mmap(NULL, _restoreBufLen + 2*pagesize,
-                    PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-  JASSERT(_restoreBufAddr != (uint64_t) MAP_FAILED) (JASSERT_ERRNO);
-  _restoreBufAddr = (uint64_t)(_restoreBufAddr + pagesize);
-  // Guard page _restoreBufAddr; prevent kernel from merging regions
-  // Note that PROT_READ was added to 'mprotect' on the guard pages.
-  //   Before adding this, test/{dmtcp5,sched_test,shared-fd1}, and others
-  //   were failing during the _first_ checkpoint, only.  The checkpoint
-  //   image was malformed because write() of these guard pages
-  //   was failing with EFAULT (although no SEGFAULT occurred) when trying to
-  //   read the guard pages and write them to the checkpoint image.
-  //   This occurred in Linux 3.10.0-1062.9.1.el7.x86_64 in CentOS 7.7.1908.
-  //   (But it did not occur in Ubuntu 18.04 with Linux 4.15.)
-  //   This is arguably a bug in the Linux 3.10 kernel.
-  mprotect((char *)_restoreBufAddr - pagesize, pagesize,
-           PROT_READ | PROT_EXEC);
-  JASSERT(_restoreBufLen % pagesize == 0) (_restoreBufLen) (pagesize);
-  mprotect((char *)_restoreBufAddr + _restoreBufLen, pagesize,
-           PROT_READ | PROT_EXEC);
+  updateRestoreBufAddr(nullptr);
 
   if (_ckptDir.empty()) {
     updateCkptDirFileSubdir();
   }
+}
+
+void
+ProcessInfo::updateRestoreBufAddr(void* addr)
+{
+  if (_restoreBufAddr != 0) {
+    JASSERT(munmap((void*) _restoreBufAddr, _restoreBufLen) == 0) (JASSERT_ERRNO);
+  }
+
+  int flags = MAP_SHARED | MAP_ANONYMOUS;
+
+  if (addr != nullptr) {
+    flags += MAP_FIXED;
+  }
+
+  _restoreBufAddr = (uint64_t) mmap(addr, _restoreBufLen,
+                    PROT_NONE, flags, -1, 0);
+  JASSERT(_restoreBufAddr != (uint64_t) MAP_FAILED) (JASSERT_ERRNO);
 }
 
 void
@@ -442,14 +441,7 @@ ProcessInfo::restoreHeap()
 void
 ProcessInfo::restart()
 {
-  // Unmap the restore buffer and remap it with PROT_NONE. We do munmap followed
-  // by mmap to ensure that the kernel releases the backing physical pages.
-  JASSERT(munmap((void *)_restoreBufAddr, _restoreBufLen) == 0)
-    ((void *)_restoreBufAddr) (_restoreBufLen) (JASSERT_ERRNO);
-
-  JASSERT(mmap((void*) _restoreBufAddr , _restoreBufLen, PROT_NONE,
-               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0) != MAP_FAILED)
-    ((void *)_restoreBufAddr) (_restoreBufLen) (JASSERT_ERRNO);
+  updateRestoreBufAddr((void *)_restoreBufAddr);
 
   restoreHeap();
 

--- a/src/processinfo.h
+++ b/src/processinfo.h
@@ -145,6 +145,7 @@ class ProcessInfo
 
     uint64_t savedBrk(void) const { return _savedBrk; }
 
+    void updateRestoreBufAddr(void* addr);
     uint64_t restoreBufAddr(void) const { return _restoreBufAddr; }
 
     uint64_t restoreBufLen(void) const { return RESTORE_TOTAL_SIZE; }


### PR DESCRIPTION
There are two main changes:
* keep the entire restore-buf region mapped at all times.
* exposed API to allow a plugin to update the restore-buf region (as needed by MANA).