### PR TITLE
Set WorkerState to RESTARTING in src/dmtcprestartinternal.cpp

### DIFF
--- a/src/dmtcprestartinternal.cpp
+++ b/src/dmtcprestartinternal.cpp
@@ -173,6 +173,7 @@ RestoreTarget::RestoreTarget(const string &path)
 void
 RestoreTarget::initialize()
 {
+  WorkerState::setCurrentState(WorkerState::RESTARTING);
   UniquePid::ThisProcess() = _pInfo.upid();
   UniquePid::ParentProcess() = _pInfo.uppid();
 


### PR DESCRIPTION
  The src/dmtcprestartinternal.cpp was a duplicate of mtcp_restart.cpp
  for MANA, but it was not updated. This change only affects MANA.