### PR TITLE
Fixed a bug in Util::mmap_fixed_noreplace

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -178,8 +178,8 @@ void allowGdbDebug(int currentDebugLevel);
 
 string getTimestampStr();
 string replace(const string &in, const string &match, const string &replace);
-void* mmap_fixed_noreplace(void *addr, size_t len, int prot, int flags,
-                           int fd, off_t offset);
+void* mmap_fixed_noreplace_private(void *addr, size_t len, int prot, int flags,
+                                   int fd, off_t offset);
 } // namespace Util
 }
 #endif // ifdef __cplusplus

--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -190,9 +190,9 @@ SharedData::initialize(const char *tmpDir,
                 PROT_READ | PROT_WRITE, MAP_SHARED,
                 PROTECTED_SHM_FD, 0);
   } else {
-    addr = Util::mmap_fixed_noreplace((void *)sharedDataHeader, size,
-                                      PROT_READ | PROT_WRITE, MAP_SHARED,
-                                      PROTECTED_SHM_FD, 0);
+    addr = Util::mmap_fixed_noreplace_private((void *)sharedDataHeader, size,
+                                              PROT_READ | PROT_WRITE, MAP_SHARED,
+                                              PROTECTED_SHM_FD, 0);
     // If the checkpointed program has parent and child processes,
     // the child process will try to map the shared area at the same
     // address that was mapped by the dmtcp_restart. We ignore this


### PR DESCRIPTION
  Util::mmap_fixed_noreplace emulates the mmap() with MAP_FIXED_NOREPLACE
  flag for old systems. It uses a regular mmap() with the given address
  and check if the return value is the same as the given address. However,
  we found a case that the kernel returns a different address although the
  requirest memory range is available. Therefore, the mmap_fixed_noreplace
  function returns an error message EEXIST, which is not expectec.

  Now we check if the requested memory range is available by calling mlock()
  page by page. The mlock function will return -1 with an errono of ENOMEM.
  If there's no already mapped pages in the request memory range, the function
  will call mmap() with MAP_FIXED. Otherwise, the function will return
  MAP_FAILED with an errno of EEXIST.