### PR TITLE
Check kernel & glibc ver. for close_range syscall

### DIFF
--- a/src/miscwrappers.cpp
+++ b/src/miscwrappers.cpp
@@ -43,6 +43,11 @@
 #endif  // if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 22) &&
         // __GLIBC_PREREQ(2,
 // 8)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0) && __GLIBC_PREREQ(2, 34)
+#include <linux/close_range.h>
+#endif  // if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0) &&
+        // __GLIBC_PREREQ(2,
+// 34)
 
 #ifdef __aarch64__
 
@@ -339,12 +344,14 @@ syscall(long sys_num, ...)
     break;
   }
 
+#ifdef SYS_close_range
   case SYS_close_range:
   {
     SYSCALL_GET_ARGS_3(int, fd1, int, fd2, unsigned int, flags);
     ret = close_range(fd1, fd2, flags);
     break;
   }
+#endif
 
   case SYS_rt_sigaction:
   {

--- a/test/syscall-tester.c
+++ b/test/syscall-tester.c
@@ -72,8 +72,8 @@
 #include <sys/vfs.h>
 #include <linux/version.h>
 
-// include the close_range.h header file only if linux kernel version is >= 5.9.0.
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+// include the close_range.h header file only if linux kernel version is >= 5.9.0 and glibc version is >= 2.34
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0) && __GLIBC_PREREQ(2, 34)
 #include <linux/close_range.h>
 #endif
 
@@ -904,7 +904,7 @@ close_test(int fd)
   return ret;
 }
 
-#ifdef __linux__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0) && __GLIBC_PREREQ(2, 34)
 int close_range_test(unsigned int first_fd, unsigned int last_fd, unsigned int flags)
 {
   int ret, save_errno;
@@ -3771,7 +3771,7 @@ BasicFile(void)
 /*    printf("END Test %d\n\n", test);*/
 /*    test++;*/
 
-#ifdef __linux__
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0) && __GLIBC_PREREQ(2, 34)
 /* Test the close_range system call functionality */
 int BasicCloseRange(void)
 {
@@ -5251,7 +5251,7 @@ testall()
     char *desc;
   } tests[] = {
     { BasicFile, "BasicFile: simple open/close/access/unlink tests." },
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0) && __GLIBC_PREREQ(2, 34)
     { BasicCloseRange, "BasicCloseRange: Test close_range system call functionality." },
 #endif
     { BasicFileIO, "BasicFileIO: simple write/read/seek tests." },


### PR DESCRIPTION
Check kernel and glibc version when defining wrappers and tests for the `close_range()` syscall. According to the man page, `close_range()` requires `kernel >=5.9` and `glibc >=2.34.`