### PR TITLE
Align jalloc.cpp:lvlXStorageBuffer[] to 16 bytes

### DIFF
--- a/jalib/jalloc.cpp
+++ b/jalib/jalloc.cpp
@@ -345,11 +345,16 @@ jalib::JFixedAllocStack<1024> *lvl3;
 jalib::JFixedAllocStack<4096> *lvl4;
 jalib::JFixedAllocStack<4 * 4096> *lvl5;
 
-static char lvl1StorageBuffer[sizeof(jalib::JFixedAllocStack<64>)];
-static char lvl2StorageBuffer[sizeof(jalib::JFixedAllocStack<256>)];
-static char lvl3StorageBuffer[sizeof(jalib::JFixedAllocStack<1024>)];
-static char lvl4StorageBuffer[sizeof(jalib::JFixedAllocStack<4096>)];
-static char lvl5StorageBuffer[sizeof(jalib::JFixedAllocStack<4 * 4096>)];
+static char lvl1StorageBuffer[sizeof(jalib::JFixedAllocStack<64>)]
+  __attribute__ ((aligned (16)));
+static char lvl2StorageBuffer[sizeof(jalib::JFixedAllocStack<256>)]
+  __attribute__ ((aligned (16)));
+static char lvl3StorageBuffer[sizeof(jalib::JFixedAllocStack<1024>)]
+  __attribute__ ((aligned (16)));
+static char lvl4StorageBuffer[sizeof(jalib::JFixedAllocStack<4096>)]
+  __attribute__ ((aligned (16)));
+static char lvl5StorageBuffer[sizeof(jalib::JFixedAllocStack<4 * 4096>)]
+  __attribute__ ((aligned (16)));
 
 void
 jalib::JAllocDispatcher::initialize(void)


### PR DESCRIPTION
In `jalib/jalloc.cpp`, dwcas uses 128-bit (16-byte) data structures.  We need to align them on a 16-byte boundary for lvlXStorageBuffer[].   The compiler can align uint128_t datatypes, but in this case, gcc doesn't apparently know that the class instance contains 128-bit quantities.

This was exposed for ARM64, when the commit 121166 was added (Added Coordinator Plugins).

So, we add an `aligned` attribute.