### PR TITLE
ARM64: add comment, __NR_getpgrp doesn't exist in glibc-2.36

### DIFF
--- a/src/plugin/pid/pid_miscwrappers.cpp
+++ b/src/plugin/pid/pid_miscwrappers.cpp
@@ -347,6 +347,7 @@ syscall(long sys_num, ...)
 // SYS_getpgrp undefined in aarch64.
 // Presumably, it's handled by libc, and is not a kernel call
 //   in AARCH64 (e.g., v5.01).
+// Tested with glibc-2.36:  __NR_getpgrp not defined on ARM64.
 #ifndef __aarch64__
   case SYS_getpgrp:
   {


### PR DESCRIPTION
So, __NR_getpgrp is  not defined for ARM64, even though glibc-2.36 does have the getprgrp symbol.

I've tested this now on an ARM64 Raspberry Pi with glibc-2.36.