### PR TITLE
C23 fix for syscallsreal.c and pid_syscallsreal.c

### DIFF
--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -1578,10 +1578,8 @@ DmtcpCoordinator::addDataSocket(CoordClient *client)
 // Copy name+suffix into short_buf of length len, and truncate name to fit.
 // This keeps only the last component of name (after last '/')
 char *short_name(char short_buf[], char *name, unsigned int len, char *suffix) {
-  char name_copy[strlen(name)+1];
-  memcpy(name_copy, name, strlen(name)+1);
-  char *base_name = strrchr(name_copy, '/') == NULL ?
-                    name_copy : strrchr(name_copy, '/') + 1;
+  const char* last_slash = strrchr(name, '/');
+  const char* base_name = (last_slash == nullptr) ? name : last_slash + 1;
   int suffix_len = strlen(suffix);
   if (6 + strlen(suffix) > len) {
     return NULL;

--- a/src/plugin/pid/pid_syscallsreal.c
+++ b/src/plugin/pid/pid_syscallsreal.c
@@ -26,9 +26,12 @@
 // #define GNU_SRC
 // #define __USE_UNIX98
 #include <dlfcn.h>
+#include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/ioctl.h>
 #include <sys/syscall.h>
+#include <termios.h>
 #include <unistd.h>
 #include "dmtcp.h"
 #include "pidwrappers.h"
@@ -85,6 +88,17 @@ pid_initialize_wrappers()
   }
 }
 
+#define REAL_FUNC_PASSTHROUGH(name) \
+  static typeof(&name) fn = NULL;   \
+  REAL_FUNC_PASSTHROUGH_WORK(name)  \
+  return (*fn)
+
+// As above, but (*fn) does not return.
+#define REAL_FUNC_PASSTHROUGH_NORETURN(name) \
+  static typeof(&name) fn = NULL;            \
+  REAL_FUNC_PASSTHROUGH_WORK(name)           \
+  (*fn)
+
 #define REAL_FUNC_PASSTHROUGH_WORK(name)                                      \
   if (fn == NULL) {                                                           \
     if (pid_real_func_addr[PIDVIRT_ENUM(name)] == NULL) {                     \
@@ -99,23 +113,6 @@ pid_initialize_wrappers()
       abort();                                                                \
     }                                                                         \
   }
-
-#define REAL_FUNC_PASSTHROUGH(name) REAL_FUNC_PASSTHROUGH_TYPED(int, name)
-
-#define REAL_FUNC_PASSTHROUGH_TYPED(type, name) \
-  static type (*fn)() = NULL;                   \
-  REAL_FUNC_PASSTHROUGH_WORK(name)              \
-  return (*fn)
-
-#define REAL_FUNC_PASSTHROUGH_VOID(name) \
-  static void (*fn)() = NULL;            \
-  REAL_FUNC_PASSTHROUGH_WORK(name)       \
-  (*fn)
-
-#define REAL_FUNC_PASSTHROUGH_NORETURN(name)                \
-  static void (*fn)() __attribute__((__noreturn__)) = NULL; \
-  REAL_FUNC_PASSTHROUGH_WORK(name)                          \
-  (*fn)
 
 LIB_PRIVATE
 void *
@@ -170,21 +167,21 @@ LIB_PRIVATE
 pid_t
 _real_getpgrp(void)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, getpgrp) ();
+  REAL_FUNC_PASSTHROUGH(getpgrp) ();
 }
 
 LIB_PRIVATE
 pid_t
 _real_setpgrp(void)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, setpgrp) ();
+  REAL_FUNC_PASSTHROUGH(setpgrp) ();
 }
 
 LIB_PRIVATE
 pid_t
 _real_getpgid(pid_t pid)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, getpgid) (pid);
+  REAL_FUNC_PASSTHROUGH(getpgid) (pid);
 }
 
 LIB_PRIVATE
@@ -198,14 +195,14 @@ LIB_PRIVATE
 pid_t
 _real_getsid(pid_t pid)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, getsid) (pid);
+  REAL_FUNC_PASSTHROUGH(getsid) (pid);
 }
 
 LIB_PRIVATE
 pid_t
 _real_setsid(void)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, setsid) ();
+  REAL_FUNC_PASSTHROUGH(setsid) ();
 }
 
 LIB_PRIVATE
@@ -219,14 +216,14 @@ LIB_PRIVATE
 pid_t
 _real_wait(__WAIT_STATUS stat_loc)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, wait) (stat_loc);
+  REAL_FUNC_PASSTHROUGH(wait) (stat_loc);
 }
 
 LIB_PRIVATE
 pid_t
 _real_waitpid(pid_t pid, int *stat_loc, int options)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, waitpid) (pid, stat_loc, options);
+  REAL_FUNC_PASSTHROUGH(waitpid) (pid, stat_loc, options);
 }
 
 LIB_PRIVATE
@@ -240,14 +237,14 @@ LIB_PRIVATE
 pid_t
 _real_wait3(__WAIT_STATUS status, int options, struct rusage *rusage)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, wait3) (status, options, rusage);
+  REAL_FUNC_PASSTHROUGH(wait3) (status, options, rusage);
 }
 
 LIB_PRIVATE
 pid_t
 _real_wait4(pid_t pid, __WAIT_STATUS status, int options, struct rusage *rusage)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, wait4) (pid, status, options, rusage);
+  REAL_FUNC_PASSTHROUGH(wait4) (pid, status, options, rusage);
 }
 
 LIB_PRIVATE
@@ -264,7 +261,7 @@ _real_ioctl(int d, unsigned long int request, ...)
   va_end(ap);
 
   ///usr/include/unistd.h says syscall returns long int (contrary to man page)
-  REAL_FUNC_PASSTHROUGH_TYPED(int, ioctl) (d, request, arg);
+  REAL_FUNC_PASSTHROUGH(ioctl) (d, request, arg);
 }
 
 LIB_PRIVATE
@@ -324,25 +321,26 @@ _real_syscall(long sys_num, ...)
   va_end(ap);
 
   ///usr/include/unistd.h says syscall returns long int (contrary to man page)
-  REAL_FUNC_PASSTHROUGH_TYPED(long, syscall) (sys_num, arg[0], arg[1],
-                                              arg[2], arg[3], arg[4],
-                                              arg[5], arg[6]);
+  REAL_FUNC_PASSTHROUGH(syscall) (sys_num, arg[0], arg[1], arg[2],
+                                        arg[3], arg[4], arg[5], arg[6]);
 }
 
 LIB_PRIVATE
 pid_t
 _real_fork()
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, fork) ();
+  REAL_FUNC_PASSTHROUGH(fork) ();
 }
 
 LIB_PRIVATE
 pid_t
 _real_vfork()
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, vfork) ();
+  REAL_FUNC_PASSTHROUGH(vfork) ();
 }
 
+extern int __clone (int (*__fn) (void *__arg), void *__child_stack,
+                    int __flags, void *__arg, ...);
 LIB_PRIVATE
 int
 _real_clone(int (*function)(
@@ -364,7 +362,7 @@ LIB_PRIVATE
 void *
 _real_shmat(int shmid, const void *shmaddr, int shmflg)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(void *, shmat) (shmid, shmaddr, shmflg);
+  REAL_FUNC_PASSTHROUGH(shmat) (shmid, shmaddr, shmflg);
 }
 
 LIB_PRIVATE
@@ -433,7 +431,7 @@ LIB_PRIVATE
 void
 _real_pthread_exit(void *retval)
 {
-  REAL_FUNC_PASSTHROUGH_VOID(pthread_exit) (retval);
+  REAL_FUNC_PASSTHROUGH_NORETURN(pthread_exit) (retval);
 }
 
 LIB_PRIVATE
@@ -475,7 +473,7 @@ LIB_PRIVATE
 int
 _real_sched_setparam(pid_t pid, const struct sched_param *param)
 {
-  REAL_FUNC_PASSTHROUGH(sched_setparam) (pid);
+  REAL_FUNC_PASSTHROUGH(sched_setparam) (pid, param);
 }
 
 LIB_PRIVATE

--- a/src/syscallsreal.c
+++ b/src/syscallsreal.c
@@ -36,11 +36,15 @@
 #include <fcntl.h>
 #include <malloc.h>
 #include <pthread.h>
+#include <sched.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <syslog.h>
 #include <sys/mman.h>
 #include <sys/select.h>
+#include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/time.h>
 #include <sys/types.h>
@@ -48,6 +52,10 @@
 #include "constants.h"
 #include "syscallwrappers.h"  /* glibc > ver. 2.33: redefines xstat to stat */
 #include "trampolines.h"
+
+// There are many deprecated functions used by the target program.
+// So, we must continue to interpose on them.  So, ignore "deprecated" warnings.
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 typedef int (*funcptr_t) ();
 typedef pid_t (*funcptr_pid_t) ();
@@ -237,14 +245,23 @@ dmtcp_prepare_wrappers(void)
 //////////////////////////
 //// FIRST DEFINE REAL VERSIONS OF NEEDED FUNCTIONS
 
-#define REAL_FUNC_PASSTHROUGH(name) REAL_FUNC_PASSTHROUGH_TYPED(int, name)
+#define REAL_FUNC_PASSTHROUGH(name) \
+  static typeof(&name) fn = NULL;   \
+  REAL_FUNC_PASSTHROUGH_WORK(name)  \
+  return (*fn)
+
+// As above, but (*fn) does not return.
+#define REAL_FUNC_PASSTHROUGH_NORETURN(name) \
+  static typeof(&name) fn = NULL;            \
+  REAL_FUNC_PASSTHROUGH_WORK(name)           \
+  (*fn)
 
 #define REAL_FUNC_PASSTHROUGH_WORK(name)                                      \
   if (fn == NULL) {                                                           \
-    if (dmtcp_real_func_addr[ENUM(name)] == NULL) {                                \
+    if (dmtcp_real_func_addr[ENUM(name)] == NULL) {                           \
       dmtcp_prepare_wrappers();                                               \
     }                                                                         \
-    fn = dmtcp_real_func_addr[ENUM(name)];                                         \
+    fn = dmtcp_real_func_addr[ENUM(name)];                                    \
     if (fn == NULL) {                                                         \
       fprintf(stderr, "*** DMTCP: Error: lookup failed for %s.\n"             \
                       "           The symbol wasn't found in current library" \
@@ -253,21 +270,6 @@ dmtcp_prepare_wrappers(void)
       abort();                                                                \
     }                                                                         \
   }
-
-#define REAL_FUNC_PASSTHROUGH_TYPED(type, name) \
-  static type (*fn)() = NULL;                   \
-  REAL_FUNC_PASSTHROUGH_WORK(name)              \
-  return (*fn)
-
-#define REAL_FUNC_PASSTHROUGH_VOID(name) \
-  static void (*fn)() = NULL;            \
-  REAL_FUNC_PASSTHROUGH_WORK(name)       \
-  (*fn)
-
-#define REAL_FUNC_PASSTHROUGH_NORETURN(name)                \
-  static void (*fn)() __attribute__((__noreturn__)) = NULL; \
-  REAL_FUNC_PASSTHROUGH_WORK(name)                          \
-  (*fn)
 
 typedef void * (*dlsym_fnptr_t) (void *handle, const char *symbol);
 
@@ -296,14 +298,14 @@ LIB_PRIVATE
 void *
 _real_dlopen(const char *filename, int flag)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(void *, dlopen) (filename, flag);
+  REAL_FUNC_PASSTHROUGH(dlopen) (filename, flag);
 }
 
 LIB_PRIVATE
 int
 _real_dlclose(void *handle)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(int, dlclose) (handle);
+  REAL_FUNC_PASSTHROUGH(dlclose) (handle);
 }
 
 LIB_PRIVATE
@@ -412,7 +414,7 @@ LIB_PRIVATE
 FILE *
 _real_popen(const char *command, const char *mode)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(FILE *, popen) (command, mode);
+  REAL_FUNC_PASSTHROUGH(popen) (command, mode);
 }
 
 LIB_PRIVATE
@@ -426,14 +428,14 @@ LIB_PRIVATE
 pid_t
 _real_fork(void)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, fork) ();
+  REAL_FUNC_PASSTHROUGH(fork) ();
 }
 
 LIB_PRIVATE
 pid_t
 _real_vfork(void)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, vfork) ();
+  REAL_FUNC_PASSTHROUGH(vfork) ();
 }
 
 LIB_PRIVATE
@@ -443,12 +445,14 @@ _real_close(int fd)
   REAL_FUNC_PASSTHROUGH(close) (fd);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0) && __GLIBC_PREREQ(2, 34)
 LIB_PRIVATE
 int
 _real_close_range(unsigned int first, unsigned int last, int flags)
 {
   REAL_FUNC_PASSTHROUGH(close_range) (first, last, flags);
 }
+#endif
 
 LIB_PRIVATE
 int
@@ -482,7 +486,7 @@ LIB_PRIVATE
 void
 _real_exit(int status)
 {
-  REAL_FUNC_PASSTHROUGH_VOID(exit) (status);
+  REAL_FUNC_PASSTHROUGH_NORETURN(exit) (status);
 }
 
 LIB_PRIVATE
@@ -504,7 +508,7 @@ LIB_PRIVATE
  FILE *
 _real_tmpfile()
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(FILE *, tmpfile) ();
+  REAL_FUNC_PASSTHROUGH(tmpfile) ();
 }
 
 LIB_PRIVATE
@@ -546,14 +550,14 @@ LIB_PRIVATE
 ssize_t
 _real_readlink(const char *path, char *buf, size_t bufsiz)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(ssize_t, readlink) (path, buf, bufsiz);
+  REAL_FUNC_PASSTHROUGH(readlink) (path, buf, bufsiz);
 }
 
 LIB_PRIVATE
 char *
 _real_realpath(const char *path, char *resolved_path)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(char*, realpath) (path, resolved_path);
+  REAL_FUNC_PASSTHROUGH(realpath) (path, resolved_path);
 }
 
 LIB_PRIVATE
@@ -574,14 +578,14 @@ LIB_PRIVATE
 void
 _real_openlog(const char *ident, int option, int facility)
 {
-  REAL_FUNC_PASSTHROUGH_VOID(openlog) (ident, option, facility);
+  REAL_FUNC_PASSTHROUGH(openlog) (ident, option, facility);
 }
 
 LIB_PRIVATE
 void
 _real_closelog(void)
 {
-  REAL_FUNC_PASSTHROUGH_VOID(closelog) ();
+  REAL_FUNC_PASSTHROUGH(closelog) ();
 }
 
 // set the handler
@@ -589,7 +593,7 @@ LIB_PRIVATE
 sighandler_t
 _real_signal(int signum, sighandler_t handler)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(sighandler_t, signal) (signum, handler);
+  REAL_FUNC_PASSTHROUGH(signal) (signum, handler);
 }
 
 LIB_PRIVATE
@@ -643,14 +647,14 @@ LIB_PRIVATE
 int
 _real_pthread_sigmask(int how, const sigset_t *a, sigset_t *b)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_sigmask) (how, a, b);
+  REAL_FUNC_PASSTHROUGH(pthread_sigmask) (how, a, b);
 }
 
 LIB_PRIVATE
 void *
 _real_pthread_getspecific(pthread_key_t key)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(void *, pthread_getspecific)(key);
+  REAL_FUNC_PASSTHROUGH(pthread_getspecific)(key);
 }
 
 LIB_PRIVATE
@@ -664,7 +668,7 @@ LIB_PRIVATE
 sighandler_t
 _real_sigset(int sig, sighandler_t disp)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(sighandler_t, sigset) (sig, disp);
+  REAL_FUNC_PASSTHROUGH(sigset) (sig, disp);
 }
 
 LIB_PRIVATE
@@ -682,6 +686,7 @@ _real_sigignore(int sig)
 }
 
 // See 'man sigpause':  signal.h defines two possible versions for sigpause.
+extern int __sigpause (int __sig_or_mask, int __is_sig);
 LIB_PRIVATE
 int
 _real__sigpause(int __sig_or_mask, int __is_sig)
@@ -753,7 +758,7 @@ LIB_PRIVATE
 pid_t
 _real_wait4(pid_t pid, __WAIT_STATUS status, int options, struct rusage *rusage)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(pid_t, wait4) (pid, status, options, rusage);
+  REAL_FUNC_PASSTHROUGH(wait4) (pid, status, options, rusage);
 }
 
 LIB_PRIVATE
@@ -776,28 +781,28 @@ LIB_PRIVATE
 FILE *
 _real_fopen(const char *path, const char *mode)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(FILE *, fopen) (path, mode);
+  REAL_FUNC_PASSTHROUGH(fopen) (path, mode);
 }
 
 LIB_PRIVATE
 FILE *
 _real_fopen64(const char *path, const char *mode)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(FILE *, fopen64) (path, mode);
+  REAL_FUNC_PASSTHROUGH(fopen64) (path, mode);
 }
 
 LIB_PRIVATE
 FILE *
 _real_freopen(const char *path, const char *mode, FILE *fp)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(FILE *, freopen) (path, mode, fp);
+  REAL_FUNC_PASSTHROUGH(freopen) (path, mode, fp);
 }
 
 LIB_PRIVATE
 FILE *
 _real_freopen64(const char *path, const char *mode, FILE *fp)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(FILE *, freopen64) (path, mode, fp);
+  REAL_FUNC_PASSTHROUGH(freopen64) (path, mode, fp);
 }
 
 LIB_PRIVATE
@@ -821,7 +826,7 @@ LIB_PRIVATE
 DIR *
 _real_opendir(const char *name)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(DIR *, opendir) (name);
+  REAL_FUNC_PASSTHROUGH(opendir) (name);
 }
 
 LIB_PRIVATE
@@ -851,9 +856,8 @@ _real_syscall(long sys_num, ...)
   va_end(ap);
 
   ///usr/include/unistd.h says syscall returns long int (contrary to man page)
-  REAL_FUNC_PASSTHROUGH_TYPED(long, syscall) (sys_num, arg[0], arg[1],
-                                              arg[2], arg[3], arg[4],
-                                              arg[5], arg[6]);
+  REAL_FUNC_PASSTHROUGH(syscall) (sys_num, arg[0], arg[1], arg[2],
+                                        arg[3], arg[4], arg[5], arg[6]);
 }
 
 #ifdef _STAT_VER
@@ -910,11 +914,12 @@ _real_lstat64(const char *path, struct stat64 *buf) {
 }
 #endif
 
+extern int __clone (int (*__fn) (void *__arg), void *__child_stack,
+                    int __flags, void *__arg, ...);
 LIB_PRIVATE
 int
-_real_clone(int (*function)(
-              void *), void *child_stack, int flags, void *arg, int *parent_tidptr, struct user_desc *newtls,
-            int *child_tidptr)
+_real_clone(int (*function)(void *), void *child_stack, int flags, void *arg,
+            int *parent_tidptr, struct user_desc *newtls, int *child_tidptr)
 {
   REAL_FUNC_PASSTHROUGH(__clone) (function, child_stack, flags, arg,
                                   parent_tidptr, newtls, child_tidptr);
@@ -924,7 +929,7 @@ LIB_PRIVATE
 int
 _real_pthread_tryjoin_np(pthread_t thread, void **retval)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_tryjoin_np) (thread, retval);
+  REAL_FUNC_PASSTHROUGH(pthread_tryjoin_np) (thread, retval);
 }
 
 LIB_PRIVATE
@@ -933,7 +938,7 @@ _real_pthread_timedjoin_np(pthread_t thread,
                            void **retval,
                            const struct timespec *abstime)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_timedjoin_np) (thread, retval,
+  REAL_FUNC_PASSTHROUGH(pthread_timedjoin_np) (thread, retval,
                                                           abstime);
 }
 
@@ -944,7 +949,7 @@ _real_pthread_create(pthread_t *thread,
                      void *(*start_routine)(void *),
                      void *arg)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(int, pthread_create)
+  REAL_FUNC_PASSTHROUGH(pthread_create)
     (thread, attr, start_routine, arg);
 }
 
@@ -967,7 +972,7 @@ LIB_PRIVATE
 void *
 _real_shmat(int shmid, const void *shmaddr, int shmflg)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(void *, shmat) (shmid, shmaddr, shmflg);
+  REAL_FUNC_PASSTHROUGH(shmat) (shmid, shmaddr, shmflg);
 }
 
 LIB_PRIVATE
@@ -1071,7 +1076,7 @@ LIB_PRIVATE
 mqd_t
 _real_mq_open(const char *name, int oflag, mode_t mode, struct mq_attr *attr)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(mqd_t, mq_open) (name, oflag, mode, attr);
+  REAL_FUNC_PASSTHROUGH(mq_open) (name, oflag, mode, attr);
 }
 
 LIB_PRIVATE
@@ -1096,9 +1101,9 @@ _real_mq_timedreceive(mqd_t mqdes,
                       unsigned int *msg_prio,
                       const struct timespec *abs_timeout)
 {
-  REAL_FUNC_PASSTHROUGH_TYPED(ssize_t, mq_timedreceive) (mqdes, msg_ptr,
-                                                         msg_len, msg_prio,
-                                                         abs_timeout);
+  REAL_FUNC_PASSTHROUGH(mq_timedreceive) (mqdes, msg_ptr,
+                                                msg_len, msg_prio,
+                                                abs_timeout);
 }
 
 LIB_PRIVATE


### PR DESCRIPTION
`src/syscallsreal.c` and `src/plugin/pid/pid_syscallsreal.c` were going to break when we use a compiler enforcing C23.  C23 requires signatures in fnc pointers (to be aligned with C++).  Luckily, C23 also makes the built-in, `typeof()`, part of the C standard.  GCC and CLANG always provided `typeof()`.  But now, all compliant compilers must provide it.  So, it's safe for us to use it.

And I also cleaned up some minor errors along the way:
 1. sched_setparam:  We were discarding the second argument, param, when we interposed
 2. close_range was created only with Linux 5.9 and glibc-2.34.  We were not testing this
 3. We were missing several include files that had the declarations for the functions that we were interposing on.  (Since C23 requires the signature for fnc. pointers, we now need to include the proper `.h` files.)

I also tested on Rocky Linux 8 (Linux 4.18 and glibc-2.28).  This is an older O/S.  So, hopefully, we're not breaking DMTCP on older Linuxes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated wrapper macros across system call handlers for improved type safety and consistency.
  * Refactored function pointer types to use more specific signatures rather than generic types.
  * Reorganized system headers and function declarations for clearer code structure.

* **Bug Fixes**
  * Enhanced error handling to abort immediately when required library symbols are missing, improving diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->