### PR TITLE
Fix compiler warnings; bug fix for vfork1, problem w/ plugin-example-db

### DIFF
--- a/src/dmtcprestartinternal.cpp
+++ b/src/dmtcprestartinternal.cpp
@@ -148,7 +148,6 @@ static void setEnvironFd();
 static void runMtcpRestart(int fd, RestoreTarget *target);
 static int readCkptHeader(const string &path, ProcessInfo *pInfo);
 static int openCkptFileToRead(const string &path);
-static int processCkptImages();
 
 RestoreTarget::RestoreTarget(const string &path)
   : _path(path)

--- a/src/plugin/pid/sched_wrappers.cpp
+++ b/src/plugin/pid/sched_wrappers.cpp
@@ -278,8 +278,6 @@ pthread_getattr_np(pthread_t th, pthread_attr_t *attr)
   /* This is the guardsize after adjusting it.  */
   iattr->guardsize = *th_addr.reported_guardsize;
 
-  /* Stack size limit.  */
-  struct rlimit rl;
   /* The sizes are subject to alignment.  */
   if (__glibc_likely(*th_addr.stackblock != NULL)) {
     /* The stack size reported to the user should not include the
@@ -311,7 +309,7 @@ pthread_getattr_np(pthread_t th, pthread_attr_t *attr)
       extern void *__libc_stack_end;
       void *stack_end = (void *)((uintptr_t)__libc_stack_end & pagemask);
 #if _STACK_GROWS_DOWN
-      stack_end += pagesize;
+      stack_end = (char *)stack_end + pagesize;
 #endif
 
       VA lastEndAddr = NULL;

--- a/src/rwlock.cpp
+++ b/src/rwlock.cpp
@@ -20,7 +20,7 @@ int DmtcpRWLockTryRdLockUnsafe(DmtcpRWLock *rwlock)
 {
   int result = EBUSY;
 
-  ASSERT_EQ(gettid(), rwlock->xLock.owner);
+  ASSERT_EQ(gettid(), static_cast<int>(rwlock->xLock.owner));
 
   // Detect deadlock.
   if (rwlock->writer == gettid()) {

--- a/src/signalwrappers.cpp
+++ b/src/signalwrappers.cpp
@@ -58,6 +58,12 @@ bannedSignalNumber()
   return stopSignal;
 }
 
+// In glibc, signal.h makes this a macro, with: _Pragma "sigmask is deprecated"
+// But we need this deprecated function for user code with older BSD API.
+#ifdef sigmask
+# undef sigmask
+# define sigmask(sig) ((int)(1u << ((sig) - 1)))
+#endif
 static int
 patchBSDMask(int mask)
 {
@@ -83,6 +89,7 @@ patchBSDUserMask(int how, const int mask, int *oldmask)
     checkpointSignalBlockedForProcess = ((mask & bannedMask) != 0);
   }
 }
+#pragma GCC diagnostic pop
 
 static inline sigset_t
 patchPOSIXMask(const sigset_t *mask)

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -333,10 +333,6 @@ devnullFd = os.open(os.devnull, os.O_WRONLY)
 def runCmd(cmd):
   global devnullFd
 
-  # FIXME:  We should rewrite autotest.py cleanl (e.g., "LAUNCH_FLAGS")
-  #          For now, we will live with this hack.
-  if "dmtcp_launch ./test/syscall-tester" in cmd:
-    cmd = cmd.replace("dmtcp_launch ", "dmtcp_launch --checkpoint-open-files ")
   if args.verbose:
     print("Launching... ", cmd)
   cmd = splitWithQuotes(cmd);
@@ -860,8 +856,7 @@ runTest("gettid",        1, ["./test/gettid"])
 # there, and that will later need --checkpoint-all-files-as-precious.
 old_ckpt_cmd = CKPT_CMD
 CKPT_CMD = 'Kc' # Equivalent to 'dmtcp_command -kc'
-# THIS DOES:  ./bin/dmtcp_launch --checkpoint-open-files ./test/syscall-tester
-runTest("syscall-tester",  1, ["./test/syscall-tester"])
+runTest("syscall-tester",  1, ["--checkpoint-open-files ./test/syscall-tester"])
 CKPT_CMD = old_ckpt_cmd
 
 # Test for files opened with WRONLY mode and later unlinked.

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -71,6 +71,9 @@ disabled_tests = [
   "vfork2",
   # Raw thread creation using clone syscall directly isn't supported.
   "clone1"
+  # This test needs to be fixed.  It is not really running.
+  # ERROR: ld.so: object '/home/gene/dmtcp.git/test/plugin/example-db/dmtcp_example-dbhijack.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
+  "dmtcp_example-db"
 ]
 
 # if 'autotest.py --parallel', then initialize tests and test_dict.
@@ -901,6 +904,8 @@ runTest("plugin-sleep2", 1, ["--with-plugin "+
                              PWD+"/test/plugin/sleep2/dmtcp_sleep2hijack.so "+
                              "./test/dmtcp1"])
 
+# FIXME:  Test does not work.  Try:  AUTOTEST=-v make check-plugin-example-db
+# ERROR: ld.so: object '/home/gene/dmtcp.git/test/plugin/example-db/dmtcp_example-dbhijack.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
 runTest("plugin-example-db", 2, ["--with-plugin "+
                             PWD+"/test/plugin/example-db/dmtcp_example-dbhijack.so "+
                              "env EXAMPLE_DB_KEY=1 EXAMPLE_DB_KEY_OTHER=2 "+

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -58,7 +58,6 @@ parser.add_argument('tests',
                     help='Test to run')
 
 args = parser.parse_args()
-args.verbose = True
 
 # stats[0] is number passed; stats[1] is total number
 stats = [0, 0]
@@ -222,7 +221,7 @@ coordinator_cmdline = BIN+"dmtcp_coordinator --timeout 10800 --daemon"
 command_cmdline = BIN+"dmtcp_command" # -p " + str(coordinator_port)
 
 #Checkpoint command to send to coordinator
-CKPT_CMD = b'c'
+CKPT_CMD = 'c'
 
 #Appears as S*SLOW in code.  If --slow, then SLOW=5
 SLOW = pow(5, args.slow)
@@ -969,12 +968,12 @@ runTest("realpath",      1, ["./test/realpath"])
 runTest("pthread1",      1, ["./test/pthread1"])
 runTest("pthread2",      1, ["./test/pthread2"])
 
-S=10*DEFAULT_S
+S=0.5*DEFAULT_S
 runTest("pthread3",      1, ["./test/pthread2 80"])
-S=DEFAULT_S
 
 runTest("pthread4",      1, ["./test/pthread4"])
 runTest("pthread5",      1, ["./test/pthread5"])
+S=DEFAULT_S
 
 runTest("clone1",      1, ["./test/clone1"])
 

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -68,7 +68,7 @@ failed_tests = []
 disabled_tests = [
   # Vfork is not currently supported.
   #"vfork1", # We simulate vfork using fork.
-  "vfork2",
+  # vfork1 and vfork2 tests were failing due to a previous bug in vfork.c  <   ## "vfork2",
   # Raw thread creation using clone syscall directly isn't supported.
   "clone1"
   # This test needs to be fixed.  It is not really running.

--- a/test/pthread1.c
+++ b/test/pthread1.c
@@ -1,6 +1,9 @@
 /* Compile with:  gcc THIS_FILE -lpthread */
 
 #include <assert.h>
+// __USE_GNU is needed for pthread_getattr_np().
+// assert.h is undefining __USE_GNU as of glibc-2.35.  Arguably, a bug.
+#define __USE_GNU
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/vfork1.c
+++ b/test/vfork1.c
@@ -82,7 +82,8 @@ int main(int argc, char *argv[])
 
     while (!feof(fp)) {
       char buf;
-      fread(&buf, 1, 1, fp);
+      int rc = fread(&buf, 1, 1, fp);
+      assert(rc == 1);
       printf("%c", buf);
       fflush(stdout);
     }


### PR DESCRIPTION
The github commits say it all (with oldest commits first):

* Clean up autotest for syscall-tester
* Fix some compiler warnings; Polish autotest.py
* plugin-example-db test never did as intended
* Fix vfork[12] tests: They had a bug from the start
* Lower timeout for pthread[345] tests
  (Empirically, the continuous integration seems to succeed more often with this.)