### PR TITLE
mmap_fixed_noreplace: Fix preprocessor '#define'

### DIFF
--- a/src/mtcp/mtcp_util.c
+++ b/src/mtcp/mtcp_util.c
@@ -865,9 +865,9 @@ void* mmap_fixed_noreplace(void *addr, size_t len, int prot, int flags,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
 #ifndef MAP_FIXED_NOREPLACE
 #define MAP_FIXED_NOREPLACE 0x100000
+#endif
   // This flag should force: 'addr == addr2' or 'addr2 == MAP_FAILED'
   flags |= MAP_FIXED_NOREPLACE;
-#endif
 #endif
   void *addr2 = mtcp_sys_mmap(addr, len, prot, flags, fd, offset);
   if (addr == addr2) {


### PR DESCRIPTION
This bug was found by @karya0 .  I'm submitting it now so as not to delay.  But the original bug was mine, and @karya0 discovered thsi bug.