### PR TITLE
Misc before 3.1.0

### DIFF
--- a/jalib/jassert.cpp
+++ b/jalib/jassert.cpp
@@ -83,6 +83,7 @@ jassert_internal::JAssert::JAssert(JAssertType type)
 jassert_internal::JAssert::~JAssert()
 {
   if (_type != JAssertType::Error) {
+    Print(clearEscapeStr);
     writeToConsole(ss.str().c_str());
     writeToLog(ss.str().c_str());
     return;

--- a/jalib/jassert.h
+++ b/jalib/jassert.h
@@ -115,6 +115,8 @@ class JAssert
         return redEscapeStr;
       case JAssertType::Warning:
         return yellowEscapeStr;
+      case JAssertType::Note:
+        return greenEscapeStr;
       default:
         return "";
     }

--- a/src/plugin/dl/dlwrappers.cpp
+++ b/src/plugin/dl/dlwrappers.cpp
@@ -104,7 +104,7 @@ dlopen_try_paths(const char *filename, int flag, string path)
  * dlsym/dlopen/dlclose make a call to calloc() internally. We do not want to
  * checkpoint while we are in the midst of dlopen etc. as it can lead to
  * undesired behavior. To do so, we use WRAPPER_EXECUTION_DISABLE_CKPT() at the
- * beginning of the funtion. However, if a checkpoint request is received right
+ * beginning of the function. However, if a checkpoint request is received right
  * after WRAPPER_EXECUTION_DISABLE_CKPT(), the ckpt-thread is queued for wrlock
  * on the pthread-rwlock and any subsequent request for rdlock by other threads
  * will have to wait until the ckpt-thread releases the lock. However, in this

--- a/src/plugin/ipc/socket/connectionrewirer.cpp
+++ b/src/plugin/ipc/socket/connectionrewirer.cpp
@@ -178,7 +178,7 @@ ConnectionRewirer::openRestoreSocket(bool hasIPv4Sock,
     // socket address of the restoreSocket object (line 181). Unfortunately,
     // the jalib::JServerSocket class does not provide any interface that can
     // allow us to access the socket address being used by the socket. So,
-    // sockAddr is introducted to create the JServerSock and also to initialize
+    // sockAddr is introduced to create the JServerSock and also to initialize
     // _ip4RestoreAddr later.
     jalib::JSockAddr sockAddr(jalib::JSockAddr::ANY);
     jalib::JServerSocket restoreSocket(sockAddr, 0);

--- a/src/plugin/ipc/ssh/dmtcp_sshd.cpp
+++ b/src/plugin/ipc/ssh/dmtcp_sshd.cpp
@@ -160,10 +160,10 @@ int main(int argc, char *argv[], char *envp[])
   }
 
   /* Checkpoint database should have information about which command rsh/ssh
-   * lauched the daemon orginally on remote host. This information is required
-   * at 2 places, first in restart script which will launch the user process/
-   * dmtcp_sshd on remote host using the same command. Secondly launching
-   * dummy daemon which will launched by the same command.
+   * launched the daemon originally on the remote host. This information is
+   * required at two places:  first in the restart script, which will launch
+   * the user process dmtcp_sshd on the remote host using the same command;
+   * second, launching the dummy daemon, which is launched by the same command.
    */
 
   if (isRshProcess) {

--- a/src/plugin/pid/glibc_pthread.h
+++ b/src/plugin/pid/glibc_pthread.h
@@ -81,7 +81,7 @@
  */
 
 /* NOTE:  For future reference, the STATIC_TLS_TID_OFFSET() for a glibc version
- *  can be easily discvoered as long as a debug version of glibc is present:
+ *  can be easily discovered as long as a debug version of glibc is present:
  *  (gdb) p (char *)&(((struct pthread *)pthread_self())->tid) - \
  *                                                      (char *)pthread_self()
  *  $14 = 720  # So, 720 is the correct offset in this example.

--- a/src/plugin/pid/sched_wrappers.cpp
+++ b/src/plugin/pid/sched_wrappers.cpp
@@ -95,6 +95,9 @@ pthread_getschedparam (pthread_t th, int *policy, struct sched_param *param)
 
   *th_addr.flags = flags;
 
+  // FIXME:  We are executig this even if 'result==1' (error in prior syscall)
+  //         Further, it can happen that spolicy was not set before this,
+  //            and 'result == 0'. See: '(flags & ATTR_FLAG_SCHED_SET) == 0)'
   dmtcp_pthread_set_schedparam(th, spolicy, &sparam);
 
   glibc_lll_unlock(th_addr.lock);

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -231,7 +231,7 @@ ProcessInfo::growStack()
       stackArea = area;
       _endOfStack = (uintptr_t) area.endAddr;
       /*
-       * When using Matlab with dmtcp_launch, sometimes the bottom most
+       * When using Matlab with dmtcp_launch, sometimes the bottommost
        * page of stack (the page with highest address) which contains the
        * environment strings and the argv[] was not shown in /proc/self/maps.
        * This is arguably a bug in the Linux kernel as of version 2.6.32, etc.
@@ -247,7 +247,7 @@ ProcessInfo::growStack()
       int ret = mprotect(area.addr + area.size, 0x1000,
                          PROT_READ | PROT_WRITE | PROT_EXEC);
       if (ret == 0) {
-        JTRACE("bottom-most page of stack (page with highest address) was"
+        JTRACE("bottommost page of stack (page with highest address) was"
                " invisible in /proc/self/maps. It is made visible again now.");
       }
     }

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -340,7 +340,6 @@ mtcp_writememoryareas(int fd)
       writeAreaHeader(fd, &area);
       continue;
     } else if (Util::isIBShmArea(area)) {
-      // TODO(kapil) Add dmtcp_skip_memory_region_ckpting to IB plugin.
       continue;
     } else if (Util::strEndsWith(area.name, DELETED_FILE_SUFFIX)) {
       /* Deleted File */
@@ -352,8 +351,8 @@ mtcp_writememoryareas(int fd)
 
     /* If the area didn't have read permissions, add it temporarily.
      *
-     * NOTE: Changing the permission here can results in two adjacent memory
-     * areas to become one (merged), if they have similar permissions. This can
+     * NOTE: Changing the permission here can result in two adjacent memory
+     * areas becoming one (merged), if they have similar permissions. This can
      * results in a modified /proc/self/maps file. We shouldn't get affected by
      * the changes because we are going to remove the PROT_READ later in the
      * code and that should reset the /proc/self/maps files to its original


### PR DESCRIPTION
Four small, unrelated commits; easy to review:  Let's reiew this before the 3.1.0 release.

 1. JWWARNING/JNOTE not handling EscapeChar (color)  (JWarning was setting color to yellow permanently, and JNOTE did not print in green, although I assume that was the intention)
 2. pthread_getschedparam wrapper: bug in failure case (original commit, June, 2023; Added a FIXME comment to remind us to fix it)
 3. Fix typos and obsolete TODO comment
 4. gdb-dmtcp-utils.py: polishing; no functional diff    