### PR TITLE
Added close_range test to syscall-tester.

### DIFF
--- a/src/miscwrappers.cpp
+++ b/src/miscwrappers.cpp
@@ -339,6 +339,13 @@ syscall(long sys_num, ...)
     break;
   }
 
+  case SYS_close_range:
+  {
+    SYSCALL_GET_ARGS_3(int, fd1, int, fd2, unsigned int, flags);
+    ret = close_range(fd1, fd2, flags);
+    break;
+  }
+
   case SYS_rt_sigaction:
   {
     SYSCALL_GET_ARGS_3(int,

--- a/src/syscallsreal.c
+++ b/src/syscallsreal.c
@@ -445,6 +445,13 @@ _real_close(int fd)
 
 LIB_PRIVATE
 int
+_real_close_range(unsigned int first, unsigned int last, int flags)
+{
+  REAL_FUNC_PASSTHROUGH(close_range) (first, last, flags);
+}
+
+LIB_PRIVATE
+int
 _real_fclose(FILE *fp)
 {
   REAL_FUNC_PASSTHROUGH(fclose) (fp);

--- a/src/syscallwrappers.h
+++ b/src/syscallwrappers.h
@@ -227,6 +227,7 @@ extern int dmtcp_wrappers_initializing;
   MACRO(openat64)                     \
   MACRO(opendir)                      \
   MACRO(close)                        \
+  MACRO(close_range)                  \
   MACRO(fclose)                       \
   MACRO(closedir)                     \
                                       \
@@ -351,6 +352,7 @@ int _real_openat(int dirfd, const char *pathname, int flags, ...);
 int _real_openat64(int dirfd, const char *pathname, int flags, ...);
 DIR *_real_opendir(const char *name);
 int _real_close(int fd);
+int _real_close_range(unsigned int first, unsigned int last, int flags);
 int _real_fclose(FILE *fp);
 int _real_closedir(DIR *dir);
 int _real_setrlimit(int resource, const struct rlimit *rlim);


### PR DESCRIPTION
This is a new system call introduced in Linux 5.9. The added test fails without the wrapper and passes with wrapper.