### PR TITLE
Forked ckpt improvement (support shared memory, etc.)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,7 @@ if test "$use_unique_checkpoint_filenames" = "yes"; then
   AC_DEFINE([UNIQUE_CHECKPOINT_FILENAMES],[1],[Use unique filenames for checkpoint images])
 fi
 
+dnf FIXME:  Remove EXPERIMENTAL, once this PR works.
 AC_ARG_ENABLE([forked_checkpointing],
             [AS_HELP_STRING([--enable-forked-checkpointing],
                             [fork a child process to do checkpointing, so that

--- a/include/procselfmaps.h
+++ b/include/procselfmaps.h
@@ -28,6 +28,8 @@ class ProcSelfMaps
 
     const char* getData() const { return data; }
 
+    void reset() { dataIdx = 0; }
+
   private:
     unsigned long int readDec();
     unsigned long int readHex();

--- a/src/ckptserializer.cpp
+++ b/src/ckptserializer.cpp
@@ -305,6 +305,11 @@ open_ckpt_to_write(int fd, int pipe_fds[2], char **extcomp_args)
 {
   pid_t cpid;
 
+// FIXME:  We should create a grandchild and let the parent exit.
+//         Then we don't have to worry about Zombie processes
+//           SIGCHILD_HANDLER, and waiting for the child.
+//         When the grandchild reads the end of the pipe to write areas,
+//           it sees EOF and exits.
   cpid = _real_sys_fork();
   if (cpid == -1) {
     JWARNING(false) (extcomp_args[0]) (JASSERT_ERRNO)

--- a/src/ckptserializer.cpp
+++ b/src/ckptserializer.cpp
@@ -25,6 +25,7 @@
 #include <sys/wait.h>
 #if defined(__aarch64__) || defined(__riscv)
 
+// FIXME:  Remove this when doing it with writeckpt.cpp
 /* On aarch64 and riscv, fork() is not implemented, in favor of clone().
  *   A true fork call would include CLONE_CHILD_SETTID and set the thread id
  * in the thread area of the child (using set_thread_area).  We don't do that.
@@ -54,6 +55,7 @@
 #else  // if defined(__aarch64__)
 # define _real_pipe(a)         _real_syscall(SYS_pipe, a)
 #endif  // if defined(__aarch64__)
+// FIXME:  Remove this when doing it with writeckpt.cpp
 #define _real_waitpid(a, b, c) _real_syscall(SYS_wait4, a, b, c, NULL)
 
 using namespace dmtcp;
@@ -63,7 +65,6 @@ using namespace dmtcp;
 #define FORKED_CKPT_PARENT 1
 #define FORKED_CKPT_CHILD  2
 
-static int forked_ckpt_status = -1;
 static pid_t ckpt_extcomp_child_pid = -1;
 static struct sigaction saved_sigchld_action;
 static int open_ckpt_to_write(int fd, int pipe_fds[2], char **extcomp_args);
@@ -79,7 +80,8 @@ default_sigchld_handler(int sig)
   JASSERT(sig == SIGCHLD);
 }
 
-static void
+// Used for gzip compression process and forked ckpt process
+void
 prepare_sigchld_handler()
 {
   /* 3a. Set SIGCHLD to our own handler;
@@ -97,6 +99,29 @@ prepare_sigchld_handler()
   sigaction(SIGCHLD, &default_sigchld_action, &saved_sigchld_action);
 }
 
+/*************************************************************
+ * FIXME:  A better idea is to block SIGCHLD in parent,
+ *         waitpid, and then restore the original mask.
+ * sigset_t mask, oldmask;
+ * sigemptyset(&mask);
+ * sigaddset(&mask, SIGCHLD);
+ * JASSERT(sigprocmask(SIG_BLOCK, &mask, &oldmask) == 0);
+ * waitpid(...); // This assumes the child quickly exits.
+ *                // This works if doing double-fork.  So, we need to also
+ *                // do the double-fork for the gzip process, while
+ *                // keeping the pipe.
+ * sigprocmask(SIG_SETMASK, &oldmask, NULL);
+ * // NOTE:  The previous implementation of forked ckpt had a child gzip
+ * //        process, and we did a waitpid on that child gzip.  But the
+ * //        child gzip would not exit until the ckpt image was created.
+ * //        So, that forked ckpt was no faster than non-forking.
+ * // Note that the child will inherit the SIGCHLD blocking mask, but the
+ * //   children are our own processes in this usage, and so that's fine.
+ * // Then we don't need prepare_sigchld_handler()
+ * //   and restore_sigchld_handler_and_wait_for_zombie(pid_t pid)
+ *************************************************************/
+// Used by gzip compression process, and used in forked ckpt, where
+//   we create a grandchild to write to the ckpt file asynchronously.
 void
 restore_sigchld_handler_and_wait_for_zombie(pid_t pid)
 {
@@ -440,12 +465,6 @@ CkptSerializer::writeCkptImage(DmtcpCkptHeader ckptHdr,
 // JASSERT(rename(ProcessInfo::instance().getTempCkptFilename().c_str(),
 //         ProcessInfo::instance().getCkptFilename().c_str()) == 0);
 
-  if (forked_ckpt_status == FORKED_CKPT_CHILD) {
-    // Use _exit() instead of exit() to avoid popping atexit() handlers
-    // registered by the parent process.
-    _exit(0); /* grandchild exits */
-  }
-
   if (use_compression) {
     /* In perform_open_ckpt_image_fd(), we set SIGCHLD to our own handler.
      * Restore it now, and wait on compression process (e.g., gzip).
@@ -455,9 +474,12 @@ CkptSerializer::writeCkptImage(DmtcpCkptHeader ckptHdr,
     /* IF OUT OF DISK SPACE, REPORT IT HERE. */
     JASSERT(fsync(fdCkptFileOnDisk) != -1) (JASSERT_ERRNO)
     .Text("(compression): fsync error on checkpoint file");
+    // close fdCkptFileOnDisk here; grandchild process retains a dup of this.
     JASSERT(_real_close(fdCkptFileOnDisk) == 0) (JASSERT_ERRNO)
     .Text("(compression): error closing checkpoint file.");
   }
+  // close fd here; grandchild process retains a dup of this.
+  JASSERT(_real_close(fd) == 0);
 
   JTRACE("checkpoint complete");
 }

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -504,6 +504,7 @@ DmtcpWorker::postCheckpoint()
   //       not finished writing the checkpoint file.
   //       Any user code that waits to see the restart script
   //       could assume the checkpoint is finished, even though it is not.
+  //       And do we need to do this when reading from gzip?
   CoordinatorAPI::sendCkptFilename();
 
   if (exitAfterCkpt) {

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -490,13 +490,20 @@ DmtcpWorker::postCheckpoint()
   JTRACE("Waiting for Write-Ckpt barrier");
   CoordinatorAPI::waitForBarrier("DMT:WriteCkpt");
 
+#ifndef FORKED_CHECKPOINTING
   /* Now that temp checkpoint file is complete, rename it over old permanent
    * checkpoint file.  Uses rename() syscall, which doesn't change i-nodes.
    * So, gzip process can continue to write to file even after renaming.
    */
   JASSERT(rename(ProcessInfo::instance().getTempCkptFilename().c_str(),
                  ProcessInfo::instance().getCkptFilename().c_str()) == 0);
+#endif
 
+  // NOTE: If FORKED_CHECKPOINTING, then the coordinator will write
+  //       the restart script now, even though the grandchild has
+  //       not finished writing the checkpoint file.
+  //       Any user code that waits to see the restart script
+  //       could assume the checkpoint is finished, even though it is not.
   CoordinatorAPI::sendCkptFilename();
 
   if (exitAfterCkpt) {

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -29,6 +29,7 @@
 #include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include "jassert.h"
 #include "jfilesystem.h"
 #include "constants.h"
@@ -37,7 +38,22 @@
 #include "procmapsarea.h"
 #include "procselfmaps.h"
 #include "shareddata.h"
+#include "syscallwrappers.h"
 #include "util.h"
+#if defined(__aarch64__) || defined(__riscv)
+/* On aarch64 and riscv, fork() is not implemented, in favor of clone().
+ *   A true fork call would include CLONE_CHILD_SETTID and set the thread id
+ * in the thread area of the child (using set_thread_area).  We don't do that.
+ */
+# define _real_sys_fork()                                            \
+  _real_syscall(SYS_clone,                                           \
+                CLONE_CHILD_CLEARTID | CLONE_CHILD_SETTID | SIGCHLD, \
+                NULL,                                                \
+                NULL,                                                \
+                NULL)
+#else  // ifdef __aarch64__
+# define _real_sys_fork() _real_syscall(SYS_fork)
+#endif  // ifdef __aarch64__
 
 #define DEV_ZERO_DELETED_STR "/dev/zero (deleted)"
 #define DEV_NULL_DELETED_STR "/dev/null (deleted)"
@@ -49,6 +65,10 @@
 #define _real_close          NEXT_FNC(close)
 
 using namespace dmtcp;
+
+#define FORKED_CKPT_FAILED 0
+#define FORKED_CKPT_PARENT 1
+#define FORKED_CKPT_CHILD  2
 
 EXTERNC int dmtcp_infiniband_enabled(void) __attribute__((weak));
 
@@ -83,6 +103,52 @@ writeAreaHeader(int fd, Area *area)
   JASSERT(Util::writeAll(fd, area, sizeof(*area)) == (ssize_t) sizeof(*area));
 }
 
+static int
+test_and_fork_if_forked_ckpt()
+{
+#ifdef TEST_FORKED_CHECKPOINTING
+  return 1;
+#endif  // ifdef TEST_FORKED_CHECKPOINTING
+
+  if (getenv(ENV_VAR_FORKED_CKPT) == NULL) {
+    return 0;
+  }
+
+  /* Set SIGCHLD to our own handler;
+   *     User handling is restored after forking child process.
+   */
+  // prepare_sigchld_handler();
+
+  pid_t forked_cpid = _real_sys_fork();
+  if (forked_cpid == -1) {
+    JWARNING(false)
+    .Text("Failed to do forked checkpointing, trying normal checkpoint");
+    return FORKED_CKPT_FAILED;
+  } else if (forked_cpid > 0) {
+    // FIXME: Avoid calling SIGCHLD on original user process
+    // restore_sigchld_handler_and_wait_for_zombie(forked_cpid);
+    JTRACE("checkpoint complete\n");
+    return FORKED_CKPT_PARENT;
+  } else {
+    pid_t grandchild_pid = _real_sys_fork();
+    JWARNING(grandchild_pid != -1)
+      .Text("WARNING: Forked checkpoint failed, no checkpoint available");
+    if (grandchild_pid > 0) {
+      // Uses rename() syscall, which doesn't change i-nodes.
+      // So, gzip process can continue to write to file even after renaming.
+      JASSERT(rename(ProcessInfo::instance().getTempCkptFilename().c_str(),
+            ProcessInfo::instance().getCkptFilename().c_str()) == 0);
+      // Use _exit() instead of exit() to avoid popping atexit() handlers
+      // registered by the parent process.
+      _exit(0); /* child exits */
+    }
+
+    /* grandchild continues; no need now to waitpid() on grandchild */
+    JTRACE("inside grandchild process");
+  }
+  return FORKED_CKPT_CHILD;
+}
+
 /*****************************************************************************
  *
  *  This routine is called from time-to-time to write a new checkpoint file.
@@ -93,8 +159,11 @@ writeAreaHeader(int fd, Area *area)
  *  this function which can cause memory leaks.
  *
  *****************************************************************************/
+// FIXME:  Add this enum to "procmapsarea.h", instead
+//         Or maybe remove it everywhere, and use it only in the body.
+enum memory_area_type {AREA_SHARED, AREA_NOTSHARED, AREA_END, AREA_ALL};
 void
-mtcp_writememoryareas(int fd)
+mtcp_writememoryareas(int fd, memory_area_type type)
 {
   Area area;
 
@@ -177,6 +246,12 @@ mtcp_writememoryareas(int fd)
     (ProcessInfo::instance().restoreBuf.endAddr);
   procSelfMaps = new ProcSelfMaps();
 
+memory_area_type phase[3] = {AREA_SHARED, AREA_NOTSHARED, AREA_END};
+for (int i = 0; i < 3; i++) {
+  type = phase[i];
+  if (phase[i] == AREA_NOTSHARED) {
+    test_and_fork_if_forked_ckpt(); }
+  procSelfMaps->reset();
   // We must not cause an mmap() here, or the mem regions will not be correct.
   while (procSelfMaps->getNextArea(&area)) {
     Area unchecked_area;
@@ -193,6 +268,17 @@ mtcp_writememoryareas(int fd)
         break;
       }
 
+      if ((type == AREA_SHARED) && (area.flags &= MAP_PRIVATE)) {
+        skip = 1;
+      }
+      if ((type == AREA_NOTSHARED) && !(area.flags &= MAP_PRIVATE)) {
+        skip = 1;
+      }
+      if (type == AREA_END) {
+        skip = 1;
+      }
+      if (skip) { break; }
+
       unchecked_area.addr = area.endAddr;
       unchecked_area.size = unchecked_area.endAddr - area.endAddr;
       
@@ -200,16 +286,19 @@ mtcp_writememoryareas(int fd)
       writememoryarea(fd, area);
     } while (unchecked_area.size != 0);
   }
+}
 
   /* It's now safe to do this, since we're done using writememoryarea() */
   remap_nscd_areas(*nscdAreas);
 
-  area.addr = NULL; // End of data
-  area.size = -1; // End of data
-  JASSERT(Util::writeAll(fd, &area, sizeof(area)) == sizeof(area));
+  if (type == AREA_ALL || type == AREA_END) {
+    area.addr = NULL; // End of data
+    area.size = -1; // End of data
+    JASSERT(Util::writeAll(fd, &area, sizeof(area)) == sizeof(area));
 
-  /* That's all folks */
-  JASSERT(_real_close(fd) == 0);
+    /* That's all folks */
+    JASSERT(_real_close(fd) == 0);
+  }
 }
 
 static void


### PR DESCRIPTION
This is a draft PR -- still a work in progress.  But we can support full forked ckpt (including shared memory), with only a _little_ extra code.

__Support shared memory for forked ckpt__
* mtcp_writememoryareas(int fd, int type):
    type = AREA_SHARED, AREA_NONSHARED, AREA_DONE, AREA_ALL
Then write AREA_SHARED, then fork, and then AREA_NONSHARED.
This assumes AREA_SHARED is smaller, and will not delay the parent,
when writing this small amount of memory to the checkpoint image file.

__ALSO: *.dmtcp.temp to *.dmtp only when done, and unlink previous ckpt file when we begin a new ckpt.__
 * This is to make sure that a user doesn't accidentally see the previous checkpoint image and think that the new one is done.
           But I should revise this.  Instead of unlinking the previous ckpt file, I should rename it to *.dmtcp.old, and then unlink it only when the new ckpt image file has been created.

__TODO:__
 * Verify that we are not doing any new mmap (e.g., JTRACE) in multiple calls to mtcp_writememoryareas()
 * Improve shared-memory1 and shared-memory2 to verify that the ckpt image doesn't include new writes by the parent.  Then manually test that, after configuring for --enable-forked-checkpointing.
 * Maybe also have coordinator rename restart_script.sh to restart_script.sh.old and then unlink it when the ckpts are done?
   But this code would be ugly.  So, maybe just let the user beware, and they can look for *.dmtcp.old instead.