### PR TITLE
configure.ac: define MTCP_PAGE_SIZE in config.h; zero out buf before calling readlink()

### DIFF
--- a/configure
+++ b/configure
@@ -10209,6 +10209,54 @@ as_fn_error $? "Using C++14, which should support both sync and atomic
 See \`config.log' for more details" "$LINENO" 5; }
 fi
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking value of page size (sysconf(_SC_PAGESIZE))" >&5
+printf %s "checking value of page size (sysconf(_SC_PAGESIZE))... " >&6; }
+if test "$cross_compiling" = yes
+then :
+  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else $as_nop
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+           #include <stdio.h>
+           #include <unistd.h>
+           int main() {
+             fprintf(stderr, "%d", sysconf(_SC_PAGESIZE));
+             return 0;
+           }
+
+_ACEOF
+if ac_fn_c_try_run "$LINENO"
+then :
+  sysconf_pagesize=$(./conftest$EXEEXT 2>&1)
+else $as_nop
+  sysconf_pagesize='unknown'
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+if test "$sysconf_pagesize" = "unknown"; then
+  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "Page size not found; Manually change include/config.h
+See \`config.log' for more details" "$LINENO" 5; }
+# else
+#   AC_MSG_RESULT([$sysconf_pagesize])
+fi
+
+printf "%s\n" "#define MTCP_PAGE_SIZE $sysconf_pagesize" >>confdefs.h
+
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $sysconf_pagesize" >&5
+printf "%s\n" "$sysconf_pagesize" >&6; }
+
+printf "%s\n" "#define MTCP_PAGE_SIZE $sysconf_pagesize" >>confdefs.h
+
+
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for __WAIT_STATUS type" >&5
 printf %s "checking for __WAIT_STATUS type... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext

--- a/configure
+++ b/configure
@@ -10041,9 +10041,11 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $gccSyncBuiltins" >&5
 printf "%s\n" "$gccSyncBuiltins" >&6; }
+if test "$gccSyncBuiltins" = "yes"; then
 
 printf "%s\n" "#define HAS_SYNC_BOOL 1" >>confdefs.h
 
+fi
 
 if test "$is_arm_host" == "yes" -o "$is_i486_host" == "yes" ; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for __atomic_compare_exchange_8 in -latomic" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -844,7 +844,9 @@ AC_LINK_IFELSE(
 CXXFLAGS="$CXXFLAGS_orig"
 AC_LANG_POP([C++])
 AC_MSG_RESULT([$gccSyncBuiltins])
-AC_DEFINE([HAS_SYNC_BOOL],[1],[Define to 1 if __sync_bool_compare_and_swap is supported])
+if test "$gccSyncBuiltins" = "yes"; then
+  AC_DEFINE([HAS_SYNC_BOOL],[1],[Define to 1 if __sync_bool_compare_and_swap is supported])
+fi
 
 dnl NOTE:  Using __atomic_* requires linking with -latomic.
 dnl        If libatomic not available, then we must switch to __sync_*.

--- a/configure.ac
+++ b/configure.ac
@@ -905,6 +905,31 @@ if test "$gccAtomicBuiltins" = "no"; then
                   built-ins.  Will default to using slower mutexes in jalloc.cpp])
 fi
 
+AC_MSG_CHECKING([value of page size (sysconf(_SC_PAGESIZE))])
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
+           #include <stdio.h>
+           #include <unistd.h>
+           int main() {
+             fprintf(stderr, "%d", sysconf(_SC_PAGESIZE));
+             return 0;
+           }
+           ]])],[sysconf_pagesize=$(./conftest$EXEEXT 2>&1)],
+                [sysconf_pagesize='unknown'],[])
+if test "$sysconf_pagesize" = "unknown"; then
+  AC_MSG_FAILURE([Page size not found; Manually change include/config.h])
+fi
+AC_DEFINE_UNQUOTED([MTCP_PAGE_SIZE], $sysconf_pagesize,
+                   [Page size (sysconf(_SC_PAGESIZE))])
+
+dnl TODO:  __WAIT_STATUS is defined in include/config.h to be 'int *'
+dnl        POSIX says 'int'.  Why do we need __WAIT_STATUS for DMTCP,
+dnl        and then do AC_DEFINE to define it??
+dnl        It was part of the glibc lxstat support, but it was deprecated,
+dnl        and then removed as of glibcgccAtomicBuiltins" = "no"; then
+AC_MSG_RESULT([$sysconf_pagesize])
+AC_DEFINE_UNQUOTED([MTCP_PAGE_SIZE], $sysconf_pagesize,
+                   [Page size (sysconf(_SC_PAGESIZE))])
+
 dnl TODO:  __WAIT_STATUS is defined in include/config.h to be 'int *'
 dnl        POSIX says 'int'.  Why do we need __WAIT_STATUS for DMTCP,
 dnl        and then do AC_DEFINE to define it??

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -108,6 +108,9 @@
 /* Verbose trace output and log files in $DMTCP_TMPDIR */
 #undef LOGGING
 
+/* Page size (sysconf(_SC_PAGESIZE)) */
+#undef MTCP_PAGE_SIZE
+
 /* Name of package */
 #undef PACKAGE
 

--- a/include/procmapsarea.h
+++ b/include/procmapsarea.h
@@ -23,6 +23,7 @@
 #define PROCMAPSAREA_H
 #include <stdint.h>
 #include <sys/types.h>
+#include "config.h" // For MTCP_PAGE_SIZE
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +35,6 @@ extern "C" {
 #endif // ifdef __cplusplus
 
 // MTCP_PAGE_SIZE must be page-aligned:  multiple of sysconf(_SC_PAGESIZE).
-#define MTCP_PAGE_SIZE        4096
 #define MTCP_PAGE_MASK        (~(MTCP_PAGE_SIZE - 1))
 #define MTCP_PAGE_OFFSET_MASK (MTCP_PAGE_SIZE - 1)
 #define FILENAMESIZE          1024

--- a/src/mtcp/mtcp_check_vdso.c
+++ b/src/mtcp/mtcp_check_vdso.c
@@ -301,7 +301,8 @@ void mtcp_check_vdso(char **environ)
      */
     mtcp_sys_personality((pers | ADDR_NO_RANDOMIZE) & ~ADDR_COMPAT_LAYOUT);
     if ( ADDR_NO_RANDOMIZE & mtcp_sys_personality(0xffffffffUL) ) /* if it's off now */
-    { char runtime[PATH_MAX+1];
+    { // Prepare the runtime buffer; man 2 readlink says it won't NUL terminate.
+      char runtime[PATH_MAX+1] = {0};
       int i = mtcp_sys_readlink("/proc/self/exe", runtime, PATH_MAX);
       if ( i != -1)
       { char *argv[MAX_ARGS+1];

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -1168,7 +1168,8 @@ remapExistingAreasToReservedArea(RestoreInfo *rinfo,
 
   size_t num_regions = 0;
 
-  char binary_name[PATH_MAX+1];
+  // Prepare the binary_name buffer; man 2 readlink says it won't NUL terminate.
+  char binary_name[PATH_MAX+1] = {0};
   MTCP_ASSERT(mtcp_sys_readlink("/proc/self/exe", binary_name, PATH_MAX) != -1);
 
   rinfo->currentVdsoStart = NULL;

--- a/src/util_exec.cpp
+++ b/src/util_exec.cpp
@@ -414,7 +414,8 @@ Util::patchArgvIfSetuid(const char *filename,
   memset(realFilename, 0, sizeof(realFilename));
   expandPathname(filename, realFilename, sizeof(realFilename));
 
-  // char expandedFilename[PATH_MAX];
+  // // Prepare the buffer; man 2 readlink says it won't NUL terminate.
+  // char expandedFilename[PATH_MAX] = {0};
   // expandPathname(filename, expandedFilename, sizeof (expandedFilename));
   // JASSERT(readlink(expandedFilename, realFilename, PATH_MAX - 1) != -1)
   // (filename) (expandedFilename) (realFilename) (JASSERT_ERRNO);

--- a/src/util_misc.cpp
+++ b/src/util_misc.cpp
@@ -574,6 +574,7 @@ Util::areZeroPages(void *addr, size_t numPages)
   size_t end = numPages * page_size / sizeof(*buf);
   long long res = 0;
 
+  ASSERT_EQ(sizeof(*buf) - 1, 7);
   for (i = 0; i + 7 < end; i += 8) {
     res = buf[i + 0] | buf[i + 1] | buf[i + 2] | buf[i + 3] |
       buf[i + 4] | buf[i + 5] | buf[i + 6] | buf[i + 7];

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -933,7 +933,6 @@ runTest("rlimit-restore", 1, ["./test/rlimit-restore"])
 
 runTest("rlimit-nofile",  2, ["./test/rlimit-nofile"])
 
-# Disable procfd1 until we fix readlink
 runTest("procfd1",       2, ["./test/procfd1"])
 
 # popen1 can have more than one processes

--- a/test/dmtcp5.c
+++ b/test/dmtcp5.c
@@ -38,7 +38,8 @@ myHandler(int i)
 int
 main(int argc, char *argv[])
 {
-  char cmd_file[256];
+  // Prepare the cmd_file buffer; man 2 readlink says it won't NUL terminate
+  char cmd_file[256] = {0};
   int cmd_len = readlink("/proc/self/exe", cmd_file, 255);
 
   if (cmd_len == -1) {

--- a/test/syscall-tester.c
+++ b/test/syscall-tester.c
@@ -164,6 +164,8 @@ int save_precious(int fd) {
 char *fd_to_filename(int fd, char buf[], int buf_size) {
   char fd_path[100]; // /proc/PID/fd/FD
   snprintf(fd_path, sizeof(fd_path), "/proc/self/fd/%d", fd);
+  // Prepare the buffer 'buf'; man 2 readlink says it won't NUL terminate.
+  memset(buf, 0, buf_size - 1);
   ssize_t target_len = readlink(fd_path, buf, buf_size - 1);
   if (target_len == -1) {
     perror("DMTCP: fd_to_filename: readlink");
@@ -2598,6 +2600,8 @@ readlink_test(char *path, char *buf, size_t bufsiz)
   fflush(NULL);
 
   /* do not assume buf will be null terminated */
+  // Prepare the buffer 'buf'; man 2 readlink says it won't NUL terminate.
+  memset(buf, 0, bufsiz);
   passed = handle_gez(ret = readlink(path, buf, bufsiz));
   save_errno = errno;
 


### PR DESCRIPTION
There are two general bugs, that happen to be uncovered when porting to Debian-12 on ARM64.  This PR has been tested on a Raspberry Pi on ARM64/Debian-12, and all tests pass now.

**BUG #1 (first commit):**
Debian-12 (bookworm) on ARM64 has a page size of 16384, instead of the traditional 4096.
This PR calculates MTCP_PAGE_SIZE in configure.ac using `sysconf(_SC_PAGESIZE)`, and then defines it in `config.h`.  We no longer do a separate `#define MTCP_PAGE_SIZE` in files outside of `config.h`.

**BUG #2 (second commit):**
`man 2 readlink` says that it doesn't NUL-terminate strings in the buffer that it writes.  This was happening on ARM64 when calling readlink on `/proc/self/exe`.  That caused a bug on restart.  This now fixes it.