### PR TITLE
Skip scanning pre-existing socket for MPI + Hydra

### DIFF
--- a/src/plugin/ipc/socket/socketconnlist.cpp
+++ b/src/plugin/ipc/socket/socketconnlist.cpp
@@ -255,7 +255,9 @@ SocketConnList::scanForPreExisting()
   // pre-existing or not. This can be done by adding an extra round
   // of leader election.
 
-  if (getenv("SLURM_JOBID") || (getenv("SLURM_JOB_ID"))) {
+  if ((getenv("SLURM_JOBID")) ||
+      (getenv("SLURM_JOB_ID")) ||
+      (getenv("HYDI_CONTROL_FD"))) {
     return;
   }
 


### PR DESCRIPTION
Previously, DMTCP will skip scanning pre-existing sockets if the environment variable `SLURM_JOBID` is defined, which means MPI + SLURM is used. Now we need to add the same check for Hydra (for MPICH). 

Hydra creates pipes to communicate between the management process and MPI processes. On restart, DMTCP tries to restore these pipes as sockets and cause some process has a wrong number of incoming/outgoing connections. That process keep waiting on the rewiring fd (836) for refill, which will never be complete. The restart will hang.

After merging this PR, MANA needs to revert https://github.com/mpickpt/mana/pull/474 to work with this PR as a complete solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended socket handling support for HYDI environments, complementing existing SLURM support to improve compatibility and session restoration in cluster computing environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dmtcp/dmtcp/pull/1252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->