### PR TITLE
Fix pthread1 for compiling

### DIFF
--- a/configure
+++ b/configure
@@ -10199,17 +10199,19 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $gccAtomicBuiltins" >&5
 printf "%s\n" "$gccAtomicBuiltins" >&6; }
 
+if test "$gccAtomicBuiltins" = "yes"; then
+
+printf "%s\n" "#define HAS_ATOMIC 1" >>confdefs.h
+
+fi
 if test "$gccAtomicBuiltins" = "no"; then
   { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "Using C++14, which should support both sync and atomic
                   built-ins.  Something is seriously wrong.
-                  In jalloc.cpp, replace __atomic by __sync_bool if the
+                  In jalloc.cpp, replace __atomic_* by __sync_bool_* if the
                   __sync_bool test succeeded, and then edit './configure'.
 See \`config.log' for more details" "$LINENO" 5; }
-
-printf "%s\n" "#define HAS_ATOMIC 1" >>confdefs.h
-
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for __WAIT_STATUS type" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -900,12 +900,14 @@ LDFLAGS="$LDFLAGS_orig"
 AC_LANG_POP([C++])
 AC_MSG_RESULT([$gccAtomicBuiltins])
 
+if test "$gccAtomicBuiltins" = "yes"; then
+  AC_DEFINE([HAS_ATOMIC],[1],[Define to 1 if 'gcc test.c -latomic' works for __atomic_compare_exchange])
+fi
 if test "$gccAtomicBuiltins" = "no"; then
   AC_MSG_FAILURE([Using C++14, which should support both sync and atomic
                   built-ins.  Something is seriously wrong.
                   In jalloc.cpp, replace __atomic_* by __sync_bool_* if the
                   __sync_bool test succeeded, and then edit './configure'.])
-  AC_DEFINE([HAS_ATOMIC],[1],[Define to 1 if 'gcc test.c -latomic' works for __atomic_compare_exchange])
 fi
 dnl Else can use mutex implementation; see jalib/jalloc.cpp
 

--- a/test/pthread1.c
+++ b/test/pthread1.c
@@ -1,9 +1,10 @@
 /* Compile with:  gcc THIS_FILE -lpthread */
 
-#include <assert.h>
 // __USE_GNU is needed for pthread_getattr_np().
 // assert.h is undefining __USE_GNU as of glibc-2.35.  Arguably, a bug.
-#define __USE_GNU
+// #define __USE_GNU
+#define _GNU_SOURCE     /* To get pthread_getattr_np() declaration */
+#include <assert.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -21,6 +22,7 @@ main()
   void *stackaddr;
   size_t stacksize;
   int ret = pthread_getattr_np(pthread_self(), &attr);
+  if (ret != 0) {fprintf(stderr, "error: ret: %d\n", ret);}
   assert(ret == 0);
 
   ret = pthread_attr_getstack(&attr, &stackaddr, &stacksize);


### PR DESCRIPTION
On CentOS 7 (glibc-2.17),, this would not even compile.  This fixes it.  It's trivial to review.