### PR TITLE
Changed --mpi to --kernel-loader, updated comments

### DIFF
--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -138,7 +138,7 @@ static const char *theUsage =
   "  --coord-logfile PATH (environment variable DMTCP_COORD_LOG_FILENAME\n"
   "              Coordinator will dump its logs to the given file\n"
   "  --kernel-loader\n"
-  "              Enable kernel loader mode for plugins that uses the\n"
+  "              Enable kernel loader mode for plugins that use the\n"
   "              Split Process architecture.\n"
   "              Set ADDR_NO_RANDOMIZE personality, and set UH_PRELOAD\n"
   "              instead of LD_PRELOAD for the upper half program\n"
@@ -841,11 +841,10 @@ setLDPreloadLibs(bool is32bitElf)
           "  ./configure --enable-m32 && make clean && make -j && "
           "make install\n"
           "  ./configure && make clean && make -j && make install\n");
-    setenv("LD_PRELOAD", preloadLibs32.c_str(), 1);
     if (enableKernelLoader) {
-      setenv("UH_PRELOAD", preloadLibs.c_str(), 1);
+      setenv("UH_PRELOAD", preloadLibs32.c_str(), 1);
     } else {
-      setenv("LD_PRELOAD", preloadLibs.c_str(), 1);
+      setenv("LD_PRELOAD", preloadLibs32.c_str(), 1);
     }
   }
 #endif // if defined(__x86_64__) || defined(__aarch64__)


### PR DESCRIPTION
Both MANA and CRAC needs to set the `ADDR_NO_RANDOMIZE` personality, and use `UH_PRELOAD` env var instead of `LD_PRELOAD`. I changed the flag for `dmtcp_launch` from `--mpi` to `--kernel-loader` and updated related comments so that both MANA and CRAC can use the same `--kernel-loader` flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new `--kernel-loader` command-line option for advanced plugin support.

* **Improvements**
  * Updated help messages to reflect the new option and clarify environment variable usage.
  * Enhanced environment setup to use `UH_PRELOAD` when kernel loader mode is enabled, improving compatibility with certain plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->