### PR TITLE
Add alignas(16) for dwcas in jalloc.cpp

### DIFF
--- a/jalib/jalloc.cpp
+++ b/jalib/jalloc.cpp
@@ -275,7 +275,8 @@ class JFixedAllocStack
         char buf[N];
       };
     };
-    struct StackHead {
+    // alignas(16) to support 128-bit StackHead, used in dwcas
+    struct alignas(16) StackHead {
       uintptr_t counter;
       FreeItem* node;
     };


### PR DESCRIPTION
This is an easy one-line code to be reviewed.

Recall that dwcas (double-word-compare-and-swap) is used in our lock-free algorithm for a stack.

In jalloc.cpp, we use bool_atomic_dwcas .  On x86_64, with gcc, it can probably do a workaround if its arguments are not double-world aligned (128-bit aligned).  But we can't guarantee it for all CPUs and all compilers.  And misaligned makes it slower.

This fixes it, by ensuring that all `struct StackHead` are double--word aligned.