### PR TITLE
DMTCP requires __atomic_compare_exchange_16 ; clang++ wasn't finding it

### DIFF
--- a/configure
+++ b/configure
@@ -12322,10 +12322,97 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $gccAtomicBuiltins" >&5
 printf "%s\n" "$gccAtomicBuiltins" >&6; }
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing __atomic_compare_exchange_16" >&5
+printf %s "checking for library containing __atomic_compare_exchange_16... " >&6; }
+if test ${ac_cv_search___atomic_compare_exchange_16+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char __atomic_compare_exchange_16 (void);
+int
+main (void)
+{
+return __atomic_compare_exchange_16 ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' atomic
+do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_search___atomic_compare_exchange_16=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext
+  if test ${ac_cv_search___atomic_compare_exchange_16+y}
+then :
+  break
+fi
+done
+if test ${ac_cv_search___atomic_compare_exchange_16+y}
+then :
+
+else case e in #(
+  e) ac_cv_search___atomic_compare_exchange_16=no ;;
+esac
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search___atomic_compare_exchange_16" >&5
+printf "%s\n" "$ac_cv_search___atomic_compare_exchange_16" >&6; }
+ac_res=$ac_cv_search___atomic_compare_exchange_16
+if test "$ac_res" != no
+then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+else case e in #(
+  e)
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Could not find 128-bit atomic support in libatomic." >&5
+printf "%s\n" "$as_me: WARNING: Could not find 128-bit atomic support in libatomic." >&2;}
+ ;;
+esac
+fi
+
+
 if test "$gccAtomicBuiltins" = "yes"; then
 
 printf "%s\n" "#define HAS_128_ATOMIC 1" >>confdefs.h
 
+fi
+is_clang_cpp=no
+$CXX -x c++ -dM -E - < /dev/null | grep -q "__clang__" && is_clang_cpp=yes
+if test "$gccAtomicBuiltins" = "no" -a "$is_clang_cpp" = "yes"; then
+  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+as_fn_error $? "Using C++14 with clang++ to support atomic built-ins.
+                  Missing Linux packages.  If Ubuntu/Debian, consider:
+                  sudo apt install clang libclang-rt-dev libc++abi-dev
+                  libstdc++-14-dev (or later version of libstdc++-14-dev).
+                  If Red Hat/Fedora/CentOS/Rocky Linux, consider:
+                  sudo dnf install clang-devel libstdc++-devel libatomic
+See 'config.log' for more details" "$LINENO" 5; }
 fi
 if test "$gccAtomicBuiltins" = "no"; then
   { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -464,9 +464,9 @@ if test "$is_aarch64_host" == "yes" -a "$CC" == "gcc"; then
   # See  https://lore.kernel.org/linux-arm-kernel/20240109082647.GJ19790@gate.crashing.org/T/#m2b7753c4dab70f67497dd4e618e80150649c133d
   # I suspect this is down to your toolchain enabling -moutline-atomics by default;
   # I suspect your # cross-compile toolchain doesn't enable that by default.
-  # Unfortunately, '-mno-outline' will cause arum64 to use the slower futexes.
+  # Unfortunately, '-mno-outline' will cause arm64 to use the slower futexes.
   # Arguably, this is a bug.
-  # If this is a problem, then use clang (LLVM) instead of gcc,r or wait and see
+  # If this is a problem, then use clang (LLVM) instead of gcc, or wait and see
   # if Debian/GNU gcc.will fix this toolchain misfeature.
   # See configure.ac for further discussion.
   AX_CHECK_COMPILE_FLAG([-mno-outline-atomics],
@@ -933,11 +933,29 @@ AC_LINK_IFELSE(
   ]])
 ], [gccAtomicBuiltins='yes'], [gccAtomicBuiltins='no'])
 LDFLAGS="$LDFLAGS_orig"
+
+dnl __atomic_compare_exchange_16 is often in libatomic
+AC_SEARCH_LIBS([__atomic_compare_exchange_16], [atomic], [], [
+  AC_MSG_WARN([Could not find 128-bit atomic support in libatomic.])
+])
+
 AC_LANG_POP([C++])
 AC_MSG_RESULT([$gccAtomicBuiltins])
 
 if test "$gccAtomicBuiltins" = "yes"; then
   AC_DEFINE([HAS_128_ATOMIC],[1],[Define to 1 if 'gcc test.c -latomic' works for __atomic_compare_exchange])
+fi
+dnl $CXX might be "clang++ -std=c++14".  Further, we need "-x c++"
+dnl   or else clang++ defaults to assuming a C file.
+is_clang_cpp=no
+$CXX -x c++ -dM -E - < /dev/null | grep -q "__clang__" && is_clang_cpp=yes
+if test "$gccAtomicBuiltins" = "no" -a "$is_clang_cpp" = "yes"; then
+  AC_MSG_FAILURE([Using C++14 with clang++ to support atomic built-ins.
+                  Missing Linux packages.  If Ubuntu/Debian, consider:
+                  sudo apt install clang libclang-rt-dev libc++abi-dev
+                  libstdc++-14-dev (or later version of libstdc++-14-dev).
+                  If Red Hat/Fedora/CentOS/Rocky Linux, consider:
+                  sudo dnf install clang-devel libstdc++-devel libatomic])
 fi
 if test "$gccAtomicBuiltins" = "no"; then
   AC_MSG_FAILURE([Using C++14, which should support both sync and atomic

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -21,7 +21,7 @@
 /* Override to use FSGSBASE kernel patch */
 #undef ENABLE_FSGSBASE_OVERRIDE
 
-/* Enable 'DMTCP:' prefix in comm field of 'ps' (Disable for CUDA ckpt API) */
+/* Enable 'DMTCP:' prefix in comm field of 'ps' (for CUDA ckpt) */
 #undef ENABLE_PRGNAME_PREFIX
 
 /* Child process does checkpointing */
@@ -54,7 +54,7 @@
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
-/* Define to 1 if you have the `atomic' library (-latomic). */
+/* Define to 1 if you have the 'atomic' library (-latomic). */
 #undef HAVE_LIBATOMIC
 
 /* Define to 1 if you have the <linux/version.h> header file. */
@@ -135,7 +135,7 @@
 /* No output, not even NOTE and WARNING */
 #undef QUIET
 
-/* Define to 1 if all of the C90 standard headers exist (not just the ones
+/* Define to 1 if all of the C89 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
    backward compatibility; new code need not use it. */
 #undef STDC_HEADERS


### PR DESCRIPTION
In clang++, it wasn't finding the libatomic to support that. This commit provides recommendations for the user about which Linux distro packages to load, to support libatomic in clang++.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration to detect 128-bit atomic support, record required link libraries, and emit a visible warning when missing.
  * Added a clang-specific failure path that provides actionable package-install guidance when 128-bit atomic support is unavailable.

* **Documentation**
  * Clarified and corrected several build-related comments for accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->