### PR TITLE
Adding changes that allows MANA to use the standard DMTCP

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -178,6 +178,8 @@ void allowGdbDebug(int currentDebugLevel);
 
 string getTimestampStr();
 string replace(const string &in, const string &match, const string &replace);
+void* mmap_fixed_noreplace(void *addr, size_t len, int prot, int flags,
+                           int fd, off_t offset);
 } // namespace Util
 }
 #endif // ifdef __cplusplus

--- a/src/dmtcprestartinternal.cpp
+++ b/src/dmtcprestartinternal.cpp
@@ -173,9 +173,6 @@ RestoreTarget::RestoreTarget(const string &path)
 void
 RestoreTarget::initialize()
 {
-  // FIXME:  This is only used by MANA, and so some of
-  // the code can be out of date.  We needed to revised
-  // dmtcprestartinternal.cpp
   WorkerState::setCurrentState(WorkerState::RESTARTING);
   UniquePid::ThisProcess() = _pInfo.upid();
   UniquePid::ParentProcess() = _pInfo.uppid();
@@ -914,8 +911,6 @@ DmtcpRestart::processCkptImages()
   JASSERT(independentProcessTreeRoots.size() > 0)
   .Text("There must be at least one process tree that doesn't have\n"
         "  a different process as session leader.");
-
-  WorkerState::setCurrentState(WorkerState::RESTARTING);
 
   /* Try to find non-orphaned process in independent procs list */
   RestoreTarget *t = NULL;

--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -52,6 +52,38 @@ static const SharedData::DMTCP_ARCH_MODE archMode = SharedData::DMTCP_ARCH_32;
 static const SharedData::DMTCP_ARCH_MODE archMode = SharedData::DMTCP_ARCH_64;
 #endif
 
+// This emulates MAP_FIXED_NOREPLACE, which became available only in Linux 4.17
+// FIXME:  This assume that addr is a multiple of PAGESIZE.  We should
+//         check that in the function, and either issue an error in that
+//         case, or else simulate the action of MAP_FIXED_NOREPLACE.
+void* mmap_fixed_noreplace(void *addr, size_t len, int prot, int flags,
+                           int fd, off_t offset)
+{
+  int mtcp_sys_errno;  // mtcp_sys_mmap, etc., are macros using this
+  if (flags & MAP_FIXED) {
+    flags ^= MAP_FIXED;
+  }
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
+  // This flag should force: 'addr == addr2' or 'addr2 == MAP_FAILED'
+  flags |= MAP_FIXED_NOREPLACE;
+#endif
+  void *addr2 = mmap(addr, len, prot, flags, fd, offset);
+  if (addr == addr2) {
+    return addr2;
+  } else if (addr2 != MAP_FAILED) {
+    // undo the mmap
+    munmap(addr2, len);
+    errno = EEXIST;
+    return MAP_FAILED;
+  } else {
+    // the mmap really did fail
+    return MAP_FAILED;
+  }
+}
+
 void
 SharedData::initializeHeader(const char *tmpDir,
                              DmtcpUniqueProcessId *compId,
@@ -190,9 +222,18 @@ SharedData::initialize(const char *tmpDir,
                 PROT_READ | PROT_WRITE, MAP_SHARED,
                 PROTECTED_SHM_FD, 0);
   } else {
-    addr = mmap((void *)sharedDataHeader, size,
-                PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
-                PROTECTED_SHM_FD, 0);
+    addr = mmap_fixed_noreplace((void *)sharedDataHeader, size,
+                                PROT_READ | PROT_WRITE, MAP_SHARED,
+                                PROTECTED_SHM_FD, 0);
+    // If the checkpointed program has parent and child processes,
+    // the child process will try to map the shared area at the same
+    // address that was mapped by the dmtcp_restart. We ignore this
+    // type of error and let the child process reuse the same shared
+    // area.
+    if (addr == MAP_FAILED && errno == EEXIST) {
+      addr = sharedDataHeader;
+      errno = 0;
+    }
   }
   JASSERT(addr != MAP_FAILED) (JASSERT_ERRNO)
   .Text("Unable to find shared area.");

--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -184,9 +184,16 @@ SharedData::initialize(const char *tmpDir,
   }
 
   size_t size = CEIL(SHM_MAX_SIZE, Util::pageSize());
-  void *addr = mmap((void *)sharedDataHeader, size,
-                    PROT_READ | PROT_WRITE, MAP_SHARED,
-                    PROTECTED_SHM_FD, 0);
+  void *addr;
+  if (sharedDataHeader == NULL) {
+    addr = mmap((void *)sharedDataHeader, size,
+                PROT_READ | PROT_WRITE, MAP_SHARED,
+                PROTECTED_SHM_FD, 0);
+  } else {
+    addr = mmap((void *)sharedDataHeader, size,
+                PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED,
+                PROTECTED_SHM_FD, 0);
+  }
   JASSERT(addr != MAP_FAILED) (JASSERT_ERRNO)
   .Text("Unable to find shared area.");
 


### PR DESCRIPTION
1. Setting the worker state to RESTARTING in the `RestoreTarget::initialize()` function. MANA uses `lower-half` to restore the upper half memory on restart. The `lower-half` program calls `RestoreTarget::initialize` directly, instead of the `DmtcpRestart::processCkptImages()` function.
2. Add `MAP_FIXED` flag when allocating the shared area during restart. This avoids potential conflicts between the shared area and other memory segments, the restore buffer for example. I used `MAP_FIXED` instead of `MAP_FIXED_NOREPLACE` because in some senerios, the shared area has already been allocated. Using `MAP_FIXED_NOREPLACE` will fail in such cases. We can ignore the failed mmap, but it will be the same as using `MAP_FIXED`