### PR TITLE
Aarch64 jalloc fixed

### DIFF
--- a/configure
+++ b/configure
@@ -698,6 +698,9 @@ am__EXEEXT_FALSE
 am__EXEEXT_TRUE
 LTLIBOBJS
 LIBOBJS
+AARCH64_GCC_HOST
+AARCH64_GCC_HOST_FALSE
+AARCH64_GCC_HOST_TRUE
 AARCH64_HOST
 AARCH64_HOST_FALSE
 AARCH64_HOST_TRUE
@@ -8090,6 +8093,28 @@ else
 
 fi
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether ARM64/aarch64 and g++ (if we need to use -mno-outline)" >&5
+printf %s "checking whether ARM64/aarch64 and g++ (if we need to use -mno-outline)... " >&6; }
+ if test "$is_aarch64_host" == "yes" -a "$CC" == "gcc"; then
+  AARCH64_GCC_HOST_TRUE=
+  AARCH64_GCC_HOST_FALSE='#'
+else
+  AARCH64_GCC_HOST_TRUE='#'
+  AARCH64_GCC_HOST_FALSE=
+fi
+
+if test "$is_aarch64_host" == "yes" -a "$CC" == "gcc"; then
+  AARCH64_GCC_HOST=yes
+
+  is_aarch64_gcc="yes"
+else
+  AARCH64_GCC_HOST=no
+
+  is_aarch64_gcc="no"
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $is_aarch64_gcc" >&5
+printf "%s\n" "$is_aarch64_gcc" >&6; }
+
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether tid offset for glibc is correct" >&5
 printf %s "checking whether tid offset for glibc is correct... " >&6; }
 CFLAGS_orig="$CFLAGS"
@@ -8295,6 +8320,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${AARCH64_HOST_TRUE}" && test -z "${AARCH64_HOST_FALSE}"; then
   as_fn_error $? "conditional \"AARCH64_HOST\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${AARCH64_GCC_HOST_TRUE}" && test -z "${AARCH64_GCC_HOST_FALSE}"; then
+  as_fn_error $? "conditional \"AARCH64_GCC_HOST\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 
@@ -11494,10 +11523,14 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
     #include <assert.h>
     #include <stdlib.h>
     int main() {
-      typedef unsigned __int128 uint128_t;
-      uint128_t val = static_cast<uint128_t>(1);
-      bool result = __sync_bool_compare_and_swap(&val, 1, 2);
-      assert(result == true && static_cast<int>(val) == 2);
+      __int128 dest = static_cast<__int128>(0x1234567812345678);
+      __int128 oldValue=0x7ffffffff098;
+      __int128 newValue=0x7ffffffff088;
+      bool result = __sync_bool_compare_and_swap(&dest, oldValue, newValue);
+      assert(result == false && dest != newValue);
+      dest = oldValue;
+      result = __sync_bool_compare_and_swap(&dest, oldValue, newValue);
+      assert(result == true && dest == newValue);
       return 0;
     }
 
@@ -11944,6 +11977,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${AARCH64_HOST_TRUE}" && test -z "${AARCH64_HOST_FALSE}"; then
   as_fn_error $? "conditional \"AARCH64_HOST\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${AARCH64_GCC_HOST_TRUE}" && test -z "${AARCH64_GCC_HOST_FALSE}"; then
+  as_fn_error $? "conditional \"AARCH64_GCC_HOST\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${am__EXEEXT_TRUE}" && test -z "${am__EXEEXT_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -428,6 +428,18 @@ else
   AC_SUBST([AARCH64_HOST], [no])
 fi
 
+AC_MSG_CHECKING([whether ARM64/aarch64 and g++ (if we need to use -mno-outline)])
+AM_CONDITIONAL(AARCH64_GCC_HOST,
+	       [test "$is_aarch64_host" == "yes" -a "$CC" == "gcc"])
+if test "$is_aarch64_host" == "yes" -a "$CC" == "gcc"; then
+  AC_SUBST([AARCH64_GCC_HOST], [yes])
+  is_aarch64_gcc="yes"
+else
+  AC_SUBST([AARCH64_GCC_HOST], [no])
+  is_aarch64_gcc="no"
+fi
+AC_MSG_RESULT([$is_aarch64_gcc])
+
 AC_MSG_CHECKING([whether tid offset for glibc is correct])
 CFLAGS_orig="$CFLAGS"
 CFLAGS="$CFLAGS -pthread"
@@ -802,14 +814,23 @@ CXXFLAGS_orig="$CXXFLAGS"
 CXXFLAGS="$CXXFLAGS -march=native"
 AC_LINK_IFELSE(
 [
+dnl NOTE:  x86_64 and clang do sync_book_compare_and_swap fine.
+dnl        Unfortunately, the Debian-12 release (and others??)
+dnl        have a gcc-12 that by default uses 'gcc -noutline',
+dnl        which assumes __aarch64_cas16_sync is defined, and gcc defines it
+dnl        _only_ if this is the base executable, and not a .o or .so file
   AC_LANG_SOURCE([[
     #include <assert.h>
     #include <stdlib.h>
     int main() {
-      typedef unsigned __int128 uint128_t;
-      uint128_t val = static_cast<uint128_t>(1);
-      bool result = __sync_bool_compare_and_swap(&val, 1, 2);
-      assert(result == true && static_cast<int>(val) == 2);
+      __int128 dest = static_cast<__int128>(0x1234567812345678);
+      __int128 oldValue=0x7ffffffff098;
+      __int128 newValue=0x7ffffffff088;
+      bool result = __sync_bool_compare_and_swap(&dest, oldValue, newValue);
+      assert(result == false && dest != newValue);
+      dest = oldValue;
+      result = __sync_bool_compare_and_swap(&dest, oldValue, newValue);
+      assert(result == true && dest == newValue);
       return 0;
     }
   ]])

--- a/plugin/Makefile.in
+++ b/plugin/Makefile.in
@@ -248,6 +248,7 @@ am__define_uniq_tagged_files = \
   done | $(am__uniquify_input)`
 am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/depcomp README
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+AARCH64_GCC_HOST = @AARCH64_GCC_HOST@
 AARCH64_HOST = @AARCH64_HOST@
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,15 +19,31 @@ dmtcplibdir = $(pkglibdir)
 
 SUBDIRS = mtcp plugin
 
+# clang/llmv handles arm64 correctly, but not GNU gcc.  For an overview,
+#   see:  https://github.com/llvm/llvm-project/issues/71883
+# Automake requires this weird syntax (*_x86_64; *AARCH64) using configure.ac.
+# Automake is a hack, halfway betwen GNU extensions to Makefile and autoconf/sh.
 if X86_64_HOST
- JALLOC_ATOMIC_128_CXXFLAG = -mcx16
-else
- JALLOC_ATOMIC_128_CXXFLAG =
+ JALLOC_ATOMIC_128_CXXFLAG_x86_64 = -mx86-64-v2
 endif
+if AARCH64_GCC_HOST
+# For gcc-12:
+# See  https://lore.kernel.org/linux-arm-kernel/20240109082647.GJ19790@gate.crashing.org/T/#m2b7753c4dab70f67497dd4e618e80150649c133d
+# I suspect this is down to your toolchain enabling -moutline-atomics by default;
+# I suspect your # cross-compile toolchain doesn't enable that by default.
+# Unfortunately, '-mno-outline' will cause arum64 to use the slower futexes.
+# Arguably, this is a bug.
+# If this is a problem, then use clang (LLVM) instead of gcc,r or wait and see
+# if Debian/GNU gcc.will fix this toolchain misfeature.
+# See configure.ac for further discussion.
+ JALLOC_ATOMIC_128_CXXFLAG_AARCH64 = -mno-outline-atomics
+endif
+## risc-v does not appear to support sync_bool_compare_and_swap as of 2024.
+## So, jalib/jalloc.cpp will use a futex for risc-v.
 
 PICFLAGS=-fPIC
 AM_CFLAGS = $(PICFLAGS)
-AM_CXXFLAGS = $(PICFLAGS) $(JALLOC_ATOMIC_128_CXXFLAG)
+AM_CXXFLAGS = $(PICFLAGS) $(JALLOC_ATOMIC_128_CXXFLAG_X86_64) $(JALLOC_ATOMIC_128_CXXFLAG_AARCH64)
 AM_LDFLAGS = $(PICFLAGS)
 
 if CONFIG_M32

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -405,6 +405,7 @@ am__relativize = \
     dir1=`echo "$$dir1" | sed -e "$$sed_rest"`; \
   done; \
   reldir="$$dir2"
+AARCH64_GCC_HOST = @AARCH64_GCC_HOST@
 AARCH64_HOST = @AARCH64_HOST@
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@
@@ -575,11 +576,26 @@ jalibdir = $(top_srcdir)/jalib
 dmtcpincludedir = $(top_srcdir)/include
 dmtcplibdir = $(pkglibdir)
 SUBDIRS = mtcp plugin
-@X86_64_HOST_FALSE@JALLOC_ATOMIC_128_CXXFLAG = 
-@X86_64_HOST_TRUE@JALLOC_ATOMIC_128_CXXFLAG = -mcx16
+
+# clang/llmv handles arm64 correctly, but not GNU gcc.  For an overview,
+#   see:  https://github.com/llvm/llvm-project/issues/71883
+# Automake requires this weird syntax (*_x86_64; *AARCH64) using configure.ac.
+# Automake is a hack, halfway betwen GNU extensions to Makefile and autoconf/sh.
+@X86_64_HOST_TRUE@JALLOC_ATOMIC_128_CXXFLAG_x86_64 = -mx86-64-v2
+# For gcc-12:
+# See  https://lore.kernel.org/linux-arm-kernel/20240109082647.GJ19790@gate.crashing.org/T/#m2b7753c4dab70f67497dd4e618e80150649c133d
+# I suspect this is down to your toolchain enabling -moutline-atomics by default;
+# I suspect your # cross-compile toolchain doesn't enable that by default.
+# Unfortunately, '-mno-outline' will cause arum64 to use the slower futexes.
+# Arguably, this is a bug.
+# If this is a problem, then use clang (LLVM) instead of gcc,r or wait and see
+# if Debian/GNU gcc.will fix this toolchain misfeature.
+# See configure.ac for further discussion.
+@AARCH64_GCC_HOST_TRUE@JALLOC_ATOMIC_128_CXXFLAG_AARCH64 = -mno-outline-atomics
 PICFLAGS = -fPIC
 AM_CFLAGS = $(PICFLAGS)
-AM_CXXFLAGS = $(PICFLAGS) $(JALLOC_ATOMIC_128_CXXFLAG) $(am__append_1)
+AM_CXXFLAGS = $(PICFLAGS) $(JALLOC_ATOMIC_128_CXXFLAG_X86_64) \
+	$(JALLOC_ATOMIC_128_CXXFLAG_AARCH64) $(am__append_1)
 AM_LDFLAGS = $(PICFLAGS)
 @CONFIG_M32_FALSE@d_libdir = $(top_builddir)/lib/$(PACKAGE)
 @CONFIG_M32_TRUE@d_libdir = $(top_builddir)/lib/$(PACKAGE)/32/lib/$(PACKAGE)

--- a/src/dmtcp_command.cpp
+++ b/src/dmtcp_command.cpp
@@ -20,6 +20,7 @@
  ****************************************************************************/
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "coordinatorapi.h"
 #include "util.h"
@@ -72,6 +73,7 @@ main(int argc, char **argv)
   string interval = "";
   string request = "h";
 
+  setenv("DMTCP_COMMAND", "1", 1); // for jalloc.cpp/sync_bool_compare_adn_swap
   initializeJalib();
 
   // No need to initialize the log file.

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -1024,7 +1024,7 @@ DmtcpCoordinator::onConnect()
     client->virtualPid(hello_remote.from.pid());
     _virtualPidToClientMap[client->virtualPid()] = client;
   } else if (hello_remote.type == DMT_NEW_WORKER) {
-    // Comping from dmtcp_launch or fork(), ssh(), etc.
+    // Coming from dmtcp_launch or fork(), ssh(), etc.
     JASSERT(hello_remote.state == WorkerState::RUNNING ||
             hello_remote.state == WorkerState::UNKNOWN);
     JASSERT(hello_remote.virtualPid == -1);

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -389,7 +389,7 @@ main(int argc, const char **argv)
   if (getenv("DMTCP_ABORT_ON_FAILED_ASSERT")) {
     JNOTE("\n\n*********************************************\n"
               "* DMTCP_ABORT_ON_FAILED_ASSERT is obsolete. *\n"
-              "* Plesae use DMTCP_ABORT_ON_FAILURE instead.*\n"
+              "* Please use DMTCP_ABORT_ON_FAILURE instead.*\n"
               "*********************************************\n");
   }
 

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -372,7 +372,7 @@ DmtcpWorker::waitForCheckpointRequest()
   // Further, we also want to prevent any overlap between an event-hook call
   // made here vs. an event-hook call made by the user thread in vfork().
   ThreadSync::presuspendEventHookLockLock();
-  JTRACE("Procesing pre-suspend barriers");
+  JTRACE("Processing pre-suspend barriers");
   PluginManager::eventHook(DMTCP_EVENT_PRESUSPEND);
   ThreadSync::presuspendEventHookLockUnlock();
 

--- a/src/execwrappers.cpp
+++ b/src/execwrappers.cpp
@@ -200,7 +200,7 @@ fork()
     // called at the very beginning, the parent process won't have a chance to
     // reset the lock. Calling ThreadList::resetOnFork here ensures that any
     // such locks would have been reset by the caller and hence it's safe to
-    // call pthread_creat at this point.
+    // call pthread_create at this point.
     ThreadList::resetOnFork();
 
     /* NOTE: Any work that needs to be done for the newly created child

--- a/src/plugin/Makefile.in
+++ b/src/plugin/Makefile.in
@@ -348,6 +348,7 @@ am__define_uniq_tagged_files = \
   done | $(am__uniquify_input)`
 am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/depcomp
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+AARCH64_GCC_HOST = @AARCH64_GCC_HOST@
 AARCH64_HOST = @AARCH64_HOST@
 ACLOCAL = @ACLOCAL@
 AMTAR = @AMTAR@

--- a/src/procselfmaps.cpp
+++ b/src/procselfmaps.cpp
@@ -41,7 +41,7 @@ ProcSelfMaps::ProcSelfMaps()
   // for each level of the allocator.  See jalib/jalloc.cpp:preExpand().
   // It assumes no allocation larger than jalloc.cpp:MAX_CHUNKSIZE.
   // Ideally, we would have followed the MTCP C code, and not allocated
-  // any memory bewteen the constructor and destructor of ProcSelfMaps.
+  // any memory between the constructor and destructor of ProcSelfMaps.
   // But since C++ is biased toward frequent mallocs (e.g., dynamic vectors),
   // we try to compensate here for the weaknesses of C++.
   // If we use this /proc/self/maps for checkpointing, we must not mmap

--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -214,7 +214,7 @@ SharedData::initialize(const char *tmpDir,
       // performance optimization, we could use a SysV // semaphore/condition
       // variable, instead of sleeping and re-trying inside the loop.
       // NOTE:  This code is correct under total store order or seq. consist.
-      //   But the relaxed consstency model, partial store order, ouuld create a
+      //   But the relaxed consistency model, partial store order, ouuld create a
       //   theoretically possible bug if initialized does not reach memory last.
       if (statbuf.st_size > 0 && initialized) {
         break;

--- a/src/tls.cpp
+++ b/src/tls.cpp
@@ -144,7 +144,7 @@ static int glibcMinorVersion()
  */
 
 /* NOTE:  For future reference, the STATIC_TLS_TID_OFFSET() for a glibc version
- *  can be easily discvoered as long as a debug version of glibc is present:
+ *  can be easily discovered as long as a debug version of glibc is present:
  *  (gdb) p (char *)&(((struct pthread *)pthread_self())->tid) - \
  *                                                      (char *)pthread_self()
  *  $14 = 720  # So, 720 is the correct offset in this example.
@@ -219,13 +219,13 @@ tls_set_thread_area(Thread *thread)
 
   if (mtcp_inline_syscall(arch_prctl, 2, ARCH_SET_FS, thread->tlsInfo.fs)
       != 0) {
-    printf("\n*** DMTCP: Error restorig TLS.\n\n");
+    printf("\n*** DMTCP: Error restoring TLS.\n\n");
     abort();
   };
 
   if (mtcp_inline_syscall(arch_prctl, 2, ARCH_SET_GS, thread->tlsInfo.gs)
       != 0) {
-    printf("\n*** DMTCP: Error restorig TLS.\n\n");
+    printf("\n*** DMTCP: Error restoring TLS.\n\n");
     abort();
   }
 }
@@ -254,7 +254,7 @@ tls_set_thread_area(Thread *thread)
 
   if (mtcp_inline_syscall(set_thread_area, 1, &thread->tlsInfo.gdtentrytls)
         != 0) {
-    printf("\n*** DMTCP: Error restorig TLS.\n\n");
+    printf("\n*** DMTCP: Error restoring TLS.\n\n");
     abort();
   };
 
@@ -301,7 +301,7 @@ tls_set_thread_area(Thread *thread)
   if (mtcp_syscall(__ARM_NR_set_thread_area,
                    &mtcp_sys_errno,
                    thread->tlsInfo.tlsAddr) != 0) {
-    printf("\n*** DMTCP: Error restorig TLS.\n\n");
+    printf("\n*** DMTCP: Error restoring TLS.\n\n");
     abort();
   };
 }

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -859,7 +859,7 @@ runTest("gettid",        1, ["./test/gettid"])
 # (sets exitAfterCkptOnce in src/dmtcp_coordinator.cpp) for
 # checkpointing so that the process is killed right after checkpoint. Otherwise
 # the syscall-tester could fail in the following case:
-#   1. create and open temp file
+#   1. create an open temp file
 #   2. close temp file
 #   3. ckpt
 #   4. unlink temp file

--- a/util/gdb-dmtcp-utils.py
+++ b/util/gdb-dmtcp-utils.py
@@ -547,7 +547,7 @@ class Pstree(gdb.Command):
 Pstree()
 
 class Lsof(gdb.Command):
-  """pstree (same as:  shell shell lsof -w [for this username])"""
+  """lsof (same as:  shell shell lsof -w [for this username])"""
   def __init__(self):
     super(Lsof,
           self).__init__("lsof", gdb.COMMAND_STATUS)


### PR DESCRIPTION
First commit:  Change configure.ac, src/Makefile.am to recognize if this is aarch64 with gcc/g++.  If so, then due to what is arguably a bug, dwcas in jalloc.cpp fails for `__sync_bool_cmpare_and_swap`.  The comments tell the full story.

In the second commit, we have a problem, because the tiny dmtcp_command executable has to support all of the complexity of libjalib.a.  In particular, dmtcp_launch/restart/coordnator was fixed by the first commit.  But for dmtcp_command, it uses jalloc (even though there's no good reason for that).  In the future, we should simply remove JALLOC and jalloc.cpp:malloc from being called by dmtcp_command.cpp/coordinatorapi.cpp.

The third commit is simply a spell fix and fixing minor typos.