### PR TITLE
Several initialization bugfixes

### DIFF
--- a/include/wrapperlock.h
+++ b/include/wrapperlock.h
@@ -48,6 +48,8 @@ class LibDlWrapperLock
 
     LibDlWrapperLock();
     virtual ~LibDlWrapperLock();
+  private:
+    bool acquired = false;
 };
 
 }

--- a/src/plugin/pid/virtualpidtable.cpp
+++ b/src/plugin/pid/virtualpidtable.cpp
@@ -201,13 +201,17 @@ VirtualPidTable::updateMapping(pid_t virtualId, pid_t realId)
 pid_t
 VirtualPidTable::realToVirtual(pid_t realPid)
 {
+  if (realPid == -1 || realPid == 0) {
+    return realPid;
+  }
+
   return VirtualIdTable<pid_t>::realToVirtual(realPid);
 }
 
 pid_t
 VirtualPidTable::virtualToReal(pid_t virtualId)
 {
-  if (virtualId == -1) {
+  if (virtualId == -1 || virtualId == 0) {
     return virtualId;
   }
 

--- a/src/shareddata.cpp
+++ b/src/shareddata.cpp
@@ -180,7 +180,9 @@ SharedData::initialize(const char *tmpDir,
     JASSERT(fd != -1) (JASSERT_ERRNO);
     JASSERT(_real_dup2(fd, PROTECTED_SHM_FD) == PROTECTED_SHM_FD)
       (JASSERT_ERRNO);
-    _real_close(fd);
+    if (fd != PROTECTED_SHM_FD) {
+      _real_close(fd);
+    }
   }
 
   size_t size = CEIL(SHM_MAX_SIZE, Util::pageSize());

--- a/src/wrapperlock.cpp
+++ b/src/wrapperlock.cpp
@@ -41,12 +41,14 @@ WrapperLock::~WrapperLock()
 
 LibDlWrapperLock::LibDlWrapperLock()
 {
-  ThreadSync::libdlLockLock();
+  acquired = ThreadSync::libdlLockLock();
 }
 
 LibDlWrapperLock::~LibDlWrapperLock()
 {
-  ThreadSync::libdlLockUnlock();
+  if (acquired) {
+    ThreadSync::libdlLockUnlock();
+  }
 }
 
 }


### PR DESCRIPTION
These commits fix issues that are observed during initialization when non-glibc malloc libraries and programs where constructors are called before DMTCP is fully initialized.