### PR TITLE
Logging improvements

### DIFF
--- a/jalib/jassert.cpp
+++ b/jalib/jassert.cpp
@@ -64,7 +64,6 @@ jassert_internal::JAssert::Text(const char *msg)
 {
   Print("Message: ");
   Print(msg);
-  Print("\n");
   return *this;
 }
 
@@ -83,7 +82,10 @@ jassert_internal::JAssert::JAssert(JAssertType type)
 jassert_internal::JAssert::~JAssert()
 {
   if (_type != JAssertType::Error) {
-    Print(clearEscapeStr);
+    if (_type != JAssertType::Trace) {
+      Print(clearEscapeStr);
+    }
+    Print("\n");
     writeToConsole(ss.str().c_str());
     writeToLog(ss.str().c_str());
     return;

--- a/jalib/jassert.h
+++ b/jalib/jassert.h
@@ -137,6 +137,7 @@ class JAssert
     template<typename T>
     JAssert &Print(const T &t);
     JAssert &Print(const char *t);
+    JAssert &Print(char *t);
     template<typename T>
     JAssert &Print(const dmtcp::vector<T> &t);
 
@@ -228,11 +229,22 @@ JAssert::Print(const T &t)
 }
 
 inline JAssert&
+JAssert::Print(char *t)
+{
+  return Print(static_cast<const char *>(t));
+}
+
+inline JAssert&
 JAssert::Print(const char *t)
 {
-  if (t != NULL) {
+  if (t == NULL) {
+    ss << "<NULL>";
+  } else if (t[0] == '\0') {
+    ss << "\"\"";
+  } else {
     ss << t;
   }
+
   return *this;
 }
 

--- a/jalib/jassert.h
+++ b/jalib/jassert.h
@@ -333,6 +333,20 @@ void open_log_file();
     .JASSERT_CONT_A;                                              \
   } while (0)
 
+#define ASSERT_LT(expected, term)                                 \
+  do {                                                            \
+  auto lhs = (expected);                                          \
+  auto rhs = (term);                                              \
+  if (lhs < rhs) {                                               \
+  } else                                                          \
+    jassert_internal::JAssert()                                   \
+    .JASSERT_CONTEXT_NO_NEWLINE("ASSERT_LT failed; ")             \
+    .Print("<" #expected "(").Print(lhs)                          \
+    .Print(")> < <" #term "(").Print(rhs)                        \
+    .Print(")>.\n")                                               \
+    .JASSERT_CONT_A;                                              \
+  } while (0)
+
 #define ASSERT_NULL(term)                                         \
   if (nullptr == (term)) {                                        \
   } else                                                          \

--- a/src/constants.h
+++ b/src/constants.h
@@ -113,6 +113,7 @@
 
 // Set to "1" if the system supports FSGSBASE feature.
 #define ENV_VAR_FSGSBASE_ENABLED        "DMTCP_FSGSBASE_ENABLED"
+#define ENV_VAR_LOG_FILE                "DMTCP_LOG_FILE"
 
 // this list should be kept up to date with all "protected" environment vars
 #define ENV_VARS_ALL                  \
@@ -135,7 +136,8 @@
   ENV_VAR_SIGCKPT,                    \
   ENV_VAR_SCREENDIR,                  \
   ENV_VAR_VIRTUAL_PID,                \
-  ENV_VAR_FSGSBASE_ENABLED
+  ENV_VAR_FSGSBASE_ENABLED,           \
+  ENV_VAR_LOG_FILE
 
 #define DMTCP_RESTART_CMD       "dmtcp_restart"
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -55,8 +55,9 @@
 // #define X11_LISTENER_PORT_START 6000
 
 // Virtual pids used by coordinator.
-#define INITIAL_VIRTUAL_PID         40000
-#define MAX_VIRTUAL_PID             400000000
+#define INITIAL_VIRTUAL_PID         ((pid_t)40000)
+#define VIRTUAL_PID_STEP            ((pid_t)1000)
+#define MAX_VIRTUAL_PID             ((pid_t)1000000)
 
 // NEEDED FOR STRINGIFY(DEFAULT_PORT)
 #define QUOTE(arg) #arg

--- a/src/dlwrappers.cpp
+++ b/src/dlwrappers.cpp
@@ -96,15 +96,18 @@ callback(struct dl_phdr_info *info, size_t size, void *data) {
   // Turn on JTRACE for an overview of this logic in action.
   if (address != NULL) {
     dlsym_addr_instance++;
-    JTRACE("Symbol dlsym_symbol in info->dlpi_name; found at address")
-          (dlsym_symbol) (info->dlpi_name) (address);
+    // Can't use JTRACE here because it can deadlock due to memory allocation.
+    // JTRACE("Symbol dlsym_symbol in info->dlpi_name; found at address")
+    //       (dlsym_symbol) (info->dlpi_name) (address);
   }
   if (dlsym_addr_instance == 1) {
-    JTRACE("Caller of dlsym_symbol() in info->dlpi_name; wrapper fnc. address")
-          (dlsym_symbol) (info->dlpi_name) (address);
+    // Can't use JTRACE here because it can deadlock due to memory allocation.
+    // JTRACE("Caller of dlsym_symbol() in info->dlpi_name; wrapper fnc. address")
+    //       (dlsym_symbol) (info->dlpi_name) (address);
   }
   if (dlsym_addr_instance == 2) {
-    JTRACE("RTLD_NEXT") (address);
+    // Can't use JTRACE here because it can deadlock due to memory allocation.
+    // JTRACE("RTLD_NEXT") (address);
     dlsym_retval = address;
   }
   return 0;

--- a/src/plugin/pid/virtualpidtable.cpp
+++ b/src/plugin/pid/virtualpidtable.cpp
@@ -158,7 +158,6 @@ VirtualPidTable::refresh()
     }
   }
   _do_unlock_tbl();
-  printMaps();
 }
 
 pid_t

--- a/src/util_init.cpp
+++ b/src/util_init.cpp
@@ -121,12 +121,17 @@ Util::calcTmpDir(const char *tmpdirenv)
 void
 Util::initializeLogFile(const char *tmpDir, const char *prefix)
 {
-  ostringstream o;
-  o << tmpDir << "/" << prefix
-    << "." << Util::getTimestampStr()
-    << "." << UniquePid::ThisProcess()
-    << ".log";
-  JASSERT_SET_LOG(o.str().c_str());
+  const char *logFile = getenv(ENV_VAR_LOG_FILE);
+  if (logFile != NULL) {
+    JASSERT_SET_LOG(logFile);
+  } else {
+    ostringstream o;
+    o << tmpDir << "/" << prefix
+      << "." << Util::getTimestampStr()
+      << "." << UniquePid::ThisProcess()
+      << ".log";
+    JASSERT_SET_LOG(o.str().c_str());
+  }
 
   // This causes an error when configure is done with --enable-logging
   //   JLOG(a.str().c_str());

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -454,11 +454,11 @@ writememoryarea(int fd, Area area)
   }
 
   if (!(area.flags & MAP_ANONYMOUS)) {
-    JTRACE("save region") (area.addr) (area.size) (area.name) (area.offset);
+    JTRACE("save region") ((void*)area.addr) (area.size) (area.name) (area.offset);
   } else if (area.name[0] == '\0') {
-    JTRACE("save anonymous") (area.addr) (area.size);
+    JTRACE("save anonymous") ((void*)area.addr) (area.size);
   } else {
-    JTRACE("save anonymous") (area.addr) (area.size) (area.name) (area.offset);
+    JTRACE("save anonymous") ((void*)area.addr) (area.size) (area.name) (area.offset);
   }
 
   if (area.name[0] == '\0') {


### PR DESCRIPTION
* DMTCP_LOG_FILE env var to specify a path for log file. This allows multiple processes to use the same log file and is important when debugging distributed computations.
* Single-line logging -- when logging to single file, one line per log message makes it easier to parse log files using external tooling.
* Bug fixes to make --enable-logging work.
* Some non-fatal asserts replaced with warnings.