### PR TITLE
Remove --mpi from restart related code.

### DIFF
--- a/src/dmtcprestartinternal.cpp
+++ b/src/dmtcprestartinternal.cpp
@@ -98,7 +98,6 @@ static const char *theUsage =
   "              Directory to store checkpoint images\n"
   "              (default: use the same dir used in previous checkpoint)\n"
   "  --restartdir Directory that contains checkpoint image directories\n"
-  "  --mpi       Use as MPI proxy (default: no MPI proxy)\n"
   "  --tmpdir PATH (environment variable DMTCP_TMPDIR)\n"
   "              Directory to store temp files (default: $TMDPIR or /tmp)\n"
   "  -q, --quiet (or set environment variable DMTCP_QUIET = 0, 1, or 2)\n"
@@ -755,9 +754,6 @@ DmtcpRestart::DmtcpRestart(int argc, char **argv, const string& binaryName, cons
     } else if (argc > 1 && (s == "--gdb")) {
       requestedDebugLevel = atoi(argv[1]);
       shift; shift;
-    } else if (s == "--mpi") {
-      runMpiProxy = true;
-      shift;
     } else if (s == "-q" || s == "--quiet") {
       *getenv(ENV_VAR_QUIET) = *getenv(ENV_VAR_QUIET) + 1;
 

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -221,10 +221,6 @@ mtcp_restart_process_args(int argc, char *argv[], char **environ, void (*restore
     if (mtcp_strcmp(argv[0], "--use-gdb") == 0) {
       rinfo.use_gdb = 1;
       shift;
-    } else if (mtcp_strcmp(argv[0], "--mpi") == 0) {
-      rinfo.mpiMode = 1;
-      shift;
-      // Flags for call by dmtcp_restart follow here:
     } else if (mtcp_strcmp(argv[0], "--fd") == 0) {
       rinfo.fd = mtcp_strtol(argv[1]);
       shift; shift;
@@ -247,10 +243,6 @@ mtcp_restart_process_args(int argc, char *argv[], char **environ, void (*restore
       // We would use MTCP_PRINTF, but it's also for output of util/readdmtcp.sh
       mtcp_printf("Considering '%s' as a ckpt image.\n", argv[0]);
       mtcp_strcpy(rinfo.ckptImage, argv[0]);
-      break;
-    } else if (rinfo.mpiMode) {
-      // N.B.: The assumption here is that the user provides the `--mpi` flag
-      // followed by a list of checkpoint images
       break;
     } else {
       MTCP_PRINTF("MTCP Internal Error: Unknown argument: %s\n", argv[0]);


### PR DESCRIPTION
MANA uses its kernel-loader to restart. So the --mpi flag in DMTCP is deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed MPI proxy option (`--mpi` flag) from the restart command-line interface and its associated argument processing, simplifying restart behavior by discontinuing MPI-specific handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->