### PR TITLE
autotest.py: int/int (float); --verbose/JWARN sets color mode

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -428,7 +428,7 @@ def free_diskspace(dir):
 # We can use the lesser of half the free disk space of filesystem or 100 MB.
 if free_diskspace(ckptDir) > 20*1024*1024:
   oldLimit = resource.getrlimit(resource.RLIMIT_CORE)
-  newLimit = [min(free_diskspace(ckptDir)/2, 100*1024*1024), oldLimit[1]]
+  newLimit = [min(free_diskspace(ckptDir)//2, 100*1024*1024), oldLimit[1]]
   if oldLimit[1] != resource.RLIM_INFINITY:  # Keep soft limit below hard limit
     newLimit[0] = min(newLimit[0], oldLimit[1])
   resource.setrlimit(resource.RLIMIT_CORE, newLimit)

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -656,6 +656,9 @@ def runTestRaw(name, numProcs, cmds):
 
   try:
     sys.stdout.flush()
+    # If verbose mode, maybe JWARNING/KASSERT was interrupted during color print
+    if args.verbose:
+      os.write(sys.stdout.fileno(), COLOR_RESET.encode("ascii"))
     printFixed(name, DEFAULT_TESTNAME_WIDTH)
 
     if name in disabled_tests:


### PR DESCRIPTION
This is trivial to review.
1.  In Python, an `int / int` returns a float.  We wanted to return an int.  Hence, `int // int`
2. If `autotest.py --verbose` and `JWARNING` or `JASSERT` occurs, then it starts printing in color, and the timeout in autotest kills the process.  Now, autotest.py will clear the color mode at the next test.  (And of course, the user can call `reset` if it was only a single test for `autotest`.