### PR TITLE
Fix 'dmtcp_command -kc'

### DIFF
--- a/src/dmtcp_command.cpp
+++ b/src/dmtcp_command.cpp
@@ -206,10 +206,14 @@ main(int argc, char **argv)
               "Unknown command: %c, try 'dmtcp_command --help'\n", *cmd);
       break;
     case CoordCmdStatus::ERROR_NOT_RUNNING_STATE:
-      fprintf(stderr,
-              "Error, computation not in running state."
-              "  Either a checkpoint is\n"
-              " currently happening or there are no connected processes.\n");
+      if (*cmd == 'K') {
+        printf("Computation was checkpointed and killed.\n");
+      } else {
+        fprintf(stderr,
+                "Error, computation not in running state."
+                "  Either a checkpoint is\n"
+                " currently happening or there are no connected processes.\n");
+      }
       break;
     default:
       fprintf(stderr, "Unknown error\n");

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -310,11 +310,12 @@ DmtcpCoordinator::handleUserCommand(string cmd, DmtcpMessage *reply /*= NULL*/)
     reply->coordCmdStatus = CoordCmdStatus::NOERROR;
   }
 
-  if (cmd == "bc" || cmd == "kc" || cmd == "ck" || cmd == "c") {
+  if (cmd == "bc" || cmd == "kc" || cmd == "ck" || cmd == "K" || cmd == "c") {
     if (cmd == "bc") {
       blockUntilDone = true;
       JTRACE("blocking checkpoint beginning...");
-    } else if (cmd == "kc" || cmd == "ck") {
+    } else if (cmd == "kc" || cmd == "ck" || cmd == "K") {
+      // dmtcp_command encodes this as 'cmd == "K"; '-kc' is the user flag.
       JTRACE("Will kill peers after creating the checkpoint...");
       killAfterCkptOnce = true;
     } else {
@@ -1480,7 +1481,7 @@ DmtcpCoordinator::updateCheckpointInterval(uint32_t interval)
     theCheckpointInterval = interval;
   }
   if (clients.size() == 0) {
-    resetCkptTimer(); // Will set to staleTimeout; Coulld be onDisconnect
+    resetCkptTimer(); // Will set to staleTimeout; Could be onDisconnect
     currentCkptInterval = -1; // Set to -1; we now have staleTimeout
   } else if (currentCkptInterval == -1) { // Was staleTimeout or initializing
     resetCkptTimer(); // Could be onConnect or initializing


### PR DESCRIPTION
This was checkpointing, but not also killing the computation, which `-kc` was supposed to do.
This is fixed now.  This should be trivial to review.  The bug fix is just 3 lines (in the first commit).  (The second commit is to clean up some code in `dmtcp_command.cpp`.  But also simple.)

And this has been a long-standing bug, ever since we chose to internally use the unique command 'K' instead of '-kc', for reasons of simplifying the `coordinatorapi.cpp` logic with a single character.

And of course, we need this fix, also, before the DMTCP-3.1.0 release.  :-(