### PR TITLE
Fixed SYS_close_range in syscall wrapper

### DIFF
--- a/src/miscwrappers.cpp
+++ b/src/miscwrappers.cpp
@@ -344,7 +344,7 @@ syscall(long sys_num, ...)
     break;
   }
 
-#ifdef SYS_close_range
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0) && __GLIBC_PREREQ(2, 34)
   case SYS_close_range:
   {
     SYSCALL_GET_ARGS_3(int, fd1, int, fd2, unsigned int, flags);


### PR DESCRIPTION
This is a follow up of PR https://github.com/dmtcp/dmtcp/pull/1210. On Khoury Login, `SYS_close_range` is defined, although the `close_range()` syscall is not available. Therefore, I added the version check before using close_range() in the `syscall()` wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Improved Linux compatibility by enabling close-range handling only on systems with Linux kernel 5.9+ and GLIBC 2.34+, preventing errors on older environments.
- Chores
  - Updated platform checks to align system call usage with supported OS and library versions, enhancing stability across distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->