### PR TITLE
Use static buffer for motherofall.

### DIFF
--- a/src/threadlist.h
+++ b/src/threadlist.h
@@ -34,6 +34,7 @@ namespace ThreadList
 void init();
 void createCkptThread();
 Thread *getNewThread(void *(*fn)(void *), void *arg);
+void prepareThread(Thread *th, void *(*fn)(void *), void *arg);
 void initThread(Thread *);
 void resetOnFork();
 void threadExit();


### PR DESCRIPTION
When using JALLOC_MALLOC for motherofall allocation, we can get into infinite recursion if a user application has put wrappers around mmap. The fix is to use a static buffer.