### PR TITLE
Fix missing file creation mode on restart

### DIFF
--- a/src/plugin/ipc/file/fileconnection.cpp
+++ b/src/plugin/ipc/file/fileconnection.cpp
@@ -127,6 +127,7 @@ FileConnection::drain()
   // Read the current file descriptor offset
   _offset = lseek(_fds[0], 0, SEEK_CUR);
   fstat(_fds[0], &statbuf);
+  _mode = statbuf.st_mode;
   _st_dev = statbuf.st_dev;
   _st_ino = statbuf.st_ino;
   _st_size = statbuf.st_size;
@@ -370,7 +371,8 @@ FileConnection::refill(bool isRestart)
       tempfd = openFile();
     } else if (_fcntlFlags & O_WRONLY) {
       // File doesn't exist. If it's a WRONLY file, we'll create a new one.
-      tempfd = _real_open(_path.c_str(), O_CREAT|O_WRONLY|O_TRUNC);
+      mode_t createMode = (_mode == 0) ? 0600 : (_mode & 0777);
+      tempfd = _real_open(_path.c_str(), O_CREAT|O_WRONLY|O_TRUNC, createMode);
       ASSERT_NE(-1, tempfd);
       ASSERT_EQ(0, ftruncate(tempfd, _st_size));
     } else {
@@ -633,7 +635,7 @@ FileConnection::serializeSubClass(jalib::JBinarySerializer &o)
 {
   JSERIALIZE_ASSERT_POINT("FileConnection");
   o&_path &_rel_path;
-  o&_offset&_st_dev&_st_ino&_st_size&_ckpted_file &_rmtype;
+  o&_mode &_offset&_st_dev&_st_ino&_st_size&_ckpted_file &_rmtype;
   JTRACE("Serializing FileConn.") (_path) (_rel_path)
     (dmtcp_get_ckpt_files_subdir()) (_ckpted_file) (_allow_overwrite) (
     _fcntlFlags);

--- a/src/plugin/ipc/file/fileconnection.h
+++ b/src/plugin/ipc/file/fileconnection.h
@@ -82,7 +82,8 @@ class FileConnection : public Connection
       FILE_BATCH_QUEUE
     };
 
-    FileConnection() {}
+    FileConnection()
+      : _mode(0) {}
 
     FileConnection(const string &path,
                    int flags,
@@ -90,6 +91,7 @@ class FileConnection : public Connection
                    int type = FILE_REGULAR)
       : Connection(type)
       , _path(path)
+      , _mode(mode)
       , _fileAlreadyExists(false) {}
 
     virtual void doLocking() override;
@@ -140,9 +142,7 @@ class FileConnection : public Connection
     int32_t _rmtype;
 
     // int64_t       _flags;
-
-    /* No method uses _mode yet.  Stop compiler from issuing warning. */
-    /* int64_t       _mode; */
+    int64_t _mode;
     int64_t _offset;
     uint64_t _st_dev;
     uint64_t _st_ino;

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -892,6 +892,9 @@ S=10*DEFAULT_S
 runTest("file2",         1, ["./test/file2"])
 S=DEFAULT_S
 
+# Test for files where restart restores mode when file is missing.
+runTest("file3", 1, ["./test/file3"])
+
 # Test for normal file, /dev/tty, proc file, and illegal pathname
 runTest("stat",         1, ["./test/stat"])
 

--- a/test/file3.c
+++ b/test/file3.c
@@ -1,0 +1,111 @@
+#include <stdio.h>
+#define __USE_GNU
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define DMTCP_PACKAGE_VERSION "test"
+#include "dmtcp.h"
+
+#define EXPECTED_MODE 0640
+
+int
+main()
+{
+  long int count = 0;
+  int rc;
+  int fd;
+  char filename[100];
+  char oldFilename[100];
+  struct stat statbuf;
+  int dmtcpEnabled = dmtcp_is_enabled();
+  uint32_t generation = 0;
+  int renamedAfterCkpt = 0;
+  int sawRecreatedFile = 0;
+
+  char *dir = getenv("DMTCP_TMPDIR");
+
+  if (!dir) {
+    dir = getenv("TMPDIR");
+  }
+  if (!dir) {
+    dir = "/tmp";
+  }
+
+  if (sizeof(filename) < strlen(dir) + sizeof("/file_recreate.out.0")) {
+    printf("Directory string too large.\n");
+    return 1;
+  }
+  strcpy(filename, dir);
+  strcat(filename, "/file_recreate.out");
+  strcpy(oldFilename, dir);
+  strcat(oldFilename, "/file_recreate.out.0");
+
+  unlink(filename);
+  unlink(oldFilename);
+
+  fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC, EXPECTED_MODE);
+  if (fd < 0) {
+    abort();
+  }
+
+  rc = stat(filename, &statbuf);
+  if (rc == -1) {
+    abort();
+  }
+  if ((statbuf.st_mode & 07000) != 0 ||
+      (statbuf.st_mode & 0777) != EXPECTED_MODE) {
+    abort();
+  }
+
+  if (dmtcpEnabled) {
+    generation = dmtcp_get_generation();
+  }
+
+  while (1) {
+    char buf[64];
+    int n = snprintf(buf, sizeof(buf), "%ld\n", count++);
+    if (write(fd, buf, n) != n) {
+      abort();
+    }
+
+    if (!renamedAfterCkpt && dmtcpEnabled && dmtcp_get_generation() > generation) {
+      // Rename the file after checkpoint so restart must recreate it.
+      renamedAfterCkpt = 1;
+      printf("Renaming %s to %s\n", filename, oldFilename);
+      rc = rename(filename, oldFilename);
+      if (rc == -1) {
+        abort();
+      }
+      fflush(stdout);
+    }
+
+    if (renamedAfterCkpt) {
+      rc = stat(filename, &statbuf);
+      if (rc == 0) {
+        sawRecreatedFile = 1;
+        if ((statbuf.st_mode & 07000) != 0 ||
+            (statbuf.st_mode & 0777) != EXPECTED_MODE) {
+          abort();
+        }
+      } else if (errno != ENOENT) {
+        abort();
+      }
+    }
+
+    if (count % 1000 == 0) {
+      // Print count every second.
+      printf("%ld ", count);
+      fflush(stdout);
+    }
+
+    // Sleep for a millisecond so we don't fill up the disk too quickly.
+    usleep(1000);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This PR fixes the file creation mode for missing files on restart, by saving the file mode in the FileConnection.

I noticed that files recreated after a restart sometimes get strange modes:

```
-r-x--S--T 1 tex tex    8589 May  1 10:21 out.log    # recreated file
-rw-r----- 1 tex tex    8589 May  1 08:11 out.log.0  # original
```

If the file is removed/renamed after the checkpoint is taken then on restart the variadic function `_real_open` is called with `O_CREAT` but no `mode` argument.

https://github.com/dmtcp/dmtcp/blob/6896e12276a9fe449edb0cf206203ce01b19efe6/src/plugin/ipc/file/fileconnection.cpp#L373

This causes the `va_arg`  call in `_real_open` to take an undefined `mode` value off the stack, leading to unexpected file permissions.

https://github.com/dmtcp/dmtcp/blob/6896e12276a9fe449edb0cf206203ce01b19efe6/src/nosyscallsreal.c#L419-L432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Files opened for writing are now properly recreated with their original permissions during checkpoint restart, even if the files are deleted before the restart occurs.

* **Tests**
  * Added test coverage for file mode preservation across restart scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->