### PR TITLE
Fix for forked ckpt: commit 7e486722bdb broke it

### DIFF
--- a/configure
+++ b/configure
@@ -1525,7 +1525,8 @@ Optional Features:
   --enable-forked-checkpointing
                           fork a child process to do checkpointing, so that
                           parent sees only minor delay during checkpoint.
-                          (EXPERIMENTAL)
+                          (EXPERIMENTAL: Currently, shared memory is not
+                          supported.)
   --enable-fast-restart   uses tricks to mmap from checkpoint image file;
                           disables all kinds of compression (EXPERIMENTAL)
   --disable-test-suite    disables "make check"; target apps for testing (e.g.

--- a/configure.ac
+++ b/configure.ac
@@ -155,7 +155,8 @@ AC_ARG_ENABLE([forked_checkpointing],
             [AS_HELP_STRING([--enable-forked-checkpointing],
                             [fork a child process to do checkpointing, so that
                             parent sees only minor delay during checkpoint.
-			    (EXPERIMENTAL)])],
+			    (EXPERIMENTAL: Currently, shared memory is not
+                             supported.)])],
             [use_forked_ckpt=$enableval],
             [use_forked_ckpt=no])
 

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -475,12 +475,14 @@ DmtcpWorker::postCheckpoint()
     kvdb::set(workerPath, "ProcSelfMaps_JAllocArenas", o.str());
   }
 
+#ifndef FORKED_CHECKPOINTING
   {
     kvdb::set(
       workerPath,
       "ProcSelfMaps_Ckpt",
       procSelfMaps->getData());
   }
+#endif
 
   WorkerState::setCurrentState(WorkerState::CHECKPOINTED);
 


### PR DESCRIPTION
@karya0 ,
    Apparently, your addition of kvdb for DMTCP (commit 7e486722bdb) had not considered the case of forked checkpointing.
    I'm commenting out one line of that code when forked ckpt is being used.
    Could you please check this, to see if you want to modify kvdb for this case, or just ignore it, since forked ckpt is less common?

To recall, in forked ckpt, the original process figures out open fd's, signal handlers, etc., and then forks a grandchild.  The grandchild writes the memory areas to the ckpt_*.temp file.  The original process then renames the *.temp file to *.dmtcp, but the grandchild is allowed to continue executing and write out the rest of the memory areas.  The grandchild then exits when done.

@xuyao0127,
    When we also have the enhancement for SOCK_SEQPACKET, let's add this commit, also, and do a new point release for DMTCP.

Thanks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted behavior under forked checkpointing to avoid writing certain process mapping data, improving consistency with expected operation.

* **Documentation**
  * Updated the configure option description for forked checkpointing to clarify its experimental status and note that shared memory is currently not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->