### PR TITLE
Detect unallocated pages via pagemap residency at checkpoint

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -257,6 +257,8 @@ bool isPseudoTty(const char *path);
 size_t pageSize();
 size_t pageMask();
 bool areZeroPages(void *addr, size_t numPages);
+bool scanOccupiedRangeBatch(uintptr_t start, uintptr_t end,
+                            uintptr_t *size_scanned);
 
 char *findExecutable(char *executable, const char *path_env, char *exec_path);
 char *getPath(const char *cmd, bool is32bit = false);

--- a/src/constants.h
+++ b/src/constants.h
@@ -134,6 +134,11 @@
 #define ENV_VAR_FSGSBASE_ENABLED        "DMTCP_FSGSBASE_ENABLED"
 #define ENV_VAR_LOG_FILE                "DMTCP_LOG_FILE"
 
+// Set to "1" to force Util::scanOccupiedRangeBatch() to use the portable
+// pread() scan of /proc/self/pagemap instead of the ioctl(PAGEMAP_SCAN)
+// fast path (debugging/testing the fallback on kernels that support both).
+#define ENV_VAR_DISABLE_PAGEMAP_SCAN    "DMTCP_DISABLE_PAGEMAP_SCAN"
+
 // this list should be kept up to date with all "protected" environment vars
 #define ENV_VARS_ALL                  \
   ENV_VAR_NAME_HOST,                  \
@@ -171,6 +176,7 @@
   ENV_VAR_VIRTUAL_PPID,               \
   ENV_VAR_REAL_PPID,                  \
   ENV_VAR_FSGSBASE_ENABLED,           \
+  ENV_VAR_DISABLE_PAGEMAP_SCAN,       \
   ENV_VAR_LOG_FILE
 
 #define DMTCP_RESTART_CMD       "dmtcp_restart"

--- a/src/util_misc.cpp
+++ b/src/util_misc.cpp
@@ -23,10 +23,15 @@
 #include <fcntl.h>
 #include <gnu/libc-version.h>
 #include <limits.h>  // for PATH_MAX
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/ioctl.h>
 #include <sys/time.h>
+#include <unistd.h>
+#include <linux/fs.h>  // for PAGEMAP_SCAN ioctl (Linux 6.7+)
 #include "../jalib/jfilesystem.h"
+#include "constants.h"
 #include "dmtcp.h"
 #include "membarrier.h"
 #include "protectedfds.h"
@@ -595,6 +600,143 @@ Util::areZeroPages(void *addr, size_t numPages)
     }
   }
   return res == 0;
+}
+
+// BATCH_SIZE: pages inspected per pread() in the fallback path.
+// 1024 pages = 4MB of virtual address space per batch (4KB pages).
+#define PAGEMAP_BATCH_SIZE 1024
+
+// Returns true if the leading run of pages in the anonymous range [start, end)
+// is "zero" (each page neither present nor swapped), false if it is occupied
+// (present or swapped).  *size_scanned (OUT) is set to the byte length of that
+// leading run.  Callers advance start by *size_scanned and call again to walk
+// the whole area, mirroring mtcp_get_next_page_range() in writeckpt.cpp but
+// without faulting in absent pages.
+//
+// CORRECTNESS CONSTRAINT: "absent => reads as zero" holds only for genuinely
+// anonymous private memory.  For file-backed mappings (including deleted-but-
+// still-mapped files) an absent page faults in the file's contents, so the
+// caller MUST restrict this to anonymous regions.
+//
+// Prefers ioctl(PAGEMAP_SCAN) (Linux 6.7+, where the kernel skips holes) and
+// falls back to a batched pread() of /proc/self/pagemap on older kernels.  If
+// the pagemap cannot be inspected at all, it conservatively reports the range
+// as occupied so the caller writes the data (no data loss).
+bool
+Util::scanOccupiedRangeBatch(uintptr_t start, uintptr_t end,
+                             uintptr_t *size_scanned)
+{
+  const size_t page_size = pageSize();
+  const uintptr_t pgMask = ~(uintptr_t)(page_size - 1);
+
+  // DMTCP areas are already page-aligned; align defensively anyway.
+  uintptr_t startAddr = start & pgMask;
+  uintptr_t endAddr = (end + page_size - 1) & pgMask;
+
+  if (startAddr >= endAddr) { // empty range
+    *size_scanned = 0;
+    return false;
+  }
+
+  // Use _real_open/_real_close: this may run mid-checkpoint, where the file
+  // plugin's open()/close() wrappers (fd tracking) must not be invoked.
+  int fd = _real_open("/proc/self/pagemap", O_RDONLY);
+  if (fd < 0) {
+    *size_scanned = endAddr - start;
+    return false; // can't inspect: treat as occupied (write the data)
+  }
+
+// PAGEMAP_SCAN (and pm_scan_arg, PAGE_IS_PRESENT, etc.) is defined in
+// /usr/include/linux/fs.h; it is absent on kernel headers older than Linux 6.7,
+// in which case only the pread() fallback below is compiled.
+#ifdef PAGEMAP_SCAN
+  // DMTCP_DISABLE_PAGEMAP_SCAN=1 forces the portable pread() fallback even
+  // where the ioctl is available (covers that path in testing/debugging).
+  if (!readBooleanEnv(ENV_VAR_DISABLE_PAGEMAP_SCAN, false)) {
+    struct page_region region;
+    struct pm_scan_arg arg;
+    memset(&arg, 0, sizeof(arg));
+    arg.size = sizeof(arg);
+    arg.start = startAddr;
+    arg.end = endAddr;
+    arg.vec = (uintptr_t)&region;
+    arg.vec_len = 1; // only need the leading occupied run / first hole edge
+    arg.category_anyof_mask = PAGE_IS_PRESENT | PAGE_IS_SWAPPED;
+    arg.return_mask = PAGE_IS_PRESENT | PAGE_IS_SWAPPED;
+
+    long ret = ioctl(fd, PAGEMAP_SCAN, &arg);
+    if (ret >= 0) {
+      _real_close(fd);
+      if (ret == 0) {
+        // No occupied pages found: the walked range is all zero.
+        uintptr_t walkEnd = arg.walk_end ? (uintptr_t)arg.walk_end : endAddr;
+        *size_scanned = walkEnd - start;
+        return true;
+      }
+      if ((uintptr_t)region.start <= startAddr) {
+        // start is occupied: leading run is the returned occupied region.
+        *size_scanned = (uintptr_t)region.end - start;
+        return false;
+      }
+      // start is in a hole: the leading zero run ends where occupancy begins.
+      *size_scanned = (uintptr_t)region.start - start;
+      return true;
+    }
+    // ioctl unsupported (pre-6.7 kernel) or failed: fall through to pread().
+  }
+#endif // PAGEMAP_SCAN
+
+  // Fallback: batched pread() of /proc/self/pagemap.
+  uint64_t entries[PAGEMAP_BATCH_SIZE];
+  uintptr_t current_addr = startAddr;
+  int leading_occupied = -1; // occupancy of the leading run; set to 0/1 below
+
+  while (current_addr < endAddr) {
+    size_t pages_remaining = (endAddr - current_addr) / page_size;
+    size_t pages_to_read = (pages_remaining < PAGEMAP_BATCH_SIZE)
+                           ? pages_remaining : PAGEMAP_BATCH_SIZE;
+    off_t offset = (off_t)(current_addr / page_size) * sizeof(uint64_t);
+    ssize_t bytes_read =
+      pread(fd, entries, pages_to_read * sizeof(uint64_t), offset);
+    if (bytes_read <= 0) {
+      break;
+    }
+    size_t actual_pages = bytes_read / sizeof(uint64_t);
+    if (actual_pages == 0) {
+      break;
+    }
+
+    for (size_t i = 0; i < actual_pages; i++) {
+      // Bit 63: present (in RAM).  Bit 62: swapped (on disk).  Normalize to a
+      // 0/1 bool so present and swapped both count as "occupied".
+      int is_occupied = ((entries[i] >> 62) & 0x3) != 0;
+
+      if (leading_occupied == -1) {
+        leading_occupied = is_occupied;
+      } else if (is_occupied != leading_occupied) {
+        // First boundary: the leading run is [start, page_ptr).
+        uintptr_t page_ptr = current_addr + i * page_size;
+        *size_scanned = page_ptr - start;
+        _real_close(fd);
+        return !leading_occupied; // negate: true == zero pages
+      }
+    }
+    current_addr += actual_pages * page_size;
+  }
+
+  _real_close(fd);
+  if (leading_occupied == -1) {
+    // No page was classified (e.g. pread failed on the first read).  Never
+    // return a zero-length run -- that would stall callers that advance by
+    // *size_scanned.  Conservatively report the whole range as occupied so the
+    // caller writes its data and still makes progress.
+    *size_scanned = endAddr - start;
+    return false;
+  }
+  // No boundary found: the whole range is one run (current_addr marks how far
+  // we got if pread() broke out early).
+  *size_scanned = (current_addr >= endAddr ? endAddr : current_addr) - start;
+  return !leading_occupied;
 }
 
 /* Caller must allocate exec_path of size at least MTCP_MAX_PATH */

--- a/src/writeckpt.cpp
+++ b/src/writeckpt.cpp
@@ -68,7 +68,8 @@ vector<ProcMapsArea> *nscdAreas = NULL;
 
 // static void sync_shared_mem(void);
 static void writememoryarea(int fd, Area area);
-static void mtcp_write_anonymous_pages(int fd, Area area);
+static void mtcp_write_anonymous_pages(int fd, Area area,
+                                       bool residencyScanSafe);
 
 static void remap_nscd_areas(const vector<ProcMapsArea> &areas);
 
@@ -270,8 +271,19 @@ mtcp_get_next_page_range(Area *area, size_t *size, int *is_zero)
 }
 
 static void
-mtcp_write_anonymous_pages(int fd, Area area)
+mtcp_write_anonymous_pages(int fd, Area area, bool residencyScanSafe)
 {
+  // The region is checkpointed as alternating zero / non-zero runs so that
+  // unallocated and zero pages cost no image space and need not be faulted in:
+  //   - zero runs are found by page residency (Util::scanOccupiedRangeBatch,
+  //     via PAGEMAP_SCAN/pagemap) for anonymous memory, or by reading contents
+  //     (mtcp_get_next_page_range -> Util::areZeroPages) for deleted-file maps;
+  //   - a zero run is saved as a DMTCP_ZERO_PAGE header with no data, then
+  //     dropped from RSS with madvise(MADV_DONTNEED); non-zero runs save bytes.
+  // On restart the parent header re-mmaps the whole region as fresh anonymous
+  // memory (zero-fill-on-demand: zero runs are left unallocated, not physically
+  // zeroed) and only the non-zero child runs are read back in.
+
   // Force DMTCP_ZERO_PAGE_PARENT_ENTRY.
   // Each consecutive zero/non-zero chunk will have a separate header.
   // On restart, we mmap the region using the parent header, but restore
@@ -280,6 +292,16 @@ mtcp_write_anonymous_pages(int fd, Area area)
   writeAreaHeader(fd, &area);
   area.properties ^= DMTCP_ZERO_PAGE_PARENT_HEADER;
 
+  // Util::scanOccupiedRangeBatch() detects zero pages from /proc/self/pagemap
+  // residency instead of reading their contents, so it never faults in absent
+  // pages.  But it classifies an absent page as zero, which is only valid for
+  // genuinely private anonymous memory.  For shared memory (incl. SysV shm,
+  // which the caller reclassifies as MAP_PRIVATE|MAP_ANONYMOUS) or a deleted-
+  // but-still-mapped file, an absent page can still hold data, so those use the
+  // content scan.  The caller decides this (before any reclassification) and
+  // passes it in as residencyScanSafe.
+  bool useResidencyScan = residencyScanSafe;
+
   while (area.size > 0) {
     size_t size;
     int is_zero;
@@ -287,6 +309,18 @@ mtcp_write_anonymous_pages(int fd, Area area)
     if (dmtcp_infiniband_enabled && dmtcp_infiniband_enabled()) {
       size = area.size;
       is_zero = 0;
+    } else if (useResidencyScan) {
+      uintptr_t scanned = 0;
+      is_zero = Util::scanOccupiedRangeBatch(
+        (uintptr_t)a.addr, (uintptr_t)a.addr + area.size, &scanned);
+      size = scanned;
+      if (size == 0) {
+        // Defensive: the scan should never report zero progress, but if it
+        // somehow does, treat the remaining area as occupied so the loop below
+        // (area.size -= size) advances instead of spinning forever.
+        size = area.size;
+        is_zero = 0;
+      }
     } else {
       mtcp_get_next_page_range(&a, &size, &is_zero);
     }
@@ -296,6 +330,11 @@ mtcp_write_anonymous_pages(int fd, Area area)
     a.size = size;
     a.endAddr = a.addr + a.size;
 
+    // TODO: Each run writes a full sizeof(Area)==4KB header (no page data for
+    // zero runs).  Residency scanning yields page-granular runs, so a sparsely-
+    // written region can emit many 4KB headers.  A future compact format (e.g.
+    // one parent header + a per-page zero/non-zero bitmap or run-length list)
+    // could decouple per-run cost from sizeof(Area).
     writeAreaHeader(fd, &a);
 
     if (!is_zero) {
@@ -319,6 +358,16 @@ writememoryarea(int fd, Area area)
   // result in a change of memory layout. For example, a call to JALLOC_NEW
   // will invoke mmap if the JAlloc arena is full. Similarly, for STL objects
   // such as vector and string.
+
+  // Residency-based zero detection ("an absent page reads as zero") is valid
+  // only for genuinely PRIVATE ANONYMOUS memory.  Capture this BEFORE the
+  // reclassification below rewrites shared regions (SysV shm, /dev/zero) as
+  // MAP_PRIVATE | MAP_ANONYMOUS: for shared memory a page that is absent from
+  // THIS process can still hold data written via another attachment, so such
+  // regions must use the content scan.
+  bool residencyScanSafe = (area.name[0] == '\0') &&
+                           (area.flags & MAP_PRIVATE) &&
+                           !(area.flags & MAP_SHARED);
 
   if ((uint64_t)area.addr == ProcessInfo::instance().restoreBuf.startAddr) {
     return;
@@ -504,10 +553,11 @@ writememoryarea(int fd, Area area)
 
   if ((area.flags & MAP_ANONYMOUS) != 0) {
     // Handle anonymous pages.
-    mtcp_write_anonymous_pages(fd, area);
+    mtcp_write_anonymous_pages(fd, area, residencyScanSafe);
   } else if (!jalib::Filesystem::FileExists(area.name)) {
-    // Handle non-existing files
-    mtcp_write_anonymous_pages(fd, area);
+    // Handle non-existing files (deleted file: not residency-safe, so the
+    // content scan runs regardless of residencyScanSafe).
+    mtcp_write_anonymous_pages(fd, area, residencyScanSafe);
   } else {
     ASSERT(strlen(area.name) > 0,
            "checkpoint file-backed area has an empty path: addr={} size={}",

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -130,6 +130,7 @@ unit/dmtcp_unit_tests: $(srcdir)/unit/main.cpp \
 		$(srcdir)/unit/dmtcp_message_tests.cpp \
 		$(srcdir)/unit/util_assert_tests.cpp \
 		$(srcdir)/unit/virtualidtable_tests.cpp \
+		$(srcdir)/unit/pagemap_scan_tests.cpp \
 		$(srcdir)/unit/unit_test.h \
 		$(DMTCP_INCLUDE)/dmtcp.h \
 		$(DMTCP_INCLUDE)/virtualidtable.h \
@@ -144,6 +145,7 @@ unit/dmtcp_unit_tests: $(srcdir)/unit/main.cpp \
 	  $(srcdir)/unit/dmtcp_message_tests.cpp \
 	  $(srcdir)/unit/util_assert_tests.cpp \
 	  $(srcdir)/unit/virtualidtable_tests.cpp \
+	  $(srcdir)/unit/pagemap_scan_tests.cpp \
 	  $(COORDINATOR_SYNTHETIC_LDADD)
 
 unit/dmtcp_header_c_test.o: $(srcdir)/unit/dmtcp_header_c_test.c \

--- a/test/autotest-parity.md
+++ b/test/autotest-parity.md
@@ -33,7 +33,7 @@ or executable-path checks enable them.
 | Harness and command protocol | `command-json-bcheckpoint`, `command-json-kill`, `command-json-quit`, `coordinator-exit-on-last`, `coordinator-replacement-worker`, `coordinator-reject-restart-while-running` |
 | Core smoke and process state | `dmtcp1`, `dmtcp1-m32`, `dmtcp1-quiet`, `dmtcp1-trace`, `dmtcp2`, `dmtcp3`, `dmtcp4`, `dmtcp5`, `alarm`, `sched_test`, `coordinator-barrier`, `gettid`, `sigchild`, `rlimit-restore`, `rlimit-nofile`, `environ`, `realpath`, `forkexec`, `vfork1`, `vfork2`, `frisbee`, `checkpoint-header`, `selinux1`, `cma`, `waitpid`, `waitid-syscall` |
 | Logging | `logging-runtime`, `logging-quiet`, `logging-overrides` |
-| File, fd, and path behavior | `file1`, `file2`, `file3`, `stat`, `mmap1`, `mremap`, `poll`, `shared-fd1`, `shared-fd2`, `stale-fd`, `procfd1`, `epoll1`, `epoll2`, `gzip` |
+| File, fd, and path behavior | `file1`, `file2`, `file3`, `stat`, `mmap1`, `mremap`, `zeropages`, `zeropages-pread`, `poll`, `shared-fd1`, `shared-fd2`, `stale-fd`, `procfd1`, `epoll1`, `epoll2`, `gzip` |
 | Threads and synchronization | `pthread1`, `pthread2`, `pthread3`, `pthread4`, `pthread5`, `pthread6`, `pthread_atfork1`, `pthread_atfork2`, `mutex1`, `mutex2`, `mutex3`, `mutex4`, `timer1`, `clock`, `gettimeofday` |
 | IPC, sockets, and PTY smoke | `client-server`, `seqpacket`, `ssh1`, `shared-memory1`, `shared-memory2`, `shared-memory3`, `sysv-shm1`, `sysv-shm2`, `sysv-sem`, `sysv-msg`, `posix-mq1`, `posix-mq-close-untracked`, `pty1`, `pty2` |
 | Plugins and events | `dlopen1`, `dlopen2`, `syscall-tester`, `presuspend`, `plugin-sleep2`, `plugin-example-db`, `plugin-init`, `poll-disable-event-plugin`, `popen1`, `restartdir`, `nocheckpoint` |

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -1559,6 +1559,12 @@ class TestRegistry:
             TestSpec("dmtcp2", 1, ["./test/dmtcp2"]),
             TestSpec("dmtcp3", 1, ["./test/dmtcp3"]),
             TestSpec("dmtcp4", 1, ["./test/dmtcp4"]),
+            # Regression guard for the pagemap residency zero-page optimization
+            # (Util::scanOccupiedRangeBatch in writeckpt.cpp).  Run on both the
+            # ioctl(PAGEMAP_SCAN) fast path and the portable pread() fallback.
+            TestSpec("zeropages", 1, ["./test/zeropages"]),
+            TestSpec("zeropages-pread", 1, ["./test/zeropages"],
+                     env={"DMTCP_DISABLE_PAGEMAP_SCAN": "1"}),
             TestSpec("alarm", 1, ["./test/alarm"]),
             TestSpec("sched_test", 2, ["./test/sched_test"]),
             TestSpec("coordinator-barrier", 2, ["./test/sched_test"],

--- a/test/unit/main.cpp
+++ b/test/unit/main.cpp
@@ -13,6 +13,8 @@ extern const dmtcp_test::TestCase utilAssertTests[];
 extern const size_t utilAssertTestCount;
 extern const dmtcp_test::TestCase virtualIdTableTests[];
 extern const size_t virtualIdTableTestCount;
+extern const dmtcp_test::TestCase pagemapScanTests[];
+extern const size_t pagemapScanTestCount;
 
 int
 main()
@@ -26,6 +28,8 @@ main()
                utilAssertTests + utilAssertTestCount);
   tests.insert(tests.end(), virtualIdTableTests,
                virtualIdTableTests + virtualIdTableTestCount);
+  tests.insert(tests.end(), pagemapScanTests,
+               pagemapScanTests + pagemapScanTestCount);
 
   return dmtcp_test::runTests(std::span<const dmtcp_test::TestCase>(tests));
 }

--- a/test/unit/pagemap_scan_tests.cpp
+++ b/test/unit/pagemap_scan_tests.cpp
@@ -1,0 +1,186 @@
+#include "util.h"
+
+#undef ASSERT_EQ
+#undef ASSERT_NE
+#undef ASSERT_LT
+#undef ASSERT_NULL
+#undef ASSERT_NOT_NULL
+#undef ASSERT_TRUE
+
+#include "unit_test.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <sys/mman.h>
+#include <unistd.h>
+
+namespace {
+
+const size_t MB = 1 << 20;
+
+// RAII setenv override that restores the previous value (or unsets it if it was
+// not set) on destruction, so a test does not leak/clobber process-wide env.
+class ScopedEnvOverride {
+ public:
+  ScopedEnvOverride(const char *name, const char *value) : name_(name)
+  {
+    const char *old = getenv(name);
+    hadOld_ = (old != nullptr);
+    if (hadOld_) {
+      oldValue_ = old;
+    }
+    setenv(name, value, 1);
+  }
+
+  ~ScopedEnvOverride()
+  {
+    if (hadOld_) {
+      setenv(name_.c_str(), oldValue_.c_str(), 1);
+    } else {
+      unsetenv(name_.c_str());
+    }
+  }
+
+ private:
+  std::string name_;
+  bool hadOld_ = false;
+  std::string oldValue_;
+};
+
+// Touch (write) every page in [addr, addr+len) so the kernel makes it present.
+void touchPages(char *addr, size_t len, size_t page_size)
+{
+  for (size_t off = 0; off < len; off += page_size) {
+    addr[off] = 1;
+  }
+}
+
+// Walk [start, end) and check that scanOccupiedRangeBatch() returns the
+// expected (is_zero, size) for each successive leading run.
+void checkRuns(uintptr_t start,
+               uintptr_t end,
+               const bool *expZero,
+               const uintptr_t *expSize,
+               int nExp)
+{
+  uintptr_t addr = start;
+  int idx = 0;
+  while (addr < end) {
+    ASSERT_TRUE(idx < nExp); // no more runs than expected
+    uintptr_t sizeScanned = 0;
+    bool isZero = dmtcp::Util::scanOccupiedRangeBatch(addr, end, &sizeScanned);
+    ASSERT_TRUE(sizeScanned > 0); // a zero-length run would loop forever
+    ASSERT_EQ(isZero, expZero[idx]);
+    ASSERT_EQ(sizeScanned, expSize[idx]);
+    addr += sizeScanned;
+    idx++;
+  }
+  ASSERT_EQ(idx, nExp); // exactly the expected number of runs
+}
+
+// Occupied prefix and zero suffix, both spanning the 4MB pread-batch boundary.
+void mixedRunsCrossBatchBoundary()
+{
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  size_t total = 16 * MB;
+  char *region = (char *)mmap(NULL, total, PROT_READ | PROT_WRITE,
+                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_TRUE(region != MAP_FAILED);
+  touchPages(region, 6 * MB, page_size); // [0,6MB) occupied; [6MB,16MB) zero
+
+  const bool expZero[] = { false, true };
+  const uintptr_t expSize[] = { 6 * MB, 10 * MB };
+  checkRuns((uintptr_t)region, (uintptr_t)region + total, expZero, expSize, 2);
+
+  munmap(region, total);
+}
+
+// The previously-broken case: a fully zero range that never hits a boundary.
+void entireRangeZero()
+{
+  char *region = (char *)mmap(NULL, 4 * MB, PROT_READ | PROT_WRITE,
+                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_TRUE(region != MAP_FAILED);
+
+  const bool expZero[] = { true };
+  const uintptr_t expSize[] = { 4 * MB };
+  checkRuns((uintptr_t)region, (uintptr_t)region + 4 * MB, expZero, expSize, 1);
+
+  munmap(region, 4 * MB);
+}
+
+void entireRangeOccupied()
+{
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  char *region = (char *)mmap(NULL, 2 * MB, PROT_READ | PROT_WRITE,
+                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_TRUE(region != MAP_FAILED);
+  touchPages(region, 2 * MB, page_size);
+
+  const bool expZero[] = { false };
+  const uintptr_t expSize[] = { 2 * MB };
+  checkRuns((uintptr_t)region, (uintptr_t)region + 2 * MB, expZero, expSize, 1);
+
+  munmap(region, 2 * MB);
+}
+
+// Force the portable pread() fallback (DMTCP_DISABLE_PAGEMAP_SCAN=1) and
+// verify it classifies runs the same as the ioctl path, including the
+// all-zero fall-off-the-end branch.
+void fallbackPreadPathMatchesIoctl()
+{
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  ScopedEnvOverride forceFallback("DMTCP_DISABLE_PAGEMAP_SCAN", "1");
+
+  size_t total = 16 * MB;
+  char *mixed = (char *)mmap(NULL, total, PROT_READ | PROT_WRITE,
+                             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_TRUE(mixed != MAP_FAILED);
+  touchPages(mixed, 6 * MB, page_size); // [0,6MB) occupied; [6MB,16MB) zero
+  {
+    const bool expZero[] = { false, true };
+    const uintptr_t expSize[] = { 6 * MB, 10 * MB };
+    checkRuns((uintptr_t)mixed, (uintptr_t)mixed + total, expZero, expSize, 2);
+  }
+  munmap(mixed, total);
+
+  char *zeros = (char *)mmap(NULL, total, PROT_READ | PROT_WRITE,
+                             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_TRUE(zeros != MAP_FAILED);
+  {
+    const bool expZero[] = { true };
+    const uintptr_t expSize[] = { total };
+    checkRuns((uintptr_t)zeros, (uintptr_t)zeros + total, expZero, expSize, 1);
+  }
+  munmap(zeros, total);
+}
+
+void emptyRangeReturnsZeroSize()
+{
+  char *region = (char *)mmap(NULL, MB, PROT_READ | PROT_WRITE,
+                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_TRUE(region != MAP_FAILED);
+
+  uintptr_t sizeScanned = 0xdead;
+  dmtcp::Util::scanOccupiedRangeBatch((uintptr_t)region, (uintptr_t)region,
+                                      &sizeScanned);
+  ASSERT_EQ(sizeScanned, (uintptr_t)0);
+
+  munmap(region, MB);
+}
+
+} // namespace
+
+extern const dmtcp_test::TestCase pagemapScanTests[] = {
+  {"mixed occupied/zero runs cross pread batch boundary",
+   mixedRunsCrossBatchBoundary},
+  {"entire range zero", entireRangeZero},
+  {"entire range occupied", entireRangeOccupied},
+  {"pread fallback matches ioctl path", fallbackPreadPathMatchesIoctl},
+  {"empty range returns zero size", emptyRangeReturnsZeroSize},
+};
+
+extern const size_t pagemapScanTestCount =
+  sizeof(pagemapScanTests) / sizeof(pagemapScanTests[0]);

--- a/test/zeropages.c
+++ b/test/zeropages.c
@@ -1,0 +1,129 @@
+/* Memory-integrity regression test for the pagemap residency zero-page
+ * optimization in writeckpt.cpp (Util::scanOccupiedRangeBatch()).
+ *
+ * Maps a large anonymous region and writes a deterministic NON-zero pattern to
+ * 1/4 of the pages, leaving the rest as untouched zero holes.  It must survive
+ * checkpoint/restart with:
+ *   - touched (present, non-zero) pages restored byte-exact, and
+ *   - untouched zero holes restored as zero.
+ * On any mismatch it prints FAIL and exits, so the harness (which checks that
+ * the worker stays connected) reports a failure.
+ *
+ * The holes are deliberately NOT read before the first checkpoint, so they stay
+ * absent and the checkpoint exercises the residency "absent => zero" skip path.
+ * Holes are only verified once a checkpoint has occurred (dmtcp_get_generation
+ * changes); by then the checkpoint image has already captured them as absent.
+ *
+ * Compiles and runs both with and without DMTCP (dmtcp.h weak symbols).
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+#include "dmtcp.h"
+
+#define REGION_BYTES (32 * 1024 * 1024)
+
+static unsigned char *region;
+static size_t page_size;
+static size_t npages;
+
+static inline unsigned char patByte(size_t i, size_t j)
+{
+  return (unsigned char)(i * 131u + (unsigned)j * 7u + 1u);
+}
+
+static int isTouched(size_t i) { return (i % 4) == 0; }
+
+static void fillPage(size_t i)
+{
+  unsigned char *p = region + i * page_size;
+  for (size_t j = 0; j < page_size; j++) {
+    p[j] = patByte(i, j);
+  }
+}
+
+static int verifyPattern(void)
+{
+  for (size_t i = 0; i < npages; i++) {
+    if (!isTouched(i)) {
+      continue;
+    }
+    unsigned char *p = region + i * page_size;
+    for (size_t j = 0; j < page_size; j++) {
+      if (p[j] != patByte(i, j)) {
+        printf("FAIL: pattern page %zu byte %zu: got %u want %u\n",
+               i, j, p[j], patByte(i, j));
+        return 0;
+      }
+    }
+  }
+  return 1;
+}
+
+static int verifyHolesZero(void)
+{
+  for (size_t i = 0; i < npages; i++) {
+    if (isTouched(i)) {
+      continue;
+    }
+    unsigned char *p = region + i * page_size;
+    for (size_t j = 0; j < page_size; j++) {
+      if (p[j] != 0) {
+        printf("FAIL: hole page %zu byte %zu: got %u want 0\n", i, j, p[j]);
+        return 0;
+      }
+    }
+  }
+  return 1;
+}
+
+int main(void)
+{
+  page_size = sysconf(_SC_PAGESIZE);
+  npages = REGION_BYTES / page_size;
+  region = mmap(NULL, REGION_BYTES, PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (region == MAP_FAILED) {
+    perror("mmap");
+    return 2;
+  }
+
+  for (size_t i = 0; i < npages; i++) {
+    if (isTouched(i)) {
+      fillPage(i);
+    }
+  }
+
+  int enabled = dmtcp_is_enabled();
+  uint32_t gen0 = enabled ? dmtcp_get_generation() : 0;
+
+  /* Do not read the holes yet, so the first checkpoint sees them as absent. */
+  if (!verifyPattern()) {
+    printf("FAIL: pre-checkpoint pattern verify\n");
+    fflush(stdout);
+    return 1;
+  }
+  printf("READY\n");
+  fflush(stdout);
+
+  for (int iter = 0;; iter++) {
+    if (!verifyPattern()) {
+      fflush(stdout);
+      return 1;
+    }
+    /* Safe to read holes once a checkpoint has happened (or with no DMTCP). */
+    if (!enabled || dmtcp_get_generation() != gen0) {
+      if (!verifyHolesZero()) {
+        fflush(stdout);
+        return 1;
+      }
+    }
+    printf("OK iter %d\n", iter);
+    fflush(stdout);
+    sleep(1);
+  }
+  return 0;
+}


### PR DESCRIPTION
@karya0 , Please review this, since you have the background.  I won't push this in until you tell me that DMTCP-5.0 is stable enough for this PR.  But hopefully, this is orthogonal to what you're still doing.

@aayushi363 , Since you are using a lockset algorithm (written jointly with Claude) in DeepDebug, the lockset code may also have a huge number of unallocated pages.  If checkpointing takes a long time for you, please try out DMCTP with this PR.

## Summary
Java and applications compiled with tsan (thread-sanitizer) create a huge number of unallocated pages.  Checkpointing will be very slow if we have to read each unallocated page (thereby faulting it in) and confirm that it is all zeroes, and then use a zero-page region in the checkpoint image file.  This version runs for Linux-6.7+, using the new PAGEMAP_SCAN option for ioctl.

Note also the explanatory comments in  `src/writeckpt.cpp:mtcp_write_anonymous_pages()`
Note also that even a one-page unallocated memory region uses 4 KB in the ckpt file. There is a TODO comment that a future version of DMTCP might want to enhance this into a more compact format for the checkpoint image.

Checkpointing anonymous memory called `Util::areZeroPages()`, which reads every
byte of every page to decide whether a 1 MB chunk is all zeros. For targets with
large untouched anonymous regions, this faults in never-resident
(zero-fill-on
-demand) pages just to confirm they are zero, then frees them again
with `madvise(MADV_DONTNEED)` — pure overhead.

This adds `Util::scanOccupiedRangeBatch()`, which classifies zero vs. occupied
runs from `/proc/self/pagemap` residency (present/swapped bits) instead of page
contents, so it never faults in absent pages. It prefers `ioctl(PAGEMAP_SCAN)`
(Linux 6.7+, kernel skips holes) and falls back to a batched `pread()` of the
pagemap on older kernels. `DMTCP_DISABLE_PAGEMAP_SCAN=1` forces the fallback.

Wired into `mtcp_write_anonymous_pages()`, gated on `MAP_ANONYMOUS`: absent ⇒
zero holds only for anonymous memory, so deleted-but-still-mapped files keep the
content-based scan.

## Commits
1. **Detect zero pages via pagemap residency at checkpoint** — core function +
   `DMTCP_DISABLE_PAGEMAP_SCAN` knob + `writeckpt.cpp` integration.
2. **Add unit tests for pagemap residency scan** — `test/unit/`, covering ioctl
   and forced-fallback paths.
3. **Add zeropages checkpoint/restart regression test** — `test/zeropages.c` +
   `autotest.py` specs `zeropages` (ioctl) and `zeropages-pread` (fallback).

## Testing
- C++ unit suite: 17/17 (both scan paths).
- `zeropages` / `zeropages-pread`: pass full ckpt→rstr→ckpt→rstr cycles; verified
  the test has teeth (a single corrupted hole byte fails it).
- `dmtcp1`/`dmtcp3` confirm no general checkpoint/restart regression.

## Note
Behavioral trade-off: a *present-but-zero* page is now written as data (the old
content scan skipped + `madvise`'d it). Correct on restart, occasionally a
slightly larger image, in exchange for never faulting in absent pages.

*This PR was done with the "superpowers" agent on top of Claude Code.  It took about 2 hours for the three commits.  I was starting with an older standalone test for using PAGEMAP_SCAN with ioctl that I had written with the help of Gemini comprising 400 lines of code.  I mention this experience, so as to help us compare the newer AI tools appearing.  The three commits added only 321 lines of C/C++/preprocessor/python code including unit tests and a new autotest, and 90 lines of comments. The reduced count of loc is because we no longer have the standalone test file.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced anonymous-memory checkpointing to better detect untouched pages using page residency “zero-page” runs, reducing checkpoint size/overhead.
  * Checkpoint generation now scans in batches to avoid unnecessary page faults when residency scanning is used.
  * Added `DMTCP_DISABLE_PAGEMAP_SCAN` to force a portable scan method instead of the optimized pagemap path.

* **Tests**
  * Added unit and integration coverage for zero/occupied page detection, including the fallback scan mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->