### PR TITLE
util/check-pthread-tid-offset.c: update for risc-v

### DIFF
--- a/src/plugin/pid/glibc_pthread.h
+++ b/src/plugin/pid/glibc_pthread.h
@@ -105,13 +105,17 @@
 // TODO(kapil): Add dynamic check for this.
 #define _STACK_GROWS_DOWN 1
 
+// These constants can be determined automatically, by running:
+//  check-pthread-tid-offset -v # Source code in util/check-pthread-tid-offset.c
 struct libc_tcbhead_t {
-#if defined(__arm__) || defined(__aarch64__)
-  char pad[24 * sizeof(void*)];
-#elif defined(__x86__) || defined(__x86_64__)
+#if defined(__x86__) || defined(__x86_64__)
   char pad[704];
+#elif defined(__arm__) || defined(__aarch64__)
+  char pad[24 * sizeof(void*)];
+#elif defined(__riscv)
+  char pad[192]; // Same as 'char pad[24 * sizeof(void*)];' (__aarch64__ above)
 #else
-# error "Unsupported architecture"
+# error "Unsupported architecture; Call executable with '-v' flag for info."
 #endif
 };
 


### PR DESCRIPTION
This updates to confirm the constant for RISC-V now.

`util/check-pthread-tid-offset -v` now has a clearer message.

As before, ./configure runs this utility to verify that the tid offset has not changed in the most recent glibc.