### PR TITLE
Added support for vvar_vclock ckpt.

### DIFF
--- a/src/mtcp/mtcp_header.h
+++ b/src/mtcp/mtcp_header.h
@@ -17,6 +17,8 @@ typedef union _MtcpHeader {
     void *vdsoEnd;
     void *vvarStart;
     void *vvarEnd;
+    void *vvarVClockStart;
+    void *vvarVClockEnd;
     void (*post_restart)(double, int);
   };
 

--- a/src/mtcp/mtcp_restart.h
+++ b/src/mtcp/mtcp_restart.h
@@ -107,6 +107,8 @@ typedef struct RestoreInfo {
   VA vdsoEnd;
   VA vvarStart;
   VA vvarEnd;
+  VA vvarVClockStart;
+  VA vvarVClockEnd;
   VA endOfStack;
   fnptr_t post_restart;
   // NOTE: Update the offset when adding fields to the RestoreInfo struct
@@ -119,6 +121,8 @@ typedef struct RestoreInfo {
   VA currentVdsoEnd;
   VA currentVvarStart;
   VA currentVvarEnd;
+  VA currentVvarVClockStart;
+  VA currentVvarVClockEnd;
 
   VA old_stack_addr;
   size_t old_stack_size;

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -226,6 +226,9 @@ ProcessInfo::growStack()
     } else if (strcmp(area.name, "[vvar]") == 0) {
       _vvarStart = (unsigned long)area.addr;
       _vvarEnd = (unsigned long)area.endAddr;
+    } else if (strcmp(area.name, "[vvar_vclock]") == 0) {
+      _vvarVClockStart = (unsigned long)area.addr;
+      _vvarVClockEnd = (unsigned long)area.endAddr;
     } else if ((VA)&area >= area.addr && (VA)&area < area.endAddr) {
       JTRACE("Original stack area") ((void *)area.addr) (area.size);
       stackArea = area;
@@ -294,6 +297,7 @@ ProcessInfo::init()
 #endif // ifdef CONFIG_M32
 
   _vdsoStart = _vdsoEnd = _vvarStart = _vvarEnd = _endOfStack = 0;
+  _vvarVClockStart = _vvarVClockEnd = 0;
 
   processRlimit();
 
@@ -686,7 +690,8 @@ ProcessInfo::serialize(jalib::JBinarySerializer &o)
     & _gettimeofday_offset & _time_offset;
   o & _compGroup & _numPeers;
   o & _restoreBufAddr & _savedHeapStart & _savedBrk;
-  o & _vdsoStart & _vdsoEnd & _vvarStart & _vvarEnd & _endOfStack;
+  o & _vdsoStart & _vdsoEnd & _vvarStart & _vvarEnd;
+  o & _vvarVClockStart & _vvarVClockEnd & _endOfStack;
   o & _ckptDir & _ckptFileName & _ckptFilesSubDir;
   o & kvmap;
 

--- a/src/processinfo.h
+++ b/src/processinfo.h
@@ -157,6 +157,10 @@ class ProcessInfo
 
     uint64_t vvarEnd(void) const { return _vvarEnd; }
 
+    uint64_t vvarVClockStart(void) const { return _vvarVClockStart; }
+
+    uint64_t vvarVClockEnd(void) const { return _vvarVClockEnd; }
+
     bool vdsoOffsetMismatch(uint64_t f1, uint64_t f2,
                             uint64_t f3, uint64_t f4);
     uint64_t endOfStack(void) const { return _endOfStack; }
@@ -211,6 +215,8 @@ class ProcessInfo
     uint64_t _vdsoEnd;
     uint64_t _vvarStart;
     uint64_t _vvarEnd;
+    uint64_t _vvarVClockStart;
+    uint64_t _vvarVClockEnd;
     uint64_t _endOfStack;
 
     uint64_t _clock_gettime_offset;

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -319,6 +319,8 @@ prepareMtcpHeader(MtcpHeader *mtcpHdr)
   mtcpHdr->vdsoEnd = (void *)ProcessInfo::instance().vdsoEnd();
   mtcpHdr->vvarStart = (void *)ProcessInfo::instance().vvarStart();
   mtcpHdr->vvarEnd = (void *)ProcessInfo::instance().vvarEnd();
+  mtcpHdr->vvarVClockStart = (void *)ProcessInfo::instance().vvarVClockStart();
+  mtcpHdr->vvarVClockEnd = (void *)ProcessInfo::instance().vvarVClockEnd();
 
   mtcpHdr->post_restart = &ThreadList::postRestart;
 }

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -273,7 +273,8 @@ mtcp_writememoryareas(int fd)
 
     if (0 == strcmp(area.name, "[vsyscall]") ||
         0 == strcmp(area.name, "[vectors]") ||
-        0 == strcmp(area.name, "[vvar]")) {
+        0 == strcmp(area.name, "[vvar]") ||
+        0 == strcmp(area.name, "[vvar_vclock]")) {
       // NOTE: We can't trust kernel's "[vdso]" label here.  See below.
       JTRACE("skipping over memory special section")
         (area.name) ((void*)area.addr) (area.size);


### PR DESCRIPTION
On new kernels, there is a new area `[vvar_vclock]` that needs to be handled in the same way as `[vvar]`. This PR duplicates the `[vvar]` handling to support `[vvar_vclock]`. We can refactor the code to remove duplication down the road.