### PR TITLE
Fix VirtPidTbl initialization to not rely on getpid.

### DIFF
--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -198,6 +198,23 @@ dmtcp_initialize()
   dmtcp_prepare_wrappers();
 }
 
+#ifdef DEBUG
+// This is a test function which we can use to simulate foreign constructors
+// that might be invoked before dmtcp_initialize_entry_point is called. We
+// should be able to put arbitrary code here without worrying about the order of
+// initialization. The constructor attribute priority is set to 100, so it will
+// be called before dmtcp_initialize_entry_point.
+// Note that 1-100 are reserved for implementation, but we are okay since this
+// function is only enabled for debugging.
+extern "C" void __attribute__((constructor(100)))
+dmtcp_initialize_entry_point_test()
+{
+  cpu_set_t cpuset;
+  pthread_t thread = pthread_self();
+  pthread_getaffinity_np(thread, sizeof(cpu_set_t), &cpuset);
+}
+#endif
+
 // Initialize remaining components.
 extern "C" void __attribute__((constructor(101)))
 dmtcp_initialize_entry_point()

--- a/src/plugin/pid/pid.cpp
+++ b/src/plugin/pid/pid.cpp
@@ -128,8 +128,7 @@ void dmtcp_init_virtual_tid()
 {
   removeExitedChildTids();
   pid_t virtualTid = VirtualPidTable::instance().getNewVirtualTid();
-  dmtcpResetTid(virtualTid);
-  VirtualPidTable::instance().updateMapping(virtualTid, _real_gettid());
+  VirtualPidTable::resetTid(virtualTid);
 
   dmtcp_pthread_set_tid(pthread_self(), virtualTid);
 }
@@ -276,8 +275,6 @@ pidVirt_PostRestart()
   // We can't just send two SIGWINCH's now, since window size has not
   // changed yet, and 'screen' will assume that there's nothing to do.
 
-  dmtcp_update_ppid();
-
   ostringstream o;
   o << dmtcp_get_tmpdir() << "/dmtcpPidMap."
     << dmtcp_get_computation_id_str() << "."
@@ -304,7 +301,7 @@ pidVirt_ThreadExit(DmtcpEventData_t *data)
    *  FIXME: What if the process gets checkpointed after erase() but before the
    *  thread actually exits?
    */
-  pid_t tid = dmtcp_gettid();
+  pid_t tid = VirtualPidTable::gettid();
   DmtcpMutexLock(&exitedChildTidsLock);
   exitedChildTids->push_back(tid);
   DmtcpMutexUnlock(&exitedChildTidsLock);

--- a/src/plugin/pid/pid_miscwrappers.cpp
+++ b/src/plugin/pid/pid_miscwrappers.cpp
@@ -56,8 +56,6 @@ pidVirt_atfork_prepare()
 LIB_PRIVATE void
 pidVirt_atfork_child()
 {
-  dmtcpResetPidPpid();
-  dmtcpResetTid(getpid());
   VirtualPidTable::instance().resetOnFork();
 }
 
@@ -85,7 +83,7 @@ pidVirt_vfork_prepare()
   vfork_saved_virt_pid = getpid();
   vfork_saved_real_pid = VIRTUAL_TO_REAL_PID(getpid());
   vfork_saved_ppid = getppid();
-  vfork_saved_tid = dmtcp_gettid();
+  vfork_saved_tid = VirtualPidTable::gettid();
   if (vfork_saved_virtPidTableInst == nullptr) {
     vfork_saved_virtPidTableInst = new VirtualPidTable(*virtPidTableInst);
   } else {
@@ -148,8 +146,8 @@ vfork()
                               vfork_saved_real_pid,
                               vfork_saved_ppid,
                               _real_getppid());
-    dmtcpResetPidPpid();
-    dmtcpResetTid(getpid());
+    VirtualPidTable::resetPidPpid();
+    VirtualPidTable::resetTid(getpid());
 
     if (vforkPid > 0) {
       VirtualPidTable::instance().updateMapping(childVirtualPid, vforkPid);
@@ -321,7 +319,7 @@ syscall(long sys_num, ...)
   switch (sys_num) {
   case SYS_gettid:
   {
-    ret = dmtcp_gettid();
+    ret = VirtualPidTable::gettid();
     break;
   }
   case SYS_tkill:

--- a/src/plugin/pid/virtualpidtable.h
+++ b/src/plugin/pid/virtualpidtable.h
@@ -54,7 +54,12 @@ class VirtualPidTable : public VirtualIdTable<pid_t>
     VirtualPidTable();
     static VirtualPidTable &instance();
     static pid_t getPidFromEnvVar();
-
+    static void initializeInstance(pid_t pid);
+    static void resetPidPpid();
+    static void resetTid(pid_t tid);
+    static pid_t getpid();
+    static pid_t gettid();
+    static pid_t getppid();
     virtual void postRestart();
     virtual void resetOnFork();
 


### PR DESCRIPTION
Using getpid() in VirtPidTbl initialization causes recursion in certain cases where a foreign constructor may be called before DMTCP's initializer kicks in.