### PR TITLE
Fix virtual to real path mapping in Plugin Translator on dmtcp_restart using DMTCP_PATH_MAPPING

### DIFF
--- a/src/plugin_pathtranslator.cpp
+++ b/src/plugin_pathtranslator.cpp
@@ -137,7 +137,7 @@ pathTranslator_VirtualToReal(DmtcpEventData_t *data)
   for (const auto &mapping : *pathMapping) {
     const string &oldp = mapping.first;
     const string &newp = mapping.second;
-    if (Util::strStartsWith(virtPath, oldp.c_str()) &&!(Util::strStartsWith(virtPath, newp.c_str()))) {
+    if (Util::strStartsWith(virtPath, oldp.c_str())) {
       // boundary check: next char must be '/' or end
       char next = virtPath[oldp.size()];
       if (next == '/' || next == '\0') {

--- a/src/plugin_pathtranslator.cpp
+++ b/src/plugin_pathtranslator.cpp
@@ -141,12 +141,12 @@ pathTranslator_VirtualToReal(DmtcpEventData_t *data)
       // boundary check: next char must be '/' or end
       char next = virtPath[oldp.size()];
       if (next == '/' || next == '\0') {
-        string original = virtPath;  
-        string replaced = newp + original.substr(oldp.size());
+        string suffix = &virtPath[oldp.size()];  
         int n = snprintf(data->virtualToRealPath.path,
                          PATH_MAX,
-                         "%s",
-                         replaced.c_str());
+                         "%s%s",
+                         newp.c_str(),
+                         suffix.c_str());
         JASSERT(n > 0 && n < PATH_MAX).Text("Translated path exceeds PATH_MAX");
       }
     }

--- a/src/plugin_pathtranslator.cpp
+++ b/src/plugin_pathtranslator.cpp
@@ -137,12 +137,16 @@ pathTranslator_VirtualToReal(DmtcpEventData_t *data)
   for (const auto &mapping : *pathMapping) {
     const string &oldp = mapping.first;
     const string &newp = mapping.second;
-    if (Util::strStartsWith(virtPath, oldp.c_str())) {
+    if (Util::strStartsWith(virtPath, oldp.c_str()) &&!(Util::strStartsWith(virtPath, newp.c_str()))) {
       // boundary check: next char must be '/' or end
       char next = virtPath[oldp.size()];
       if (next == '/' || next == '\0') {
-        const char* suffix = virtPath + oldp.size();
-        int n = snprintf(data->virtualToRealPath.path, PATH_MAX, "%s%s", newp.c_str(), suffix);
+        string original = virtPath;  
+        string replaced = newp + original.substr(oldp.size());
+        int n = snprintf(data->virtualToRealPath.path,
+                         PATH_MAX,
+                         "%s",
+                         replaced.c_str());
         JASSERT(n > 0 && n < PATH_MAX).Text("Translated path exceeds PATH_MAX");
       }
     }


### PR DESCRIPTION
**Problem Description**

This PR addresses an issue previously reported in https://github.com/dmtcp/dmtcp/issues/1232.
When using DMTCP_PATH_MAPPING to relocate checkpoint files to a new directory, repeated path translations result in incorrect path expansion.

**Scenario**

Suppose I have my application executable and related files in /a/b/c, So at the time of checkpoint, it would save this path to all the files inside /a/b/c.
Now I copies contents inside "c" folder including checkpoint files to new location , suppose /q/w/e. Now if I delete the older location and try to run dmtcp_restart with DMTCP_PATH_MAPPING variable i.e below command 
`DMTCP_PATH_MAPPING="/a/b/c:/q/w/e" dmtcp_restart ckpt_*`

**Observed Behaviour**

The first path translation works correctly: `/a/b/c → /q/w/e`.
However, subsequent translations of the same virtual path result in incorrect path construction:
`/a/b/c → /q/w/ee
→ /q/w/eee
→ /q/w/eeee...`
This eventually causes:

> - Invalid paths
> - File not found errors
> - dmtcp hanging during restart

**Root Cause**

The issue appears to originate from the following line:
`int n = snprintf(data->virtualToRealPath.path, PATH_MAX, "%s%s", newp.c_str(), suffix);`
Repeated translations append the suffix multiple times, causing cumulative path corruption.
Additionally, there was no guard preventing already-translated paths from being reprocessed.

**Fix**

1. Corrected the snprintf usage to avoid unintended concatenation.
2. Added a guard condition to prevent re-translation of paths that already contain the mapped prefix.
`!(Util::strStartsWith(virtPath, newp.c_str()))`

**Testing**

> - Reproduced the issue using the scenario described above.
> - Verified correct behavior after fix:
> - Path translation happens only once.
> - No cumulative suffix growth.
> - Restart completes successfully.
Please let me know if additional test cases or automated tests should be added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an edge case in path translation that could produce incorrect translated paths in certain overlaps; preserves existing boundary checks and path-length validation.
  * No changes to public interfaces or exported signatures; behavior and validations remain unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dmtcp/dmtcp/pull/1238)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->