### PR TITLE
jalloc.h: getAllocArenas: JALIB_ALLOCATOR always

### DIFF
--- a/jalib/jalloc.h
+++ b/jalib/jalloc.h
@@ -142,9 +142,9 @@ class JAlloc
     {
       return JAllocDispatcher::free(p);
     }
+#endif // ifdef JALIB_ALLOCATOR
 
     static void getAllocArenas(JAllocArena **arenas, int *numArenas);
-#endif // ifdef JALIB_ALLOCATOR
 };
 } // namespace jalib
 


### PR DESCRIPTION
 * Bug fix for commit e64459ccf
 * If JALIB_ALLOCATOR is not defined, it fails to compile.  We move `getAllocArenas` outside of the conditionalizatio