### PR TITLE
Bug fix 8085468c: COORD_NEW->COORD_ANY on 2nd ckpt img

### DIFF
--- a/src/dmtcprestartinternal.cpp
+++ b/src/dmtcprestartinternal.cpp
@@ -283,6 +283,10 @@ RestoreTarget::createProcess(bool createIndependentRootProcesses)
 {
   initialize();
 
+  if (allowedModes == COORD_NEW) {
+    allowedModes = COORD_ANY; // we have coord; restore default of COORD_ANY
+  }
+
   JTRACE("Creating process during restart")(upid())(_pInfo.procname());
 
   RestoreTargetMap::iterator it;
@@ -836,6 +840,10 @@ DmtcpRestart::DmtcpRestart(int argc, char **argv, const string& binaryName, cons
   if ((getenv(ENV_VAR_NAME_PORT) == NULL ||
        getenv(ENV_VAR_NAME_PORT)[0]== '\0') &&
       allowedModes != COORD_NEW) {
+    if (allowedModes == COORD_ANY) {
+      // COORD_ANY is default; we should use --join to join existing coordinator
+      allowedModes = COORD_NEW;
+    }
     allowedModes = (allowedModes == COORD_ANY) ? COORD_NEW : allowedModes;
     setenv(ENV_VAR_NAME_PORT, STRINGIFY(DEFAULT_PORT), 1);
     JTRACE("No port specified\n"


### PR DESCRIPTION
@karya0,
&nbsp;&nbsp;&nbsp;&nbsp;Since you're re-doing dmtcp_restart, I would prefer if you can review this bug fix.  But if you're not available, then @xuyao0127 can review it.  Apparently, `make check-presuspend` was failing since 2017, but if the test machine didn't have localhost, then we were not testing this.

 * This fixes 'make check-presuspend'.
 * In commit 8085468c, if dmtcp_restart did not specify --join or --new, then COORD_ANY was used.  But if a preexisting DMTCP coordinator was available, then --join would be used instead of --new.  Commit 8085468c fixed that.
 * But if dmtcp_restart was used with multiple checkpoint images, then --new was used for each of the ckpt images.  So, the second ckpt image would fail.  So, this commit changes COORD_NEW back to COORD_ANY on the 2nd ckpt image.  This causes --join to be used.