### PR TITLE
python -> python3 everywhere

### DIFF
--- a/contrib/python/autocount.py
+++ b/contrib/python/autocount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, time
 

--- a/contrib/python/dmtcp.py
+++ b/contrib/python/dmtcp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # The contents of this file are inspired from the python script dmtcp_ctypes.py
 # originally supplied by Neal Becker.

--- a/contrib/python/hookexample.py
+++ b/contrib/python/hookexample.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import dmtcp
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: utils
 Priority: optional
 Maintainer: Paul Grosu <pgrosu@gmail.com>
 Uploaders: Yaroslav Halchenko <debian@onerussian.com>, Kapil Arya <kapil@ccs.neu.edu>
-Build-Depends: debhelper (>= 11), python
+Build-Depends: debhelper (>= 11), python3
 Standards-Version: 4.2.1
 Vcs-git: https://github.com/dmtcp/dmtcp.git
 Vcs-browser: https://github.com/dmtcp/dmtcp

--- a/plugin/modify-env/modify-env.py
+++ b/plugin/modify-env/modify-env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2016 Kyle Harrigan (kwharrigan@gmail.com)
 #

--- a/plugin/pathvirt/test/slot5/Makefile
+++ b/plugin/pathvirt/test/slot5/Makefile
@@ -19,7 +19,7 @@ file-test4: file-test4.c
 check: clean pv-test
 	DMTCP_ORIGINAL_PATH_PREFIX=$(PATHVIRT)/slot5/bin5:$(PATHVIRT)/slot5/doc5:$(PATHVIRT)/slot5/lib5 \
 		${DMTCP_ROOT}/bin/dmtcp_launch --pathvirt -i4 ./pv-test
-		# dmtcp_launch -i2 --pathvirt /usr/bin/python pv-test.py
+		# dmtcp_launch -i2 --pathvirt /usr/bin/env python3 pv-test.py
 
 newtest: clean file-test
 	DMTCP_ORIGINAL_PATH_PREFIX=/tmp ${DMTCP_ROOT}/bin/dmtcp_launch --checkpoint-open-files --pathvirt ./file-test
@@ -49,7 +49,7 @@ gdb: clean pv-test
 
 check-python:  clean
 	DMTCP_ORIGINAL_PATH_PREFIX=$(PATHVIRT)/slot5/bin5:$(PATHVIRT)/slot5/doc5:$(PATHVIRT)/slot5/lib5 \
-		${DMTCP_ROOT}/bin/dmtcp_launch -i4 --pathvirt /usr/bin/python pv-test.py
+		${DMTCP_ROOT}/bin/dmtcp_launch -i4 --pathvirt /usr/bin/env python3 pv-test.py
 
 restart:
 	DMTCP_NEW_PATH_PREFIX=$(PATHVIRT)/misc/slot7/bin7:$(PATHVIRT)/misc/slot7/doc7:$(PATHVIRT)/misc/slot7/lib7 \

--- a/plugin/pathvirt/test/slot5/pv-test.py
+++ b/plugin/pathvirt/test/slot5/pv-test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os, sys, time
 

--- a/src/plugin/ipc/event/eventwrappers.cpp
+++ b/src/plugin/ipc/event/eventwrappers.cpp
@@ -39,7 +39,7 @@ using namespace dmtcp;
 /* 'man 7 signal' says the following are not restarted after ckpt signal
  * even though the SA_RESTART option was used.  If we wrap these, we must
  * restart them when they are interrupted by a checkpoint signal.
- * python-2.7{socketmodule.c,signalmodule.c} assume no unknown signal
+ * python-3.7{socketmodule.c,signalmodule.c} assume no unknown signal
  *   handlers such as DMTCP checkpoint signal.  So, Python needs this.
  *
  * + Socket interfaces, when a timeout has been  set  on  the  socket

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # NOTE: .github/workflows/make-check.yml at DMTCP_ROOT calls autotest.py
 
@@ -107,7 +107,7 @@ def parallel_test(name):
     if isinstance(tests[i], subprocess.Popen) and tests[i].poll() == None:
       num_jobs += 1  # job still executing
     elif isinstance(tests[i], str):
-      tests[i] = subprocess.Popen( # Example: exec python autotest.py dmtcp1
+      tests[i] = subprocess.Popen( # Example: exec python3 autotest.py dmtcp1
                    "exec " + sys.executable + " " + autotest_path + " " +
                      tests[i] + " > /dev/null 2>&1",
                    shell=True)
@@ -1081,9 +1081,12 @@ POST_LAUNCH_SLEEP = 2  # Don't checkpoint until perl cmd has launched
 runTest("perl",          1, ["/usr/bin/perl"])
 POST_LAUNCH_SLEEP=DEFAULT_POST_LAUNCH_SLEEP
 
-if HAS_PYTHON == "yes":
+if HAS_PYTHON == "yes" or HAS_PYTHON3 == "yes":
   POST_LAUNCH_SLEEP = 2  # Don't checkpoint until python cmd has launched
-  runTest("python",      1, ["/usr/bin/python"])
+  if HAS_PYTHON == "yes":
+    runTest("python",      1, ["/usr/bin/env python"])
+  else:
+    runTest("python",      1, ["/usr/bin/env python3"])
   POST_LAUNCH_SLEEP=DEFAULT_POST_LAUNCH_SLEEP
 
 os.environ['DMTCP_GZIP'] = "1"

--- a/test/autotest_config.py.in
+++ b/test/autotest_config.py.in
@@ -8,6 +8,7 @@ ARM_HOST="@ARM_HOST@"
 # We may be running a user's python, but we should only test with canonical one
 HAS_PS="@HAS_PS@"
 HAS_PYTHON="@HAS_PYTHON@"
+HAS_PYTHON3="@HAS_PYTHON3@"
 HAS_READLINE="@HAS_READLINE@"
 HAS_DASH="@HAS_DASH@"
 HAS_TCSH="@HAS_TCSH@"

--- a/util/cpplint.py
+++ b/util/cpplint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #

--- a/util/dmtcp-style.py
+++ b/util/dmtcp-style.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 ''' Runs checks for DMTCP style. '''
 

--- a/util/dmtcp_backtrace.py
+++ b/util/dmtcp_backtrace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/util/gdb-add-libdmtcp-symbol-file.py
+++ b/util/gdb-add-libdmtcp-symbol-file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # This file is deprecated.  It is a hack, to augment the logic for
 #   'add-symbol-file libdmtcp.so' in mtcp/mtcp_restart.c
 # A better version is util/gdb-add-symbol-files-all.  Read heading for info.

--- a/util/gdb.py
+++ b/util/gdb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Here are some gdb commands written in python using the gdb Python API
 # described here:

--- a/util/save-symbol-files-to-gdb-script.py
+++ b/util/save-symbol-files-to-gdb-script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Usage:  python THIS_FILE PID > GDB_SCRIPT
 #    OR:  THIS_FILE PID > GDB_SCRIPT


### PR DESCRIPTION
Almost all distros now provide p`ython3`, and some do not provide `python` by default.

It's now time for DMTCP to default to python3.
Also, the configure.ac has always defined HAS_PYTHON and HAS_PYTHON3.  So, any .in file can test which Python is present.

I also changed `/usr/bin/python3`' to `/usr/bin/env python3`.