### PR TITLE
We cannot trust ARM64 for HAS_ATOMIC

### DIFF
--- a/configure
+++ b/configure
@@ -11590,7 +11590,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 printf "%s\n" "$gccSyncBuiltins" >&6; }
 if test "$gccSyncBuiltins" = "yes"; then
 
-printf "%s\n" "#define HAS_SYNC_BOOL 1" >>confdefs.h
+printf "%s\n" "#define HAS_128_SYNC_BOOL 1" >>confdefs.h
 
 fi
 
@@ -11745,7 +11745,7 @@ printf "%s\n" "$gccAtomicBuiltins" >&6; }
 
 if test "$gccAtomicBuiltins" = "yes"; then
 
-printf "%s\n" "#define HAS_ATOMIC 1" >>confdefs.h
+printf "%s\n" "#define HAS_128_ATOMIC 1" >>confdefs.h
 
 fi
 if test "$gccAtomicBuiltins" = "no"; then

--- a/configure.ac
+++ b/configure.ac
@@ -857,7 +857,7 @@ CXXFLAGS="$CXXFLAGS_orig"
 AC_LANG_POP([C++])
 AC_MSG_RESULT([$gccSyncBuiltins])
 if test "$gccSyncBuiltins" = "yes"; then
-  AC_DEFINE([HAS_SYNC_BOOL],[1],[Define to 1 if __sync_bool_compare_and_swap is supported])
+  AC_DEFINE([HAS_128_SYNC_BOOL],[1],[Define to 1 if __sync_bool_compare_and_swap is supported])
 fi
 
 dnl NOTE:  Using __atomic_* requires linking with -latomic.
@@ -910,7 +910,7 @@ AC_LANG_POP([C++])
 AC_MSG_RESULT([$gccAtomicBuiltins])
 
 if test "$gccAtomicBuiltins" = "yes"; then
-  AC_DEFINE([HAS_ATOMIC],[1],[Define to 1 if 'gcc test.c -latomic' works for __atomic_compare_exchange])
+  AC_DEFINE([HAS_128_ATOMIC],[1],[Define to 1 if 'gcc test.c -latomic' works for __atomic_compare_exchange])
 fi
 if test "$gccAtomicBuiltins" = "no"; then
   AC_MSG_FAILURE([Using C++14, which should support both sync and atomic

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -25,7 +25,10 @@
 #undef FORKED_CHECKPOINTING
 
 /* Define to 1 if 'gcc test.c -latomic' works for __atomic_compare_exchange */
-#undef HAS_ATOMIC
+#undef HAS_128_ATOMIC
+
+/* Define to 1 if __sync_bool_compare_and_swap is supported */
+#undef HAS_128_SYNC_BOOL
 
 /* Define to 1 if you have process_vm_readv and process_vm_writev. */
 #undef HAS_CMA
@@ -41,9 +44,6 @@
 
 /* Allow 'gdb attach' when DMTCP_RESTART_PAUSE_WHILE is defined. */
 #undef HAS_PR_SET_PTRACER
-
-/* Define to 1 if __sync_bool_compare_and_swap is supported */
-#undef HAS_SYNC_BOOL
 
 /* define if the compiler supports basic C++14 syntax */
 #undef HAVE_CXX14

--- a/jalib/jalloc.cpp
+++ b/jalib/jalloc.cpp
@@ -139,14 +139,14 @@ static inline bool
 bool_atomic_dwcas(void volatile *dst, void *oldValue, void *newValue)
 {
   bool result = false;
-#if defined(HAS_ATOMIC)
+#if defined(HAS_128_ATOMIC)
   // This requires libatomic.so in GNU
   typedef unsigned __int128 uint128_t;
   result = __atomic_compare_exchange((uint128_t*)dst,
                                      (uint128_t*)oldValue,
                                      (uint128_t*)newValue, 0,
                                       __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
-#elif defined (HAS_SYNC_BOOL)
+#elif defined (HAS_128_SYNC_BOOL)
   typedef unsigned __int128 uint128_t;
   // This requires compiling with -mcx16
   result = __sync_bool_compare_and_swap((uint128_t volatile *)dst,


### PR DESCRIPTION
 * FIXME:  We should use futex_wait, futex_post instead of pthread_mutex_lock/unlock for ARM64 for the reasons below. Add another commit.
 * See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70814 for the problem with /lib/aarch64-linux-gnu/libatomic.so.1 on ARM64 as of Sept., 2024.  (tested on libc-2.36)

@maxwellpirtle, Does this PR now fix the bug you saw with McMini during startup?

@karya0 ,
    This was a weird bug.  jalloc.cpp had HAS_ATOMIC defined, and used the C++ atomics. That caused C++ to delegate to libatomic.so.  But in libatomic.so, they did _not_ use the atomic assembly instruction.  Instead, they called `pthread_mutex_lock`.  Unfortunately, McMini had its own wrapper around  `pthread_mutex_lock`.  And that led to DMTCP getting control again and DMTCP trying to do an atomic in jalloc.cpp.
    So, for ARM64, I'm not allowing it to use HAS_ATOMIC.  The URL above has a full explanation.