### PR TITLE
Fixed IPC_PRIVATE handling for SysV Shm.

### DIFF
--- a/include/shareddata.h
+++ b/include/shareddata.h
@@ -198,7 +198,8 @@ void updateDlsymOffset(int32_t dlsymOffset, int32_t dlsymOffset_m32 = 0);
 int32_t getDlsymOffset(void);
 int32_t getDlsymOffset_m32(void);
 
-int32_t getRealIPCId(int type, int32_t virt);
+int32_t getRealIPCId(int type, int32_t virt,
+                     bool insertIfNotFound = false);
 void setIPCIdMap(int type, int32_t virt, int32_t real);
 
 pid_t getRealPid(pid_t virt);

--- a/src/plugin/svipc/sysvipc.cpp
+++ b/src/plugin/svipc/sysvipc.cpp
@@ -470,8 +470,8 @@ SysVShm::virtualToRealKey(key_t k)
   if (_keyMap.find(k) != _keyMap.end()) {
     return _keyMap[k];
   } else {
-    int realId = SharedData::getRealIPCId(SYSV_SHM_KEY, k);
-    if (realId != -1) {
+    int realId = SharedData::getRealIPCId(SYSV_SHM_KEY, k, true);
+    if (realId == k) {
       updateKeyMapping(k, realId);
     }
     return realId;

--- a/src/plugin/svipc/sysvipcwrappers.cpp
+++ b/src/plugin/svipc/sysvipcwrappers.cpp
@@ -68,7 +68,6 @@ shmget(key_t key, size_t size, int shmflg)
   int virtId = -1;
 
   DMTCP_PLUGIN_DISABLE_CKPT();
-  key_t realKey = -1;
 
   // If multiple clients try to simultaneously create shm regions with
   // (IPC_PRIVATE | IPC_EXCL), there is a race condition that can cause the
@@ -87,14 +86,9 @@ shmget(key_t key, size_t size, int shmflg)
   // Therefore, we detect this special case of `IPC_PRIVATE` and use
   // a process's real pid to create the shared memory region. This also
   // preserves the semantics of `IPC_PRIVATE`
-  if (key == IPC_PRIVATE) {
-    realKey = dmtcp_virtual_to_real_pid(getpid());
-  } else {
-    realKey = VIRTUAL_TO_REAL_SHM_KEY(key);
-  }
-  if (realKey == -1) {
-    realKey = key + dmtcp_virtual_to_real_pid(getpid());
-  }
+
+  key_t realKey = VIRTUAL_TO_REAL_SHM_KEY(key);
+
   realId = _real_shmget(realKey, size, shmflg);
   if (realId != -1) {
     SysVShm::instance().on_shmget(realId, realKey, key, size, shmflg);

--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -561,7 +561,7 @@ SharedData::setPidMap(pid_t virt, pid_t real)
 }
 
 int32_t
-SharedData::getRealIPCId(int type, int32_t virt)
+SharedData::getRealIPCId(int type, int32_t virt, bool insertIfNotFound)
 {
   int32_t res = -1;
   uint32_t nmaps = 0;
@@ -596,11 +596,23 @@ SharedData::getRealIPCId(int type, int32_t virt)
     JASSERT(false) (type).Text("Unknown IPC-Id type.");
     break;
   }
+
+  bool found = false;
   for (size_t i = 0; i < nmaps; i++) {
     if (map[i].virt == virt) {
       res = map[i].real;
+      found = true;
     }
   }
+
+  if (!found && insertIfNotFound) {
+    JASSERT(nmaps < MAX_IPC_ID_MAPS);
+    map[nmaps].virt = virt;
+    map[nmaps].real = virt;
+    res = virt;
+    nmaps++;
+  }
+
   Util::unlockFile(PROTECTED_SHM_FD);
   return res;
 }

--- a/test/sysv-shm2.c
+++ b/test/sysv-shm2.c
@@ -15,8 +15,9 @@ void
 parent(int fd)
 {
   int shmid;
+  srand(getpid());
 
-  if ((shmid = shmget((key_t)9979, SIZE, IPC_CREAT | 0666)) < 0) {
+  if ((shmid = shmget((key_t)rand(), SIZE, IPC_CREAT | 0666)) < 0) {
     perror("shmget");
     exit(1);
   }


### PR DESCRIPTION
IPC_PRIVATE can [now] be called multiple times and it will in turn create new handlers every time.

Also updated sysv-shm1 test to create shm segments with IPC_PRIVATE key.

Thanks @gkliu for reporting the bug and creating an initial PR (#1191) with the fix.