### PR TITLE
Use more portable readdir instead of sys_getdents

### DIFF
--- a/jalib/jfilesystem.h
+++ b/jalib/jfilesystem.h
@@ -29,22 +29,6 @@
 
 namespace jalib
 {
-struct linux_dirent {
-  unsigned long d_ino;        /* Inode number */
-  unsigned long d_off;        /* Offset to next linux_dirent */
-  unsigned short d_reclen;    /* Length of this linux_dirent */
-  char d_name[];              /* Filename (null-terminated) */
-
-  /* length is actually (d_reclen - 2 -
-     offsetof(struct linux_dirent, d_name) */
-
-  /*
-     char           pad;       // Zero padding byte
-     char           d_type;    // File type (only since Linux 2.6.4;
-                               // offset is (d_reclen - 1))
-  */
-};
-
 namespace Filesystem
 {
 // true if a given file exists


### PR DESCRIPTION
  The return values of sys_getdents and sys_getents64 have different
  data types. The offset for d_name is different. Therefore using the
  sys_getents64 syscall with 32-bit dirent structure causes the d_name
  to include an extra byte at the beginning of the string.