### PR TITLE
Fix shmget wrapper to preserve original key values on first use.

### DIFF
--- a/src/plugin/svipc/sysvipcwrappers.cpp
+++ b/src/plugin/svipc/sysvipcwrappers.cpp
@@ -89,12 +89,16 @@ shmget(key_t key, size_t size, int shmflg)
   // preserves the semantics of `IPC_PRIVATE`
   if (key == IPC_PRIVATE) {
     realKey = dmtcp_virtual_to_real_pid(getpid());
+    if (realKey == -1) {
+      realKey = key + dmtcp_virtual_to_real_pid(getpid());
+    }
   } else {
     realKey = VIRTUAL_TO_REAL_SHM_KEY(key);
+    if (realKey == -1) {
+      realKey = key;
+    }
   }
-  if (realKey == -1) {
-    realKey = key + dmtcp_virtual_to_real_pid(getpid());
-  }
+
   realId = _real_shmget(realKey, size, shmflg);
   if (realId != -1) {
     SysVShm::instance().on_shmget(realId, realKey, key, size, shmflg);


### PR DESCRIPTION
When wrapping the shmget function, this PR fixes the handling of non-IPC_PRIVATE keys. 

Previously, when VIRTUAL_TO_REAL_SHM_KEY returns -1 (indicating the key is being used for the first time by user code), we need to preserve the original key value rather than attempting to translate it. This ensures that explicit key values specified by the application are maintained correctly.

This fix is important for applications that rely on specific key values for their shared memory regions, as it ensures the DMTCP wrapper doesn't modify these values on first use.