### PR TITLE
Fix restoreBuf overlaps

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -1120,6 +1120,12 @@ remapMtcpRestartToReservedArea(RestoreInfo *rinfo,
 
   // Reserve the entire restore area. This would ensure no other memory regions
   // get mapped in this location.
+  //FIXME:  Since rinfo.restore_size is a synonym for restoreBufLen, which is
+  //        a synonym for RESTORE_TOTAL_SIZE, why don't we just use
+  //        rinfo.restore_size here and below?
+  //        The current code is probably left over from a request for
+  //        a now obsolete request by the MANA project.  We should
+  //        refactor this.
   void *addr = mmap_fixed_noreplace(rinfo->restore_addr,
                                     RESTORE_TOTAL_SIZE,
                                     PROT_NONE,

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -338,8 +338,20 @@ ProcessInfo::updateRestoreBufAddr(void* addr, uint64_t len)
   //         then sets it to _restoreBufLen.  But ProcessInfo::init() had
   //         previously set _restoreBufLen to RESTORE_TOTAL_SIZE.  So, we
   //         have now made the round trip.  This is spaghetti code. :-(
+  // NOTE: This note explains why we need the multiplier, 3, for 3*_restoreBufLen.
+  //       _restoreBufLen is a synonym for RESTORE_TOTAL_SIZE.
+  //       See the comment inside writeckpt.cpp:mtcp_writememoryareas() for
+  //       the purpose of the "restoreBuf" (aka "holebase").  Due to
+  //       address space randomization, this "restoreBuf" may have an
+  //       address conflict with the "stack", "vvar" or other, for mtcp_restart.
+  //       So, we mmap 3 * RESTORE_TOTAL_SIZE.  The entire test/data/stack of
+  //       of mtcp_restart is assumed to fit inside RESTORE_TOTAL_SIZE bytes.
+  //       So, the memory of mtcp_restart will overlap with at most two
+  //       of the three regions of size RESTORE_TOTAL_SIZE.  So, mtcp_restart
+  //       is guaranteed to find a "holebase" that doesn't overlap with
+  //       the existing memory of mtcp_restart.
   _restoreBufLen = len;
-  _restoreBufAddr = (uint64_t) mmap(addr, _restoreBufLen,
+  _restoreBufAddr = (uint64_t) mmap(addr, 3 * _restoreBufLen,
                     PROT_NONE, flags, -1, 0);
   JASSERT(_restoreBufAddr != (uint64_t) MAP_FAILED) (JASSERT_ERRNO);
 }


### PR DESCRIPTION
    mtcp_restart.c: If restoreBuf overlaps, try two more restoreBuf regions of the same size.

* In Linux 6.1 (Fedora-38), for mtcp_restart (compiled with '-fPIC'), we see
   that vvar/vdso are below stack; stack starts near 0x4000000000  For example:
>    0x3ff7ffc000       0x3ff7ffe000     0x2000        0x0  r--p   [vvar]
>   0x3ff7ffe000       0x3ff8000000     0x2000        0x0  r-xp   [vdso]
>   0x3ffffdf000       0x4000000000    0x21000        0x0  rw-p   [stack]

With address space randomization, the restoreBuf has a high probability
of overlapping with vvar/vdso.  So, we use 3 contiguous restoreBuf regions.
At least one of them has no overlap if region < RESTORE_TOTAL_SIZE. 