### PR TITLE
Support checkpoint/restart of ThreadSanitizer (-fsanitize=thread) targets

### DIFF
--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -16,7 +16,7 @@ jobs:
     - name: add extra programs for tests
       run: |
         sudo apt-get update
-        sudo apt-get install emacs emacs-nox gdb screen tcsh zsh
+        sudo apt-get install emacs emacs-nox gdb screen tcsh zsh clang
     - name: configure
       run: ./configure
     - name: make
@@ -25,3 +25,7 @@ jobs:
       run: make tests
     - name: make check
       run: make check AUTOTEST="--retry-once --jobs 8"
+    # TSAN targets need an unrestricted RLIMIT_AS, so they are skipped by
+    # `make check` (which runs under ulimit -v 32GB) and run separately here.
+    - name: make check-tsan
+      run: make check-tsan AUTOTEST="--retry-once --jobs 4"

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ am--include-marker
 *.tmp
 .vscode
 .idea/
+DMTCP-TSAN-detailed-plan-instructions.txt

--- a/Makefile.in
+++ b/Makefile.in
@@ -213,18 +213,18 @@ LIMIT=ulimit -S -v 33554432
 check: tests
 	@cd test && $(MAKE) --no-print-directory check-prereqs
 	@ if test "@HAS_PYTHON3@" = yes; then \
-	 bash -c "$(LIMIT) && python3 $(top_srcdir)/test/autotest.py --suite all ${AUTOTEST} $*";\
+	 bash -c "$(LIMIT) && python3 $(top_srcdir)/test/autotest.py --suite all ${AUTOTEST} --exclude-tag tsan $*";\
 	elif test "@HAS_PYTHON@" = yes; then \
-	 bash -c "$(LIMIT) && python $(top_srcdir)/test/autotest.py --suite all ${AUTOTEST} $*";\
+	 bash -c "$(LIMIT) && python $(top_srcdir)/test/autotest.py --suite all ${AUTOTEST} --exclude-tag tsan $*";\
 	else echo '*** No python found in your path.'; \
 	 echo '*** Please add python to path'; \
 	fi
 
 check-autotest: tests
 	@ if test "@HAS_PYTHON3@" = yes; then \
-	 bash -c "$(LIMIT) && python3 $(top_srcdir)/test/autotest.py --suite integration ${AUTOTEST} $*";\
+	 bash -c "$(LIMIT) && python3 $(top_srcdir)/test/autotest.py --suite integration ${AUTOTEST} --exclude-tag tsan $*";\
 	elif test "@HAS_PYTHON@" = yes; then \
-	 bash -c "$(LIMIT) && python $(top_srcdir)/test/autotest.py --suite integration ${AUTOTEST} $*";\
+	 bash -c "$(LIMIT) && python $(top_srcdir)/test/autotest.py --suite integration ${AUTOTEST} --exclude-tag tsan $*";\
 	else echo '*** No python found in your path.'; \
 	 echo '*** Please add python to path'; \
 	fi
@@ -247,6 +247,22 @@ check-harness-unit:
 
 check-coordinator-synthetic: build
 	cd test && $(MAKE) check-coordinator-synthetic
+
+# Explicit override of the check-%: pattern rule below: that rule passes
+# '$*' as an exact TESTNAME, which would either error out ("Unknown test:
+# tsan", since no test is named exactly "tsan" -- only tag "tsan" -- see
+# test/autotest.py's tsan-gcc TestSpec) or, if some future test happened
+# to be named "tsan" again, only run that one. Select by tag instead so
+# this dedicated, less-contended step covers all 5 TSAN tests
+# (tsan-gcc/tsan-clang/tsan-clang-static/tsan-resume/tsan-race); `check:`
+# above excludes tag "tsan" so they are not also run (redundantly, under
+# heavier parallel contention) as part of the default `make check`.
+check-tsan: tests
+	@ if test "@HAS_PYTHON3@" = yes; then \
+	bash -c "$(LIMIT) && python3 $(top_srcdir)/test/autotest.py --tag tsan ${AUTOTEST}";\
+	elif test "@HAS_PYTHON@" = yes; then \
+	bash -c "$(LIMIT) && python $(top_srcdir)/test/autotest.py --tag tsan ${AUTOTEST}";\
+	fi
 
 check-%: tests
 	@ if test "@HAS_PYTHON3@" = yes; then \

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -22,7 +22,12 @@
 #include <sys/resource.h>
 #include <linux/version.h>
 #include <errno.h>
+#include <elf.h>
+#include <fcntl.h>
+#include <limits.h>
 #include <string_view>
+#include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 11)
 # include <sys/personality.h>
@@ -52,7 +57,7 @@ static bool testSetuid(const char *filename);
 static void testStaticallyLinked(const char *filename);
 static bool testScreen(const char **argv, const char ***newArgv);
 static void testFsGsBase();
-static void setLDPreloadLibs(bool is32bitElf);
+static void setLDPreloadLibs(bool is32bitElf, const char *targetPath);
 
 // gcc-4.3.4 -Wformat=2 issues false positives for warnings unless the format
 // string has at least one format specifier with corresponding format argument.
@@ -650,7 +655,7 @@ main(int argc, const char **argv)
   // from DmtcpWorker constructor, to distinguish the two cases.
   Util::adjustRlimitStack();
 
-  setLDPreloadLibs(is32bitElf);
+  setLDPreloadLibs(is32bitElf, argv[0]);
 
   // run the user program
   const char **newArgv = NULL;
@@ -802,8 +807,176 @@ syncPluginEnvWithLauncherState(const char *envName, bool *enabled)
   }
 }
 
+// Locate an ELF file's dynamic array and its .dynstr (DT_STRTAB) region.
+// Returns the Dyn array (and sets *ndyn), and sets *strOff/*strSz to the file
+// offset and size of .dynstr; returns NULL on any problem.  Templated over the
+// 32-/64-bit ELF structs so both classes share one body.
+template <typename Ehdr, typename Phdr, typename Dyn>
+static const Dyn *
+elfDynamic(const char *base, size_t size, size_t *ndyn,
+           size_t *strOff, size_t *strSz)
+{
+  *ndyn = 0; *strOff = 0; *strSz = 0;
+  const Ehdr *eh = (const Ehdr *)base;
+  // Use subtraction-based comparisons so a malformed ELF with huge
+  // file-controlled offsets cannot overflow the sum and bypass the bound.
+  if (eh->e_phoff == 0 || eh->e_phoff > size ||
+      eh->e_phnum > (size - eh->e_phoff) / sizeof(Phdr)) {
+    return NULL;
+  }
+  const Phdr *ph = (const Phdr *)(base + eh->e_phoff);
+
+  // Locate PT_DYNAMIC and remember PT_LOAD segments to map vaddr -> file off.
+  const Phdr *dyn = NULL;
+  const Phdr *loads[64];
+  int nloads = 0;
+  for (int i = 0; i < eh->e_phnum; i++) {
+    if (ph[i].p_type == PT_DYNAMIC) {
+      dyn = &ph[i];
+    } else if (ph[i].p_type == PT_LOAD && nloads < 64) {
+      loads[nloads++] = &ph[i];
+    }
+  }
+  if (dyn == NULL || dyn->p_offset > size ||
+      dyn->p_filesz > size - dyn->p_offset) {
+    return NULL;
+  }
+
+  const Dyn *d = (const Dyn *)(base + dyn->p_offset);
+  size_t n = dyn->p_filesz / sizeof(Dyn);
+  uint64_t strVaddr = 0;
+  size_t strSize = 0;
+  for (size_t i = 0; i < n && d[i].d_tag != DT_NULL; i++) {
+    if (d[i].d_tag == DT_STRTAB) {
+      strVaddr = d[i].d_un.d_ptr;
+    } else if (d[i].d_tag == DT_STRSZ) {
+      strSize = d[i].d_un.d_val;
+    }
+  }
+  if (strVaddr == 0) {
+    return NULL;
+  }
+  for (int i = 0; i < nloads; i++) {
+    if (strVaddr >= loads[i]->p_vaddr &&
+        strVaddr < loads[i]->p_vaddr + loads[i]->p_filesz) {
+      size_t off = loads[i]->p_offset + (strVaddr - loads[i]->p_vaddr);
+      if (off > size) {
+        return NULL;
+      }
+      *strOff = off;
+      *strSz = (strSize != 0 && strSize <= size - off) ? strSize : size - off;
+      *ndyn = n;
+      return d;
+    }
+  }
+  return NULL;
+}
+
+// Return the DT_NEEDED soname containing `needle` (e.g. "libtsan.so.2"), or "".
+template <typename Ehdr, typename Phdr, typename Dyn>
+static string
+elfNeededMatching(const char *base, size_t size, const char *needle)
+{
+  size_t ndyn, strOff, strSz;
+  const Dyn *d = elfDynamic<Ehdr, Phdr, Dyn>(base, size, &ndyn, &strOff, &strSz);
+  if (d == NULL) {
+    return "";
+  }
+  for (size_t i = 0; i < ndyn && d[i].d_tag != DT_NULL; i++) {
+    if (d[i].d_tag != DT_NEEDED) {
+      continue;
+    }
+    size_t nameOff = strOff + d[i].d_un.d_val;
+    if (nameOff >= size) {
+      continue;
+    }
+    const char *name = base + nameOff;
+    size_t maxlen = size - nameOff;
+    if (strnlen(name, maxlen) < maxlen && strstr(name, needle) != NULL) {
+      return string(name);
+    }
+  }
+  return "";
+}
+
+// Return true if the ELF's .dynstr contains `needle`.  Used to detect a
+// statically-linked TSAN runtime: clang's default -fsanitize=thread links the
+// runtime into the executable, which exports many "__tsan_*" symbols (in
+// .dynsym/.dynstr) but has no TSAN entry in DT_NEEDED.
+template <typename Ehdr, typename Phdr, typename Dyn>
+static bool
+elfDynstrContains(const char *base, size_t size, const char *needle)
+{
+  size_t ndyn, strOff, strSz;
+  if (elfDynamic<Ehdr, Phdr, Dyn>(base, size, &ndyn, &strOff, &strSz) == NULL) {
+    return false;
+  }
+  return std::string_view(base + strOff, strSz).find(needle) !=
+         std::string_view::npos;
+}
+
+// Inspect the target ELF for ThreadSanitizer.  Returns the soname of a *shared*
+// TSAN runtime in DT_NEEDED (gcc libtsan.so*, or clang -shared-libsan
+// libclang_rt.tsan*.so) so dmtcp_launch can prepend it to LD_PRELOAD ahead of
+// libdmtcp -- TSAN must interpose first so DMTCP's _real_* (RTLD_NEXT) resolve
+// to libc rather than TSAN's interceptors.  Returns "" if there is no shared
+// TSAN runtime.  Sets *isTsan true for ANY TSAN target, including a statically
+// linked runtime (clang default): the static runtime is already first in symbol
+// order (it is in the executable), so it needs no prepend, but it still needs
+// ASLR disabled.
+static string
+detectTsanRuntime(const char *path, bool *isTsan)
+{
+  *isTsan = false;
+  char full[PATH_MAX];
+  Util::expandPathname(path, full, sizeof(full));
+  int fd = open(full, O_RDONLY);
+  if (fd < 0) {
+    return "";
+  }
+  struct stat st;
+  if (fstat(fd, &st) != 0 || (size_t)st.st_size < sizeof(Elf64_Ehdr)) {
+    close(fd);
+    return "";
+  }
+  size_t size = st.st_size;
+  void *map = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+  close(fd);
+  if (map == MAP_FAILED) {
+    return "";
+  }
+
+  const char *base = (const char *)map;
+  string result;
+  if (memcmp(base, ELFMAG, SELFMAG) == 0) {
+    bool is64 = base[EI_CLASS] == ELFCLASS64;
+    bool is32 = base[EI_CLASS] == ELFCLASS32;
+    static const char *const needles[] = { "libtsan.so", "libclang_rt.tsan" };
+    for (size_t n = 0; n < 2 && result.empty(); n++) {
+      if (is64) {
+        result = elfNeededMatching<Elf64_Ehdr, Elf64_Phdr, Elf64_Dyn>(
+          base, size, needles[n]);
+      } else if (is32) {
+        result = elfNeededMatching<Elf32_Ehdr, Elf32_Phdr, Elf32_Dyn>(
+          base, size, needles[n]);
+      }
+    }
+    bool hasTsanSym = false;
+    if (is64) {
+      hasTsanSym = elfDynstrContains<Elf64_Ehdr, Elf64_Phdr, Elf64_Dyn>(
+        base, size, "__tsan_init");
+    } else if (is32) {
+      hasTsanSym = elfDynstrContains<Elf32_Ehdr, Elf32_Phdr, Elf32_Dyn>(
+        base, size, "__tsan_init");
+    }
+    *isTsan = !result.empty() || hasTsanSym;
+  }
+  munmap(map, size);
+  return result;
+}
+
 static void
-setLDPreloadLibs(bool is32bitElf)
+setLDPreloadLibs(bool is32bitElf, const char *targetPath)
 {
   // preloadLibs are to set LD_PRELOAD:
   // LD_PRELOAD=PLUGIN_LIBS:UTILITY_DIR/libdmtcp.so:R_LIBSR_UTILITY_DIR/
@@ -867,6 +1040,45 @@ setLDPreloadLibs(bool is32bitElf)
 #if defined(__x86_64__) || defined(__aarch64__)
     preloadLibs32 = preloadLibs32 + ":" + getenv("LD_PRELOAD");
 #endif // if defined(__x86_64__) || defined(__aarch64__)
+  }
+
+  // A target using a *shared* TSAN runtime needs it to interpose BEFORE
+  // libdmtcp, so that DMTCP's _real_* (RTLD_NEXT) resolve past TSAN to libc.
+  // dmtcp_launch otherwise forces its own libs first, so prepend the target's
+  // TSAN runtime soname (the loader resolves the right arch).  Not added to
+  // ENV_VAR_HIJACK_LIBS: libtsan is the target's own dependency, not a DMTCP
+  // lib to be stripped by restoreUserLDPRELOAD().  A *statically* linked TSAN
+  // runtime (clang default) needs no prepend -- it is already first in symbol
+  // order (it is in the executable) -- but isTsan is still set so ASLR is
+  // disabled below.
+  bool isTsan = false;
+  string tsanLib = detectTsanRuntime(targetPath, &isTsan);
+  if (!tsanLib.empty()) {
+    TRACE("TSAN runtime detected; prepending to LD_PRELOAD: tsanLib={}",
+          tsanLib);
+    preloadLibs = tsanLib + ":" + preloadLibs;
+#if defined(__x86_64__) || defined(__aarch64__)
+    preloadLibs32 = tsanLib + ":" + preloadLibs32;
+#endif // if defined(__x86_64__) || defined(__aarch64__)
+  }
+  if (isTsan) {
+    // TSAN requires a deterministic address space: under ASLR it intermittently
+    // aborts with "ThreadSanitizer: unexpected memory mapping".  DMTCP restart
+    // also needs stable addresses.  The personality is inherited across the
+    // exec of the target, so set it here for any TSAN target (shared or static).
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 11)
+    // NOTE:  gcc-14.0+ and clang 18.1+ automatically set personality and
+    //        re-execute.  But we will execvp() anyway.  So, no need for that.
+    // Read-modify-write so we only add ADDR_NO_RANDOMIZE and preserve any
+    // inherited personality bits (e.g. READ_IMPLIES_EXEC), as setarch -R and
+    // Util::adjustRlimitStack do.  personality(0xffffffffUL) queries without
+    // changing.
+    int persona = personality(0xffffffffUL);
+    WARN_ERRNO(persona != -1 &&
+               personality((unsigned long)persona | ADDR_NO_RANDOMIZE) != -1,
+               "Could not disable ASLR for TSAN target; "
+               "run under `setarch -R` if TSAN aborts on startup.");
+#endif // if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 11)
   }
 
   if (enableKernelLoader) {

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -975,6 +975,73 @@ detectTsanRuntime(const char *path, bool *isTsan)
   return result;
 }
 
+// ThreadSanitizer interposes libc calls (read/write, pthread synchronization,
+// etc.).  On the DMTCP restart path the checkpoint thread runs DMTCP's own
+// machinery -- reading the saved environment, the PID map, and the plugin
+// DMTCP_EVENT_RESTART handlers -- on a thread whose TSAN per-thread state is
+// stale: mtcp_restart recreated it outside TSAN's pthread_create interceptor
+// and its kernel TID changed, so TSAN's bookkeeping for it is never
+// re-established.  When TSAN's interceptors then fire on this thread they spin
+// on an internal lock and restart hangs (the worker reconnects but never
+// reaches RUNNING).  More fundamentally, DMTCP's plumbing is not the code under
+// test; TSAN should watch only the user application.  So tell TSAN to skip
+// interception for any call originating in libdmtcp.so via a "called_from_lib"
+// suppression.  This covers reads, writes, AND synchronization (unlike
+// __tsan_ignore_thread_*, which covers only memory accesses, leaving the
+// barrier/mutex calls in e.g. the PID plugin still hanging).  A compile-time
+// no_sanitize("thread") attribute is no substitute either: it only strips the
+// compiler-inserted instrumentation from a function body (and libdmtcp.so is
+// not built with -fsanitize=thread, so there is nothing to strip), and has no
+// effect on TSAN's runtime interceptors -- which are what fire here.  Only a
+// runtime suppression like this controls the interceptors.  TSAN loads
+// suppressions once at init, so setting this at launch keeps it in effect
+// across the whole run, including after checkpoint/restart.
+static void
+setTsanSuppressions(const string &tmpDir)
+{
+  // TSAN honors only a single suppressions file, so do not clobber one the
+  // user already provided; tell them how to add our rule instead.
+  const char *existing = getenv("TSAN_OPTIONS");
+  string opts = (existing != NULL) ? existing : "";
+  if (opts.find("suppressions=") != string::npos) {
+    WARN(false,
+         "TSAN_OPTIONS already sets 'suppressions='; DMTCP cannot add its own. "
+         "For checkpoint/restart of a TSAN target to work, add this line to "
+         "your suppressions file: called_from_lib:libdmtcp.so");
+    return;
+  }
+
+  string suppPath = tmpDir + "/tsan-suppressions.txt";
+  // Write to a per-pid temp then rename so a concurrent launcher's TSAN never
+  // reads a half-written file (rename is atomic; the content is identical).
+  string tmpPath = suppPath + "." + jalib::XToString(getpid());
+  static const char contents[] = "called_from_lib:libdmtcp.so\n";
+
+  int fd = open(tmpPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+  bool ok = (fd != -1) &&
+            (write(fd, contents, sizeof(contents) - 1) ==
+             (ssize_t)(sizeof(contents) - 1));
+  if (fd != -1) {
+    close(fd);
+  }
+  if (ok) {
+    ok = (rename(tmpPath.c_str(), suppPath.c_str()) == 0);
+  }
+  if (!ok) {
+    WARN_ERRNO(false,
+               "Could not write TSAN suppressions file; checkpoint/restart of "
+               "a TSAN target may hang. path={}",
+               suppPath);
+    unlink(tmpPath.c_str());
+    return;
+  }
+
+  string newOpts = opts.empty() ? string() : opts + " ";
+  newOpts += "suppressions=" + suppPath;
+  setenv("TSAN_OPTIONS", newOpts.c_str(), 1);
+  TRACE("TSAN suppressions installed: TSAN_OPTIONS={}", getenv("TSAN_OPTIONS"));
+}
+
 static void
 setLDPreloadLibs(bool is32bitElf, const char *targetPath)
 {
@@ -1079,6 +1146,11 @@ setLDPreloadLibs(bool is32bitElf, const char *targetPath)
                "Could not disable ASLR for TSAN target; "
                "run under `setarch -R` if TSAN aborts on startup.");
 #endif // if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 11)
+
+    // Make TSAN ignore DMTCP's own libc calls so checkpoint/restart does not
+    // hang in a TSAN interceptor running on the (post-restart, stale-state)
+    // checkpoint thread.  See setTsanSuppressions() for the full rationale.
+    setTsanSuppressions(tmpDir);
   }
 
   if (enableKernelLoader) {

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -132,7 +132,12 @@ DmtcpWorker::determineCkptSignal()
 {
   int sig = CKPT_SIGNAL;
   char *endp = NULL;
-  static const char *tmp = getenv(ENV_VAR_SIGCKPT);
+  // Not 'static': a function-local static needs a C++ guard (__cxa_guard_*),
+  // which ThreadSanitizer intercepts.  If this runs from a DMTCP wrapper during
+  // TSAN's own constructor (e.g. TSAN installing signal handlers via sigaction),
+  // the guard re-enters a not-yet-initialized TSAN and crashes.  getenv is cheap
+  // and this result is already cached one level up (bannedSignalNumber).
+  const char *tmp = getenv(ENV_VAR_SIGCKPT);
 
   if (tmp != NULL) {
     sig = strtol(tmp, &endp, 0);

--- a/src/plugin/alloc/mallocwrappers.cpp
+++ b/src/plugin/alloc/mallocwrappers.cpp
@@ -30,9 +30,25 @@ using namespace dmtcp;
 EXTERNC int
 dmtcp_alloc_enabled()
 {
-  static const int enabled =
-    internalPluginEnabled(INTERNAL_PLUGIN_ALLOC) ? 1 : 0;
-  return enabled;
+  // We used to cache this in a function-local `static const int enabled`, but a
+  // function-local static with a runtime initializer compiles to a C++ guard
+  // (__cxa_guard_acquire/release), which ThreadSanitizer intercepts.  This
+  // wrapper can run during TSAN's own constructor (TSAN may call malloc while
+  // installing its interceptors), when TSAN's shadow is not yet initialized, so
+  // the intercepted guard misbehaves -- the same class of early-init crash that
+  // bit pthread_once in initializeInternalPluginState().
+  //
+  // Use a constant-initialized atomic flag instead: no C++ guard, and the
+  // atomic ops are compiler intrinsics rather than TSAN-intercepted calls.
+  // internalPluginEnabled() is idempotent, so a benign double-init under
+  // contention is harmless.
+  static int enabled = -1;  // -1 = not yet computed
+  int value = __atomic_load_n(&enabled, __ATOMIC_ACQUIRE);
+  if (value < 0) {
+    value = internalPluginEnabled(INTERNAL_PLUGIN_ALLOC) ? 1 : 0;
+    __atomic_store_n(&enabled, value, __ATOMIC_RELEASE);
+  }
+  return value;
 }
 
 extern "C" void *calloc(size_t nmemb, size_t size)

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -103,7 +103,6 @@ static InternalPluginEntry internalPlugins[] = {
   { &dlPlugin, false }
 };
 
-static pthread_once_t internalPluginInitOnce = PTHREAD_ONCE_INIT;
 static bool disableAllInternalPlugins = false;
 
 static size_t
@@ -155,8 +154,41 @@ initializeInternalPluginStateOnce()
 static void
 initializeInternalPluginState()
 {
-  ASSERT_PTHREAD_SUCCESS(pthread_once(&internalPluginInitOnce,
-                                      initializeInternalPluginStateOnce));
+  // This runs from the alloc plugin's malloc() wrapper (via dmtcp_alloc_enabled
+  // -> internalPluginEnabled), which can fire DURING ThreadSanitizer's own
+  // constructor: while TSAN installs its interceptors it may call malloc (e.g.
+  // when a dlsym for an intercepted symbol fails and glibc formats the error).
+  //
+  // We used to guard this one-time init with pthread_once(), but pthread_once
+  // is a TSAN-intercepted synchronization primitive.  Called that early, TSAN's
+  // interceptor dereferences its MetaMap/shadow -- which is not yet initialized
+  // while TSAN is still in its own constructor -- and segfaults (observed on
+  // Rocky 9 / libtsan.so.0, in __tsan::MetaMap::GetAndLock).
+  //
+  // So we guard with a plain constant-initialized atomic state machine
+  // instead: compiler intrinsics, not function calls, so TSAN cannot
+  // intercept them (and a constant initializer means no C++ function-local
+  // static guard either).  initializeInternalPluginStateOnce() itself writes
+  // plain (non-atomic) shared state (disableAllInternalPlugins,
+  // internalPlugins[i].enabled), so simply letting two racing threads both
+  // run it -- even though they would compute identical results -- is a data
+  // race (undefined behavior) under the C++ memory model.  A CAS elects
+  // exactly one thread to run it; every other thread spins (a plain intrinsic
+  // load, not sched_yield()/usleep(), which are themselves TSAN-intercepted
+  // this early) until that thread publishes completion.
+  static int state = 0;  // 0 = uninit, 1 = initializing, 2 = done
+  int expected = 0;
+  if (__atomic_compare_exchange_n(&state, &expected, 1, false,
+                                  __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+    initializeInternalPluginStateOnce();
+    __atomic_store_n(&state, 2, __ATOMIC_RELEASE);
+    return;
+  }
+  while (__atomic_load_n(&state, __ATOMIC_ACQUIRE) != 2) {
+    // Busy-wait: the window is only the few env-var reads above, and this
+    // path runs during early process init before TSAN itself is ready, so a
+    // plain spin (no libc call) is deliberate here.
+  }
 }
 
 static InternalPluginEntry *

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -356,13 +356,19 @@ ProcessInfo::updateRestoreBufAddr()
   // This method could be called by ProcessInfo::init() or ProcessInfo::restart().
   // If it was called by ProcessInfo::restart(), then mtcp_restart() will
   // have mmap'ed this "restoreBuf".
-  // NOTE:  We are now doing 'munmap' on it, only to do ''mmap' on it once again
-  //        at the end of this method.  We need to munmap/mmap because we want
-  //        to free the backing physical pages created by mtcp_restart.
+  // NOTE:  We are now doing 'munmap' on it, only to do 'mmap' on it once
+  //        again at the end of this method.  We need to munmap/mmap because
+  //        we want to free the backing physical pages created by
+  //        mtcp_restart.
+  //
+  // Raw syscalls, not the libc wrappers: mtcp_restart already touched this
+  // range via its own raw syscalls, invisible to TSAN. So the real TSAN
+  // interceptors for munmap()/mmap() crash on TSAN's stale metadata for it. Same
+  // fix as Util::writeAll/readAll.
 
   if (restoreBuf.startAddr != 0) {
     ASSERT_NE(-1,
-      munmap((void*) restoreBuf.startAddr, RESTORE_BUF_TOTAL_SIZE),
+      syscall(SYS_munmap, restoreBuf.startAddr, RESTORE_BUF_TOTAL_SIZE),
       "failed to unmap restore buffer: start={} size={}",
       restoreBuf.startAddr, RESTORE_BUF_TOTAL_SIZE);
   }
@@ -378,7 +384,16 @@ ProcessInfo::updateRestoreBufAddr()
   //         previously set _restoreBufLen to RESTORE_TOTAL_SIZE.  So, we
   //         have now made the round trip.  This is spaghetti code. :-(
   uint64_t requestedAddr = restoreBuf.startAddr;
-  restoreBuf.startAddr = (uint64_t) mmap((void*)requestedAddr,
+#ifdef __i386__
+  // i386's SYS_mmap is the legacy single-struct-pointer ABI, incompatible
+  // with the 6-direct-argument call below.  SYS_mmap2 takes the same 6
+  // arguments (its offset argument is in pages rather than bytes, but that
+  // is 0 either way here).
+  const long mmapSyscallNr = SYS_mmap2;
+#else
+  const long mmapSyscallNr = SYS_mmap;
+#endif
+  restoreBuf.startAddr = (uint64_t) syscall(mmapSyscallNr, requestedAddr,
                                          RESTORE_BUF_TOTAL_SIZE,
                                          PROT_NONE, flags, -1, 0);
   ASSERT_ERRNO(restoreBuf.startAddr != (uint64_t) MAP_FAILED,

--- a/src/threadinfo.h
+++ b/src/threadinfo.h
@@ -85,6 +85,8 @@ struct Thread {
 #else // ifdef SETJMP
   ucontext_t savctx;     // context saved on suspend
 #endif // ifdef SETJMP
+  void *tsan_fiber_ctx; // For targets compiled with TSAN (-fsanitize=thread)
+  bool is_tsan_helper;
 
   uint32_t wrapperLockCount;
 

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -99,6 +99,44 @@ Thread *ckptThread = NULL;
 
 static int numUserThreads = 0;
 static bool originalstartup;
+
+// TSAN's own pthread_create interceptor substitutes its internal trampoline
+// (to run ThreadStart() before the real callback) as the start_routine for
+// EVERY pthread_create() call it sees -- including DMTCP's own call to
+// create the checkpoint thread, since dmtcp_launch puts TSAN ahead of
+// libdmtcp in LD_PRELOAD.  So every ordinary thread (the checkpoint thread,
+// and all application threads) shows the SAME start_routine address to
+// ThreadList::prepareThread(), while TSAN's own background/helper thread --
+// spawned via a direct, non-self-intercepted pthread_create() call, with its
+// own real entry point as start_routine -- shows a DIFFERENT, unique
+// address.  See the "Update" note in DMTCP-TSAN-detailed-plan-instructions.txt
+// for the evidence.
+//
+// commonTrampolineFn is learned with certainty from
+// ThreadList::createCkptThread()'s own pthread_create() call.  That single
+// call can trigger MORE than one ThreadList::prepareThread() call, though:
+// empirically, TSAN's interceptor lazily spawns its background/helper thread
+// (a nested, non-self-intercepted pthread_create() call of its own) as a side
+// effect of handling the FIRST pthread_create() call it ever sees, before
+// dispatching through to the real (wrapped) callback for that original call.
+// Since DMTCP's own call to create the checkpoint thread is the first
+// pthread_create() call of the whole process, this nested spawn -- if it
+// happens at all -- happens inside that one call, and its prepareThread()
+// call happens BEFORE the checkpoint thread's own.  So: every prepareThread()
+// call seen while expectCkptThreadNext is set is remembered in
+// ckptWindowCandidates; once createCkptThread()'s own pthread_create() call
+// returns, the LAST candidate recorded is the real checkpoint thread (nothing
+// can register after it, and nothing legitimate can register between it and
+// the pthread_create() call returning), and any earlier candidates in the
+// same window are the (at most one, in every run observed so far) nested
+// helper-thread spawn.  pendingUnclassifiedThread additionally covers the
+// separate case of a thread registering even before createCkptThread() is
+// called at all (not observed in practice, but cheap to handle).
+static void *commonTrampolineFn = nullptr;
+static bool expectCkptThreadNext = false;
+static Thread *pendingUnclassifiedThread = nullptr;
+static Thread *ckptWindowCandidates[4];
+static int ckptWindowCandidateCount = 0;
 // Let dmtcp.h:DMTCP_RESTART_PAUSE_WHILE(cond) use (dmtcp::restartPauseLevel
 volatile int dmtcp::restartPauseLevel = 0;
 
@@ -276,11 +314,38 @@ ThreadList::createCkptThread()
   originalstartup = true;
   pthread_t checkpointhreadid;
 
+  // Flag the immediately following pthread_create() call so that
+  // ThreadList::prepareThread() can recognize any thread it prepares during
+  // this call as belonging to this window -- see the comment above
+  // ckptWindowCandidates for why more than one prepareThread() call can
+  // happen here.
+  expectCkptThreadNext = true;
+  ckptWindowCandidateCount = 0;
+
   /* Spawn off a thread that will perform the checkpoints from time to time */
   ASSERT_PTHREAD_SUCCESS(pthread_create(&checkpointhreadid,
                                         NULL,
                                         checkpointhread,
                                         NULL));
+
+  expectCkptThreadNext = false;
+  if (is_tsan()) {
+    // The LAST candidate registered during this window is the real
+    // checkpoint thread; any earlier ones are nested TSAN-internal spawns
+    // (its background/helper thread).
+    ASSERT(ckptWindowCandidateCount >= 1,
+           "no thread was registered for the checkpoint thread's own creation");
+    commonTrampolineFn =
+      reinterpret_cast<void *>(ckptWindowCandidates[ckptWindowCandidateCount - 1]->fn);
+    for (int i = 0; i < ckptWindowCandidateCount - 1; i++) {
+      ckptWindowCandidates[i]->is_tsan_helper = true;
+    }
+    if (pendingUnclassifiedThread != nullptr) {
+      pendingUnclassifiedThread->is_tsan_helper =
+        reinterpret_cast<void *>(pendingUnclassifiedThread->fn) != commonTrampolineFn;
+      pendingUnclassifiedThread = nullptr;
+    }
+  }
 
   /* Stop until checkpoint thread has finished initializing.
    * Some programs (like gcl) implement their own glibc functions in
@@ -324,10 +389,29 @@ ThreadList::prepareThread(Thread *th, void *(*fn)(void *), void *arg)
   th->procname[0] = '\0';
   if (is_tsan()) {
     th->tsan_fiber_ctx = NULL;
-    // Threads created here (via DMTCP's pthread_create wrapper, or as
-    // motherofall) are never the TSAN helper thread; see dmtcp_get_current_
-    // thread()'s "race" branch for how that thread is identified instead.
-    th->is_tsan_helper = false;
+    if (th == &motherofallStorage) {
+      th->is_tsan_helper = false;
+    } else if (expectCkptThreadNext) {
+      // Might be the checkpoint thread's own registration, or a nested
+      // TSAN-internal spawn triggered as a side effect of intercepting that
+      // call; see the comment above ckptWindowCandidates.  Which one this is
+      // can only be determined once ThreadList::createCkptThread()'s
+      // pthread_create() call returns, so just record it for now.
+      ASSERT(ckptWindowCandidateCount <
+               (int) (sizeof(ckptWindowCandidates) / sizeof(ckptWindowCandidates[0])),
+             "more nested thread creations during ckpt-thread creation than expected");
+      ckptWindowCandidates[ckptWindowCandidateCount++] = th;
+      th->is_tsan_helper = false; // corrected after the window closes, if needed
+    } else if (commonTrampolineFn == nullptr) {
+      // We have not yet seen the checkpoint thread's own creation, so we
+      // cannot yet tell a real TSAN helper thread's unique start_routine
+      // apart from the common app-thread trampoline. Defer.
+      ASSERT_NULL(pendingUnclassifiedThread);
+      pendingUnclassifiedThread = th;
+      th->is_tsan_helper = false; // tentative; corrected above if needed
+    } else {
+      th->is_tsan_helper = reinterpret_cast<void *>(fn) != commonTrampolineFn;
+    }
   }
 }
 
@@ -579,11 +663,21 @@ ThreadList::suspendThreads()
         break;
 
       case ST_SUSPINPROG:
-        numUserThreads++;
+        // The TSAN helper thread is still signaled/suspended along with
+        // everyone else (for a consistent memory snapshot), but it is never
+        // recreated on restart (TSAN spawns a fresh one there instead -- see
+        // postRestartWork()), so it will never contribute a sem_post in
+        // waitForAllRestored().  Don't count it, or that wait would hang
+        // waiting for a post that never comes.
+        if (! (is_tsan() && thread->is_tsan_helper)) {
+          numUserThreads++;
+        }
         break;
 
       case ST_SUSPENDED:
-        numUserThreads++;
+        if (! (is_tsan() && thread->is_tsan_helper)) {
+          numUserThreads++;
+        }
         break;
 
       case ST_CKPNTHREAD:

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -704,7 +704,18 @@ stopthisthread(int signum)
 
     // --- TSAN INJECTION: PRE-CHECKPOINT ---
     if (is_tsan() && ! curThread->is_tsan_helper && ! dmtcp_is_ckpt_thread()) {
-      __tsan_ignore_thread_begin();
+      // Some TSAN runtime configurations (observed with clang's statically
+      // linked TSAN runtime) do not export __tsan_ignore_thread_begin/_end
+      // to the dynamic symbol table, even though they export the fiber API
+      // and __tsan_acquire/release. Since these are declared as weak
+      // symbols, an unexported one resolves to NULL, and calling it
+      // segfaults. Skip the ignore-begin/end bracketing entirely when
+      // unavailable: DMTCP's own checkpoint bookkeeping calls made while
+      // this thread is suspended become visible to TSAN, but that's
+      // strictly better than crashing.
+      if (__tsan_ignore_thread_begin != NULL) {
+        __tsan_ignore_thread_begin();
+      }
       // Ordinary threads don't need __tsan_acquire/release
       curThread->tsan_fiber_ctx = __tsan_get_current_fiber();
       if (curThread == motherofall) {
@@ -766,7 +777,10 @@ stopthisthread(int signum)
       // --- TSAN INJECTION: RESUME ORIGINAL PROCESS ---
       if (is_tsan() && ! curThread->is_tsan_helper && !dmtcp_is_ckpt_thread()) {
         // Ordinary threads don't need __tsan_acquire/release
-        __tsan_ignore_thread_end();
+        // See the PRE-CHECKPOINT block above for why this is null-checked.
+        if (__tsan_ignore_thread_end != NULL) {
+          __tsan_ignore_thread_end();
+        }
       }
       // -----------------------------------------------
 
@@ -800,7 +814,9 @@ stopthisthread(int signum)
       ThreadList::waitForAllRestored(curThread);
 
       // --- TSAN INJECTION: POST-RESTART CLEANUP ---
-      if (is_tsan() && ! curThread->is_tsan_helper && ! dmtcp_is_ckpt_thread()) {
+      // See the PRE-CHECKPOINT block above for why this is null-checked.
+      if (is_tsan() && ! curThread->is_tsan_helper && ! dmtcp_is_ckpt_thread() &&
+          __tsan_ignore_thread_end != NULL) {
         __tsan_ignore_thread_end();
       }
       // --------------------------------------------

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -32,6 +32,37 @@
 #include "util.h"
 #include "dmtcp_assert.h"
 
+/****************************
+ * Start of TSAN utilities
+ ****************************/
+
+// ThreadSanitizer Fiber API (weak: resolves to the TSAN runtime only for TSAN
+// targets, NULL no-op otherwise).  A "fiber" is a separate TSAN ThreadState
+// (with its own event trace) that can be bound to the current OS thread.
+// * The checkpoint thread never had a fiber originally, by design, since
+//   conceptually, libdmtcp.so acts as if it's a lower layer than libtsan.so.
+//   (see checkpointhread() (start fnc. for ckpt thread) for details).
+// * The TSAN helper thread will _not_ have a fiber (by design for TSAN).
+// * All other threads, including motherofall, have a fiber.
+// * All threads go through restarthread(); If needed, each thread will use
+//    __tsan_switch_to_fiber() to restore its fiber from 'Thread' in threadlist.
+extern "C" void *__tsan_get_current_fiber() __attribute__((weak));
+extern "C" void __tsan_switch_to_fiber(void *fiber, unsigned flags)
+  __attribute__((weak));
+extern "C" void __tsan_ignore_thread_begin() __attribute__((weak));
+extern "C" void __tsan_ignore_thread_end() __attribute__((weak));
+// Below, address is arbitrary, unique memory address for synchronization
+extern "C" void __tsan_release(void *address) __attribute__((weak));
+extern "C" void __tsan_acquire(void *address) __attribute__((weak));
+
+static bool is_tsan() {
+  return (__tsan_get_current_fiber != NULL);
+}
+
+/****************************
+ * End of TSAN utilities
+ ****************************/
+
 // For i386 and x86_64, SETJMP currently has bugs.  Don't turn this
 // on for them until they are debugged.
 // Default is to use  setcontext/getcontext.
@@ -127,7 +158,17 @@ dmtcp_get_current_thread()
     // win that race. So wait for it here instead.
     while (__atomic_load_n(&motherofall, __ATOMIC_ACQUIRE) == nullptr) {
     }
-    ThreadList::initThread(ThreadList::getNewThread(NULL, NULL));
+    Thread *th = ThreadList::getNewThread(NULL, NULL);
+    // If we reach here, then curThread is NULL, and it's not motherofall.
+    // For a TSAN target, the only such thread is TSAN's own helper/background
+    // thread: TSAN spawns it via a raw clone() that bypasses
+    // pthread_create/__clone entirely. So it only becomes visible to DMTCP
+    // the first time it calls into an intercepted libc function.  (See the
+    // TSAN utilities comment above.)
+    if (is_tsan()) {
+      th->is_tsan_helper = true;
+    }
+    ThreadList::initThread(th);
   }
 
   ASSERT_NOT_NULL(curThread);
@@ -281,6 +322,13 @@ ThreadList::prepareThread(Thread *th, void *(*fn)(void *), void *arg)
   th->exiting = 0;
   th->wrapperLockCount = 0;
   th->procname[0] = '\0';
+  if (is_tsan()) {
+    th->tsan_fiber_ctx = NULL;
+    // Threads created here (via DMTCP's pthread_create wrapper, or as
+    // motherofall) are never the TSAN helper thread; see dmtcp_get_current_
+    // thread()'s "race" branch for how that thread is identified instead.
+    th->is_tsan_helper = false;
+  }
 }
 
 /*****************************************************************************
@@ -453,6 +501,12 @@ checkpointhread(void *dummy)
 
     // Save signal mask and capture any pending signals.
     Thread_SaveSigState(ckptThread);
+
+    // --- TSAN INJECTION: ckpt-thread release (minimal test) ---
+    if (is_tsan()) {
+      __tsan_release((void*)ckptThread);
+    }
+    // ------------------------------------------------------------
 
     /* All other threads halted in 'stopthisthread' routine (they are all
      * in state ST_SUSPENDED).  It's safe to write checkpoint file now.
@@ -648,6 +702,18 @@ stopthisthread(int signum)
     WARN_NE(-1, prctl(PR_GET_NAME, curThread->procname));
 #endif  // if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 11)
 
+    // --- TSAN INJECTION: PRE-CHECKPOINT ---
+    if (is_tsan() && ! curThread->is_tsan_helper && ! dmtcp_is_ckpt_thread()) {
+      __tsan_ignore_thread_begin();
+      // Ordinary threads don't need __tsan_acquire/release
+      curThread->tsan_fiber_ctx = __tsan_get_current_fiber();
+      if (curThread == motherofall) {
+        __tsan_release((void*)curThread);
+      }
+      // -------------------------------------------------------
+    }
+    // --------------------------------------
+
     Thread_SaveSigState(curThread);  // save sig state (and block sig delivery)
     TLSInfo_SaveTLSState(curThread);  // save thread local storage state
 
@@ -696,6 +762,14 @@ stopthisthread(int signum)
              curThread->tid);
 
       ASSERT_LOCK_SUCCESS(DmtcpRWLockUnlock(&threadResumeLock));
+
+      // --- TSAN INJECTION: RESUME ORIGINAL PROCESS ---
+      if (is_tsan() && ! curThread->is_tsan_helper && !dmtcp_is_ckpt_thread()) {
+        // Ordinary threads don't need __tsan_acquire/release
+        __tsan_ignore_thread_end();
+      }
+      // -----------------------------------------------
+
     } else {
       // If the user defined DMTCP_DISABLE_PRGNAME_PREFIX, skip this prefix.
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 11)
@@ -724,6 +798,12 @@ stopthisthread(int signum)
 
       /* Else restoreinprog >= 1;  This stuff executes to do a restart */
       ThreadList::waitForAllRestored(curThread);
+
+      // --- TSAN INJECTION: POST-RESTART CLEANUP ---
+      if (is_tsan() && ! curThread->is_tsan_helper && ! dmtcp_is_ckpt_thread()) {
+        __tsan_ignore_thread_end();
+      }
+      // --------------------------------------------
     }
 
     TRACE("User thread returning to user code: tid={} return_address={}",
@@ -814,6 +894,7 @@ void
 ThreadList::postRestartWork()
 {
   Thread *thread;
+  Thread *next;
   sigset_t tmp;
 
   if (TLSInfo_HaveThreadSysinfoOffset()) {
@@ -833,7 +914,10 @@ ThreadList::postRestartWork()
   Util::allowGdbDebug(DEBUG_POST_RESTART);
 
   sigfillset(&tmp);
-  for (thread = activeThreads; thread != NULL; thread = thread->next) {
+  for (thread = activeThreads; thread != NULL; thread = next) {
+    // Precompute 'next' now, in case 'thread' is declared dead below.
+    next = thread->next;
+
     sigandset(&sigpending_global, &tmp, &(thread->sigpending));
     tmp = sigpending_global;
 
@@ -841,7 +925,13 @@ ThreadList::postRestartWork()
       continue;
     }
 
-    /* Create the thread so it can finish restoring itself. */
+    /* Create the thread so it can finish restoring itself.
+     * But remove old TSAN helper thread; it's stateless: TSAN creates new one
+     */
+    if (is_tsan() && thread->is_tsan_helper) {
+      ThreadList::threadIsDead(thread); // Del. old TSAN helper from active list
+      continue; // TSAN helper should not be restored; Stateless, TSAN creates
+    }
     pid_t tid = _real_clone(restarthread,
 
                             // -128 for red zone
@@ -882,6 +972,34 @@ restarthread(void *threadv)
   if (thread == motherofall) {  // if this is a user thread
     DMTCP_RESTART_PAUSE_WHILE(restartPauseLevel == 4);
   }
+
+  // --- TSAN INJECTION: RESTART BRIDGE ---
+  // Earlier, we already omitted restarthread() if thread->is_tsan_helper
+  //
+  // Do NOT call __tsan_ignore_thread_begin() here. thread->tsan_fiber_ctx
+  // was captured in stopthisthread()'s PRE-CHECKPOINT block *after* that
+  // block's own __tsan_ignore_thread_begin() call, so the restored fiber
+  // is already carrying "ignore" depth 1 from before checkpoint -- calling
+  // __tsan_ignore_thread_begin() again here would double-count it. Only
+  // ONE __tsan_ignore_thread_end() ever runs afterward (in
+  // stopthisthread()'s POST-RESTART CLEANUP), so an extra begin() here
+  // would leave the thread permanently stuck in "ignore" mode after every
+  // restart: no crash, just TSAN silently never reporting a race on this
+  // thread again for the rest of the process's life.
+  if (is_tsan() && ! dmtcp_is_ckpt_thread()) {
+    __tsan_switch_to_fiber(thread->tsan_fiber_ctx, 0);
+    if (thread == motherofall) {
+      __tsan_acquire((void*)thread);
+    }
+    // ---------------------------------------------------------
+  }
+  // --------------------------------------
+
+  // --- TSAN INJECTION: ckpt-thread acquire (minimal test) ---
+  if (is_tsan() && dmtcp_is_ckpt_thread()) {
+    __tsan_acquire((void*)thread);
+  }
+  // ------------------------------------------------------
 
   /* Jump to the stopthisthread routine just after sigsetjmp/getcontext call.
    * Note that if this is the restored checkpointhread, it jumps to the

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -39,16 +39,18 @@
 // ThreadSanitizer Fiber API (weak: resolves to the TSAN runtime only for TSAN
 // targets, NULL no-op otherwise).  A "fiber" is a separate TSAN ThreadState
 // (with its own event trace) that can be bound to the current OS thread.
-// * The checkpoint thread never had a fiber originally, by design, since
-//   conceptually, libdmtcp.so acts as if it's a lower layer than libtsan.so.
-//   (see checkpointhread() (start fnc. for ckpt thread) for details).
 // * The TSAN helper thread will _not_ have a fiber (by design for TSAN).
 // * All other threads, including motherofall, have a fiber.
 // * All threads go through restarthread(); If needed, each thread will use
 //    __tsan_switch_to_fiber() to restore its fiber from 'Thread' in threadlist.
+// * The checkpoint thread is a special case: on restart it is given a FRESH
+//   fiber (via __tsan_create_fiber()) rather than resuming its old one --
+//   see the comment in restarthread() for why.
 extern "C" void *__tsan_get_current_fiber() __attribute__((weak));
 extern "C" void __tsan_switch_to_fiber(void *fiber, unsigned flags)
   __attribute__((weak));
+extern "C" void *__tsan_create_fiber(unsigned flags) __attribute__((weak));
+extern "C" void __tsan_destroy_fiber(void *fiber) __attribute__((weak));
 extern "C" void __tsan_ignore_thread_begin() __attribute__((weak));
 extern "C" void __tsan_ignore_thread_end() __attribute__((weak));
 // Below, address is arbitrary, unique memory address for synchronization
@@ -547,6 +549,10 @@ checkpointhread(void *dummy)
   TRACE("Saved checkpoint-thread restart context: tid={} saved_sp={}",
         curThread->tid, curThread->saved_sp);
 
+  // On restart, we reach here via siglongjmp()/setcontext() from
+  // restarthread(), which already switched this thread to a fresh TSAN
+  // fiber before making that jump -- see the comment there for why.
+
   if (originalstartup) {
     originalstartup = false;
   } else {
@@ -585,12 +591,6 @@ checkpointhread(void *dummy)
 
     // Save signal mask and capture any pending signals.
     Thread_SaveSigState(ckptThread);
-
-    // --- TSAN INJECTION: ckpt-thread release (minimal test) ---
-    if (is_tsan()) {
-      __tsan_release((void*)ckptThread);
-    }
-    // ------------------------------------------------------------
 
     /* All other threads halted in 'stopthisthread' routine (they are all
      * in state ST_SUSPENDED).  It's safe to write checkpoint file now.
@@ -1070,6 +1070,41 @@ restarthread(void *threadv)
   Thread *thread = (Thread *)threadv;
 
   TLSInfo_RestoreTLSState(thread);
+
+  // The checkpoint thread is a special case, and must be handled here,
+  // immediately after TLSInfo_RestoreTLSState() and before anything else:
+  // unlike other threads, it never goes through the signal-handler
+  // suspend/resume path (it is explicitly excluded from
+  // __tsan_ignore_thread_begin/end), so its TSAN trace kept recording
+  // throughout its own TSAN-intercepted work in writeCkpt() -- including at
+  // the very moment the checkpoint image was written. So the saved image
+  // can capture this thread's trace/ThreadState mid-mutation, torn.
+  // TLSInfo_RestoreTLSState() just pointed this OS thread's FS/GS at that
+  // restored (possibly torn) state; the first TSAN-intercepted call made
+  // from here on (even something as ordinary as the write() behind a TRACE()
+  // call, a few lines below) touches it and hangs. Since mtcp_restart's
+  // restore + this thread's later setcontext()/siglongjmp() is, from TSAN's
+  // point of view, not how this OS thread's checkpoint-thread identity ever
+  // came to exist in the first place, there is no reason to expect that
+  // restored, possibly-torn trace to be usable. So: treat this as if the old
+  // checkpoint thread no longer exists and a fresh, unrelated one has just
+  // been created on this OS thread -- switch to a brand new TSAN fiber
+  // before anything else can touch the old one.
+  if (thread == ckptThread && is_tsan()) {
+    ASSERT_NOT_NULL(__tsan_create_fiber,
+                    "TSAN runtime is missing __tsan_create_fiber");
+    void *staleFiber = thread->tsan_fiber_ctx;
+    void *freshFiber = __tsan_create_fiber(0);
+    ASSERT_NOT_NULL(freshFiber, "__tsan_create_fiber returned NULL");
+    __tsan_switch_to_fiber(freshFiber, 0);
+    if (staleFiber != NULL) {
+      ASSERT_NOT_NULL(__tsan_destroy_fiber,
+                      "TSAN runtime is missing __tsan_destroy_fiber");
+      __tsan_destroy_fiber(staleFiber);  // now inactive; free it
+    }
+    thread->tsan_fiber_ctx = freshFiber;
+  }
+
   TLSInfo_RestoreTLSTidPid(thread);
 
   if (TLSInfo_HaveThreadSysinfoOffset()) {
@@ -1105,11 +1140,9 @@ restarthread(void *threadv)
   }
   // --------------------------------------
 
-  // --- TSAN INJECTION: ckpt-thread acquire (minimal test) ---
-  if (is_tsan() && dmtcp_is_ckpt_thread()) {
-    __tsan_acquire((void*)thread);
-  }
-  // ------------------------------------------------------
+  // The checkpoint thread is deliberately not touched here: it was already
+  // given a fresh TSAN fiber earlier in this function, immediately after
+  // TLSInfo_RestoreTLSState() -- see the comment there for why.
 
   /* Jump to the stopthisthread routine just after sigsetjmp/getcontext call.
    * Note that if this is the restored checkpointhread, it jumps to the

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -139,6 +139,26 @@ static bool expectCkptThreadNext = false;
 static Thread *pendingUnclassifiedThread = nullptr;
 static Thread *ckptWindowCandidates[4];
 static int ckptWindowCandidateCount = 0;
+
+// Enforces the invariant that at most one thread is ever classified as
+// the TSAN helper thread (TSAN spawns exactly one background thread).
+static int numTsanHelperThreadsTagged = 0;
+
+static void
+markTsanHelper(Thread *th)
+{
+  th->is_tsan_helper = true;
+  numTsanHelperThreadsTagged++;
+  ASSERT(numTsanHelperThreadsTagged <= 1,
+         "TSAN: more than one thread classified as the TSAN helper "
+         "thread: tid={}",
+         th->tid);
+  if (is_tsan()) {
+    TRACE("TSAN: classified tid={} fn={} as the TSAN helper thread",
+          th->tid, th->fn);
+  }
+}
+
 // Let dmtcp.h:DMTCP_RESTART_PAUSE_WHILE(cond) use (dmtcp::restartPauseLevel
 volatile int dmtcp::restartPauseLevel = 0;
 
@@ -206,7 +226,7 @@ dmtcp_get_current_thread()
     // the first time it calls into an intercepted libc function.  (See the
     // TSAN utilities comment above.)
     if (is_tsan()) {
-      th->is_tsan_helper = true;
+      markTsanHelper(th);
     }
     ThreadList::initThread(th);
   }
@@ -340,11 +360,13 @@ ThreadList::createCkptThread()
     commonTrampolineFn =
       reinterpret_cast<void *>(ckptWindowCandidates[ckptWindowCandidateCount - 1]->fn);
     for (int i = 0; i < ckptWindowCandidateCount - 1; i++) {
-      ckptWindowCandidates[i]->is_tsan_helper = true;
+      markTsanHelper(ckptWindowCandidates[i]);
     }
     if (pendingUnclassifiedThread != nullptr) {
-      pendingUnclassifiedThread->is_tsan_helper =
-        reinterpret_cast<void *>(pendingUnclassifiedThread->fn) != commonTrampolineFn;
+      if (reinterpret_cast<void *>(pendingUnclassifiedThread->fn) !=
+          commonTrampolineFn) {
+        markTsanHelper(pendingUnclassifiedThread);
+      }
       pendingUnclassifiedThread = nullptr;
     }
   }
@@ -501,6 +523,12 @@ checkpointhread(void *dummy)
    */
 
   ckptThread = curThread;
+  ASSERT(!(is_tsan() && ckptThread->is_tsan_helper),
+         "TSAN: checkpoint thread was misclassified as the TSAN "
+         "helper thread");
+  ASSERT(ckptThread != motherofall,
+         "TSAN: checkpoint thread and motherofall must never be "
+         "the same thread object");
   ckptThread->state = ST_CKPNTHREAD;
 
   // Important:  we set this in the ckpt thread to avoid a race,
@@ -792,6 +820,12 @@ stopthisthread(int signum)
 
   // make sure we don't get called twice for same thread
   if (Thread_UpdateState(curThread, ST_SUSPINPROG, ST_SIGNALED)) {
+    if (is_tsan()) {
+      TRACE("TSAN: stopthisthread: tid={} is_ckpt_thread={} "
+            "is_tsan_helper={}",
+            curThread->tid, dmtcp_is_ckpt_thread(),
+            curThread->is_tsan_helper);
+    }
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 11)
     WARN_NE(-1, prctl(PR_GET_NAME, curThread->procname));
 #endif  // if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 11)
@@ -1042,6 +1076,10 @@ ThreadList::postRestartWork()
       ThreadList::threadIsDead(thread); // Del. old TSAN helper from active list
       continue; // TSAN helper should not be restored; Stateless, TSAN creates
     }
+
+    ASSERT(!(is_tsan() && thread->is_tsan_helper),
+           "TSAN: helper thread reached _real_clone(); should have "
+           "been skipped above");
     pid_t tid = _real_clone(restarthread,
 
                             // -128 for red zone
@@ -1103,6 +1141,14 @@ restarthread(void *threadv)
       __tsan_destroy_fiber(staleFiber);  // now inactive; free it
     }
     thread->tsan_fiber_ctx = freshFiber;
+    if (is_tsan()) {
+      TRACE("TSAN: gave checkpoint thread a fresh fiber on restart: "
+            "tid={} staleFiber={} freshFiber={}",
+            thread->tid, staleFiber, freshFiber);
+    }
+    ASSERT(freshFiber != staleFiber,
+           "TSAN: __tsan_create_fiber unexpectedly returned the "
+           "stale fiber's address");
   }
 
   TLSInfo_RestoreTLSTidPid(thread);

--- a/src/util_misc.cpp
+++ b/src/util_misc.cpp
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <sys/syscall.h>
 #include <sys/time.h>
 #include <unistd.h>
 #include <linux/fs.h>  // for PAGEMAP_SCAN ioctl (Linux 6.7+)
@@ -209,7 +210,13 @@ Util::writeAll(int fd, const void *buf, size_t count)
   size_t num_written = 0;
 
   do {
-    ssize_t rc = write(fd, ptr + num_written, count - num_written);
+    // Use the raw write(2) syscall, not the libc wrapper: ThreadSanitizer
+    // intercepts write() and inspects the buffer's shadow.  At checkpoint time
+    // this buffer is an arbitrary memory region -- including TSAN's own shadow/
+    // meta mappings -- and TSAN then reports a spurious use-after-free.  A raw
+    // syscall is not intercepted.
+    ssize_t rc =
+      syscall(SYS_write, fd, ptr + num_written, count - num_written);
     if (rc == -1) {
       if (errno == EINTR || errno == EAGAIN) {
         continue;
@@ -240,7 +247,10 @@ Util::readAll(int fd, void *buf, size_t count)
   size_t num_read = 0;
 
   for (num_read = 0; num_read < count;) {
-    rc = read(fd, ptr + num_read, count - num_read);
+    // Raw read(2) syscall, not the libc wrapper: see writeAll() above -- TSAN
+    // intercepts read() and inspects the destination buffer, which at restart
+    // time may overlap TSAN's own mappings and trip a spurious report.
+    rc = syscall(SYS_read, fd, ptr + num_read, count - num_read);
     if (rc == -1) {
       if (errno == EINTR || errno == EAGAIN) {
         continue;
@@ -696,8 +706,12 @@ Util::scanOccupiedRangeBatch(uintptr_t start, uintptr_t end,
     size_t pages_to_read = (pages_remaining < PAGEMAP_BATCH_SIZE)
                            ? pages_remaining : PAGEMAP_BATCH_SIZE;
     off_t offset = (off_t)(current_addr / page_size) * sizeof(uint64_t);
-    ssize_t bytes_read =
-      pread(fd, entries, pages_to_read * sizeof(uint64_t), offset);
+    // Raw pread64(2) syscall, not the libc wrapper: see writeAll()/readAll()
+    // above -- TSAN intercepts pread() and inspects the destination buffer,
+    // which at checkpoint time may overlap TSAN's own mappings and trip a
+    // spurious report.
+    ssize_t bytes_read = syscall(SYS_pread64, fd, entries,
+                                  pages_to_read * sizeof(uint64_t), offset);
     if (bytes_read <= 0) {
       break;
     }

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -154,7 +154,11 @@ unit/dmtcp_header_c_test.o: $(srcdir)/unit/dmtcp_header_c_test.c \
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 # Compile plugins first; Otherwise, errors in standard tests scroll off screen.
-tests: plugins $(TESTS) $(TESTS_MULTILIB)
+# tsan_target_clang/tsan_target_clang_static build from tsan_target.c (not
+# their own .c file), so they are never globbed into $(TESTS); list them
+# explicitly so `make tests` / `check-tsan` actually builds them (each recipe
+# gates on its own runtime availability, so this is a no-op where absent).
+tests: plugins $(TESTS) $(TESTS_MULTILIB) tsan_target_clang tsan_target_clang_static
 	#${MAKE} -C credentials
 
 plugins:
@@ -167,7 +171,7 @@ tidy:
 	cd plugin && $(MAKE) tidy > /dev/null
 
 clean: tidy
-	rm -f $(TESTS) $(TESTS_MULTILIB) $(UNIT_TESTS) \
+	rm -f $(TESTS) $(TESTS_MULTILIB) $(TSAN_EXTRA_TARGETS) $(UNIT_TESTS) \
 	  $(COORDINATOR_SYNTHETIC_WORKER) unit/*.o *.pyc *.so
 	#${MAKE} -C credentials clean
 	cd plugin && $(MAKE) clean
@@ -253,6 +257,51 @@ dmtcp3: dmtcp3.c
 
 dmtcp4: dmtcp4.c
 	-$(CC) -o $@ $< $(CFLAGS) -lpthread
+
+# ThreadSanitizer startup-regression target for the gcc dynamic libtsan.so.
+# Pinned to gcc (not $(CC)) so this case is covered even when DMTCP is built
+# with another compiler; built only when gcc ships libtsan.so, otherwise skipped
+# and autotest.py auto-disables the tsan-gcc test for the missing binary.
+GCC_TSAN_RUNTIME := $(shell command -v gcc >/dev/null 2>&1 && gcc -print-file-name=libtsan.so 2>/dev/null)
+TSAN_CFLAGS = -fsanitize=thread -g -O0 -pthread
+tsan_target: tsan_target.c
+ifneq ($(filter /%,$(GCC_TSAN_RUNTIME)),)
+	-gcc $(TSAN_CFLAGS) -o $@ $<
+else
+	@rm -f $@
+	@echo "#tsan_target: skipping (no gcc libtsan.so)"
+endif
+
+# clang variant: clang's -fsanitize=thread defaults to a STATIC runtime, so use
+# -shared-libsan to get the dynamic libclang_rt.tsan*.so that DMTCP's DT_NEEDED
+# detection keys on.  Built only when clang ships a shared TSAN runtime; the
+# tsan-clang test then runs it with LD_LIBRARY_PATH set to that runtime dir.
+CLANG_RTDIR := $(shell command -v clang >/dev/null 2>&1 && clang -print-runtime-dir 2>/dev/null)
+CLANG_TSAN_SO := $(wildcard $(CLANG_RTDIR)/libclang_rt.tsan*.so)
+tsan_target_clang: tsan_target.c
+ifneq ($(CLANG_TSAN_SO),)
+	-clang $(TSAN_CFLAGS) -shared-libsan -o $@ $<
+else
+	@rm -f $@
+	@echo "#tsan_target_clang: skipping (no clang -shared-libsan TSAN runtime)"
+endif
+
+# clang STATIC default: the TSAN runtime is linked into the executable (no
+# DT_NEEDED), and dmtcp_launch detects it by the "__tsan_init" symbol in
+# .dynstr.  No LD_LIBRARY_PATH needed (runtime is in the exe).
+CLANG_TSAN_A := $(wildcard $(CLANG_RTDIR)/libclang_rt.tsan*.a)
+tsan_target_clang_static: tsan_target.c
+ifneq ($(CLANG_TSAN_A),)
+	-clang $(TSAN_CFLAGS) -o $@ $<
+else
+	@rm -f $@
+	@echo "#tsan_target_clang_static: skipping (no clang static TSAN runtime)"
+endif
+
+# tsan_target_clang/tsan_target_clang_static build from tsan_target.c (not
+# their own .c file), so they aren't in $(TESTS) and `clean` must list them
+# explicitly to remove them.
+TSAN_EXTRA_TARGETS = tsan_target_clang tsan_target_clang_static
 
 dmtcp5: dmtcp5.c
 	-$(CC) -o $@ $< $(CFLAGS) -lpthread

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -272,6 +272,15 @@ else
 	@echo "#tsan_target: skipping (no gcc libtsan.so)"
 endif
 
+# Race-detection-fidelity companion to tsan_target: same gating as above.
+tsan_target_race: tsan_target_race.c
+ifneq ($(filter /%,$(GCC_TSAN_RUNTIME)),)
+	-gcc $(TSAN_CFLAGS) -o $@ $<
+else
+	@rm -f $@
+	@echo "#tsan_target_race: skipping (no gcc libtsan.so)"
+endif
+
 # clang variant: clang's -fsanitize=thread defaults to a STATIC runtime, so use
 # -shared-libsan to get the dynamic libclang_rt.tsan*.so that DMTCP's DT_NEEDED
 # detection keys on.  Built only when clang ships a shared TSAN runtime; the

--- a/test/autotest-parity.md
+++ b/test/autotest-parity.md
@@ -39,6 +39,7 @@ or executable-path checks enable them.
 | Plugins and events | `dlopen1`, `dlopen2`, `syscall-tester`, `checkpoint-open-files-env`, `presuspend`, `plugin-sleep2`, `plugin-example-db`, `plugin-init`, `plugin-init-env`, `modify-env`, `pathvirt`, `poll-disable-event-plugin`, `poll-disable-event-plugin-env`, `popen1`, `restartdir`, `nocheckpoint` |
 | Shells, terminal apps, and language/runtime smoke | `perl`, `python`, `bash`, `dash`, `zsh`, `readline`, `tcsh`, `script`, `vim`, `emacs`, `screen`, `java1`, `cilk1`, `matlab-nodisplay`, `openmp-1`, `openmp-2` |
 | MPI smoke | `hellompich-n1`, `hellompich-n2`, `openmpi` |
+| Sanitizers | `tsan-gcc`, `tsan-clang`, `tsan-clang-static` |
 
 ## Ported With Explicit Limits
 

--- a/test/autotest-parity.md
+++ b/test/autotest-parity.md
@@ -98,6 +98,8 @@ or executable-path checks enable them.
 | `java1` | Configure-flag-gated and required-file-gated | Requires both `HAS_JAVA`/`HAS_JAVAC` and the built `test/java1.class` artifact. |
 | `shared-memory3` | Ported, slow | This old-disabled test now passes two checkpoint/restart cycles on the current host. It keeps the old harness's `S=10*DEFAULT_S` checkpoint settle delay. |
 | `mmap-noreserve` | Ported with `cycles=2`, address-space-gated | Regression guard for restoring a huge `MAP_NORESERVE` anonymous region (`src/mtcp/mtcp_restart.c`, `MAP_NORESERVE_SIZE_THRESHOLD`), modeled on how ThreadSanitizer reserves its shadow/meta mappings. The registry's `needs_max_address_space` check skips it when `RLIMIT_AS` is finite and too low to hold the test's reservation. |
+| `tsan-resume` | New test with `cycles=1`, address-space-gated | Regression guard for the TSAN checkpoint/resume path in isolation: repeatedly checkpoints the same live `tsan_target` process (via `resume_cycles=2`) without ever restarting it, before a final restart. Not a port of an old-harness test. |
+| `tsan-race` | New test with `cycles=1`, address-space-gated | Regression guard verifying TSAN's race *detection* survives a checkpoint/restart cycle, using a target (`tsan_target_race`) that only starts racing after restart and a `post_restart_validator` that waits for TSAN's own exit code instead of a still-running worker. Not a port of an old-harness test. |
 
 Logging-specific limits:
 

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -3322,8 +3322,8 @@ def print_integration_list(selected: List[TestSpec]) -> int:
 def run_integration_tests(
         args, selected: List[TestSpec],
         show_suite_heading: bool,
-        name_width: int = RUN_TESTNAME_WIDTH) -> Tuple[
-            int, int, List[FailureRecord]]:
+        name_width: int = RUN_TESTNAME_WIDTH) -> Tuple[int, int,
+                                                       List[FailureRecord]]:
     passed = 0
     failures = []
     if show_suite_heading:
@@ -3369,11 +3369,9 @@ def main():
             return 2
     except KeyError as error:
         name = error.args[0]
-        disabled_test = next(
-            (test for test in REGISTRY._disabled_tests
-             if test.name == name),
-            None,
-        )
+        disabled_test = next( (test for test in REGISTRY._disabled_tests
+                                    if test.name == name),
+                              None,)
         if disabled_test:
             print(f"Disabled test: {name}", file=sys.stderr)
             print(f"  Reason: {disabled_test.list_notes[0]}",

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -35,6 +35,10 @@ from dataclasses import dataclass, field, replace
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SLOW_FACTOR_BASE = 5
 DEFAULT_SLOW_PRE_CHECKPOINT_DELAY = 0.3
+# TSAN_OPTIONS exitcode used by the tsan-race test: the process is expected
+# to exit with exactly this code once TSAN detects the deliberate post-
+# restart race (see validate_tsan_race_detected() and tsan_target_race.c).
+TSAN_RACE_EXITCODE = 66
 VALID_LAUNCH_MODES = frozenset({"pipe", "pty"})
 COLOR_RED = "\033[0;31m"
 COLOR_RESET = "\033[0m"
@@ -202,6 +206,12 @@ class TestSpec:
     peers: Union[int, List[int]]
     commands: List[str]
     cycles: int = 2
+    # Extra checkpoint/resume round-trips inserted after each cycle's
+    # checkpoint, with NO restart in between (the live process is simply
+    # checkpointed again). Exercises repeated resume without ever touching
+    # the restart path -- see the "tsan-resume" TestSpec for why this
+    # matters.
+    resume_cycles: int = 0
     timeout: float = 30.0
     checkpoint_command: str = "--checkpoint"
     pre_checkpoint_delay: float = 0.0
@@ -520,6 +530,10 @@ class TestContext:
                 self.harness.progress("ckpt-start")
                 self._checkpoint()
                 self.harness.progress("ckpt-passed")
+                for _ in range(self.spec.resume_cycles):
+                    self.harness.progress("ckpt-start")
+                    self._checkpoint_resume()
+                    self.harness.progress("ckpt-passed")
                 self._kill_workers()
                 self.harness.progress("rstr-start")
                 self._restart()
@@ -771,6 +785,30 @@ class TestContext:
         except ValueError as error:
             raise HarnessFailure("status", str(error)) from error
 
+    def _checkpoint_resume(self):
+        # Issuing a checkpoint immediately after the worker is confirmed
+        # RUNNING can still transiently race the coordinator's own internal
+        # "workersRunningAndSuspendMsgSent" guard (see the comment on that
+        # variable in dmtcp_coordinator.cpp): the coordinator intentionally
+        # rejects an overlapping checkpoint request with
+        # DMT_COORD_NOT_RUNNING for a brief window after the previous one,
+        # and that internal readiness isn't visible through --status. This
+        # is expected, documented coordinator behavior, not a bug, so retry
+        # briefly instead of treating one rejection as a failure.
+        deadline = time.time() + self.spec.timeout
+        while True:
+            try:
+                self._checkpoint()
+                return
+            except HarnessFailure as failure:
+                # _run_json_command() wraps this message with
+                # _with_diagnostics(), appending "; port=...; ..."; match
+                # the prefix rather than the whole (decorated) message.
+                if not failure.message.startswith("DMT_COORD_NOT_RUNNING") \
+                        or time.time() >= deadline:
+                    raise
+                time.sleep(0.1)
+
     def _checkpoint(self):
         self._write_checkpoint_dir_files()
         if self.spec.pre_checkpoint_delay > 0.0:
@@ -876,6 +914,11 @@ class TestContext:
             self._quit_workers_and_coordinator()
         elif self.spec.completion_command == "--kill-exit-on-last":
             self._kill_workers_and_wait_for_coordinator_exit()
+        elif self.spec.completion_command == "--none":
+            # Worker is expected to have already exited on its own (e.g.
+            # tsan-race, where TSAN's own exit() call ends the process);
+            # nothing left to tear down here.
+            pass
         else:
             raise HarnessFailure(
                 "setup",
@@ -1508,6 +1551,29 @@ def validate_auto_checkpoint_interval(context: TestContext):
         )
 
 
+def validate_tsan_race_detected(context: TestContext):
+    # tsan_target_race.c only starts racing after restart, well after
+    # _restart() has already confirmed the worker came back up and is
+    # RUNNING; so a timeout here means TSAN failed to detect the race
+    # (not that restart itself failed).
+    proc = context.processes[-1]
+    try:
+        returncode = proc.wait(timeout=context.spec.timeout)
+    except subprocess.TimeoutExpired as error:
+        raise HarnessFailure(
+            "validate",
+            "TSAN did not detect the post-restart race within the "
+            "test timeout: worker kept running",
+        ) from error
+    if returncode != TSAN_RACE_EXITCODE:
+        raise HarnessFailure(
+            "validate",
+            f"expected TSAN to detect the post-restart race and exit "
+            f"with code {TSAN_RACE_EXITCODE}; worker exited with "
+            f"{returncode}",
+        )
+
+
 class TestRegistry:
     DISABLED_CATEGORY = "Disabled tests"
 
@@ -1973,6 +2039,60 @@ class TestRegistry:
             # absent.
             TestSpec("tsan-gcc", 1, ["./test/tsan_target"],
                      needs_max_address_space=True,
+                     tags=["tsan"]),
+            # Regression guard for the TSAN checkpoint/RESUME path
+            # specifically, as distinct from checkpoint/restart: repeatedly
+            # checkpoints the SAME live process without ever restarting it,
+            # mirroring how a real TSAN target is checkpointed under an
+            # interval timer (e.g. `dmtcp_launch -i5 ...`).  This is the
+            # exact scenario that reproduced a historical bug where two of
+            # three __tsan_ignore_thread_end() call sites in
+            # stopthisthread() were missing the is_tsan_helper guard,
+            # unbalancing TSAN's ignore-count for its own helper thread and
+            # segfaulting on ordinary resume (restart was never affected).
+            # The default "tsan-gcc" test above only resumes once per cycle
+            # before restarting, which is not enough to reliably stress
+            # this; this test forces two consecutive resumes first (one
+            # resume already reproduces the original bug, but two confirms
+            # it isn't a one-off timing artifact, at roughly 3/5 the cost
+            # of the resume_cycles=4 this test used before).
+            TestSpec("tsan-resume", 1, ["./test/tsan_target"],
+                     needs_max_address_space=True,
+                     cycles=1,
+                     resume_cycles=2,
+                     limits=["cycles=1"],
+                     tags=["tsan"]),
+            # Regression guard verifying TSAN's race *detection* itself
+            # survives a checkpoint/restart cycle -- not just that the
+            # process survives. Every other TSAN test target is
+            # deliberately race-free, so none of them can distinguish a
+            # genuine "TSAN went deaf after restart" regression from
+            # ordinary success. This is not hypothetical: writing this test
+            # caught exactly such a bug (see the restarthread() RESTART
+            # BRIDGE comment in threadlist.cpp) -- restarthread() was
+            # calling __tsan_ignore_thread_begin() on a restored fiber that
+            # was already carrying "ignore" depth 1 from before checkpoint,
+            # so restored threads were permanently stuck ignoring all
+            # reads/writes (no crash, no hang -- just silent, permanent
+            # loss of race detection for the rest of the process's life).
+            # tsan_target_race.c runs race-free (mutex-protected) for the
+            # first several iterations -- long enough for the checkpoint
+            # below to land during that window -- then, only after the
+            # process has been checkpointed and restarted, deliberately
+            # switches to an unguarded, racy increment. TSAN_OPTIONS is set
+            # so the first detected race exits with a known code;
+            # post_restart_validator waits for that exit (rather than for a
+            # still-running worker), and completion_command="--none" is
+            # needed because the worker has already exited on its own by
+            # the time the test would otherwise try to --kill it.
+            TestSpec("tsan-race", 1, ["./test/tsan_target_race"],
+                     needs_max_address_space=True,
+                     env={"TSAN_OPTIONS":
+                          f"halt_on_error=1:exitcode={TSAN_RACE_EXITCODE}"},
+                     cycles=1,
+                     post_restart_validator=validate_tsan_race_detected,
+                     completion_command="--none",
+                     limits=["cycles=1"],
                      tags=["tsan"]),
             # Same guard built with clang -fsanitize=thread -shared-libsan.
             # LD_LIBRARY_PATH points at clang's runtime dir because its shared

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -1798,6 +1798,8 @@ class TestRegistry:
             reason = cls._address_space_reason()
             if reason:
                 reasons.append(reason)
+        if test.name == "tsan-clang" and not test.library_paths:
+            reasons.append("missing clang TSAN runtime dir")
         for command in test.commands:
             reasons.extend(cls._command_executable_reasons(command))
         for path in test.required_files:
@@ -1808,8 +1810,10 @@ class TestRegistry:
 
     @classmethod
     def _address_space_reason(cls) -> Optional[str]:
-        # Trial-run instead of duplicating mmap-noreserve.c's REGION_BYTES:
-        # it prints READY on success, or fails fast via perror("mmap").
+        # Gate for every needs_max_address_space test (mmap-noreserve and the
+        # tsan tests): raise RLIMIT_AS soft to hard, then trial-run
+        # mmap-noreserve, whose huge MAP_NORESERVE region stands in for TSAN's
+        # ~125 TiB reservation.  It prints READY on success.
         binary = ROOT / "test" / "mmap-noreserve"
         if not binary.exists():
             return None  # _command_executable_reasons() will report this
@@ -1859,10 +1863,30 @@ class TestRegistry:
             for test in tests
         ]
 
+    @staticmethod
+    def _clang_runtime_dir() -> str:
+        # clang's -shared-libsan TSAN runtime lives in a non-standard dir
+        # with no RPATH, so the tsan-clang test needs LD_LIBRARY_PATH
+        # pointing at it.
+        try:
+            out = subprocess.run(["clang", "-print-runtime-dir"],
+                                 capture_output=True, text=True, timeout=10)
+            return out.stdout.strip() if out.returncode == 0 else ""
+        # Probe only: any failure here just disables the tsan-clang test
+        # (returns ""); it must never crash the suite.
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            # clang not in PATH, probe timed out, or another OS-level error.
+            return ""
+        except Exception as e:
+            print("DMTCP: autotest: internal error: unexpected exception: "
+                  f"{e!r}", file=sys.stderr)
+            return ""
+
     def _build_tests(self) -> List[TestSpec]:
         frisbee_p1, frisbee_p2, frisbee_p3 = [
             str(port) for port in sample(range(2000, 10000), 3)
         ]
+        clang_rtdir = self._clang_runtime_dir()
 
         tests = [
             TestSpec("dmtcp1", 1, ["./test/dmtcp1"]),
@@ -1943,6 +1967,30 @@ class TestRegistry:
             TestSpec("dmtcp2", 1, ["./test/dmtcp2"]),
             TestSpec("dmtcp3", 1, ["./test/dmtcp3"]),
             TestSpec("dmtcp4", 1, ["./test/dmtcp4"]),
+            # Regression guard for ThreadSanitizer (-fsanitize=thread) targets,
+            # exercising full (default cycles=2) checkpoint/restart.
+            # Auto-disabled when the TSAN runtime / ./test/tsan_target is
+            # absent.
+            TestSpec("tsan-gcc", 1, ["./test/tsan_target"],
+                     needs_max_address_space=True,
+                     tags=["tsan"]),
+            # Same guard built with clang -fsanitize=thread -shared-libsan.
+            # LD_LIBRARY_PATH points at clang's runtime dir because its shared
+            # TSAN runtime has no RPATH (a clang fact, not DMTCP-specific).
+            # Auto-disabled when clang / its shared TSAN runtime is absent
+            # (then ./test/tsan_target_clang is not built).
+            TestSpec("tsan-clang", 1, ["./test/tsan_target_clang"],
+                     library_paths=[clang_rtdir] if clang_rtdir else [],
+                     needs_max_address_space=True,
+                     tags=["tsan", "clang"]),
+            # clang STATIC default: TSAN runtime linked into the exe, detected
+            # by dmtcp_launch via the "__tsan_init" symbol in .dynstr (no
+            # DT_NEEDED, no prepend, no LD_LIBRARY_PATH; dmtcp_launch still
+            # disables ASLR).
+            TestSpec("tsan-clang-static", 1,
+                     ["./test/tsan_target_clang_static"],
+                     needs_max_address_space=True,
+                     tags=["tsan", "clang"]),
             # Regression guard for the pagemap residency zero-page optimization
             # (Util::scanOccupiedRangeBatch in writeckpt.cpp).  Run on both the
             # ioctl(PAGEMAP_SCAN) fast path and the portable pread() fallback.
@@ -2513,23 +2561,29 @@ class TestRegistry:
     def _has_all(values, required) -> bool:
         return all(value in values for value in required)
 
-    def select(self, names=None, tags=None,
-               requirements=None) -> List[TestSpec]:
+    @staticmethod
+    def _has_any(values, excluded) -> bool:
+        return any(value in values for value in excluded)
+
+    def select(self, names=None, tags=None, requirements=None,
+               exclude_tags=None) -> List[TestSpec]:
         if names:
             tests = [self.get_test(name) for name in names]
         else:
             tests = list(self._tests)
         tags = tags or []
         requirements = requirements or []
+        exclude_tags = exclude_tags or []
         return [
             test for test in tests
             if self._has_all(test.tags, tags) and
-            self._has_all(test.requirements, requirements)
+            self._has_all(test.requirements, requirements) and
+            not self._has_any(test.tags, exclude_tags)
         ]
 
     def select_for_listing(
-            self, names=None, tags=None,
-            requirements=None) -> List[TestSpec]:
+            self, names=None, tags=None, requirements=None,
+            exclude_tags=None) -> List[TestSpec]:
         all_tests = list(self._tests) + list(self._disabled_tests)
         if names:
             by_name = {test.name: test for test in all_tests}
@@ -2538,10 +2592,12 @@ class TestRegistry:
             tests = all_tests
         tags = tags or []
         requirements = requirements or []
+        exclude_tags = exclude_tags or []
         return [
             test for test in tests
             if self._has_all(test.tags, tags) and
-            self._has_all(test.requirements, requirements)
+            self._has_all(test.requirements, requirements) and
+            not self._has_any(test.tags, exclude_tags)
         ]
 
     def disabled_reason_counts(
@@ -2624,6 +2680,9 @@ def parse_args():
                              "successful tests")
     parser.add_argument("--tag", action="append", default=[],
                         help="run or list tests with this metadata tag")
+    parser.add_argument("--exclude-tag", action="append", default=[],
+                        help="do not run or list tests with this metadata "
+                             "tag, even if they otherwise match")
     parser.add_argument("--requires", action="append", default=[],
                         help="run or list tests with this requirement marker")
     parser.add_argument("--suite", action="append",
@@ -3354,7 +3413,7 @@ def main():
     try:
         if args.list:
             selected = REGISTRY.select_for_listing(
-                args.tests, args.tag, args.requires)
+                args.tests, args.tag, args.requires, args.exclude_tag)
             if not selected:
                 print("No tests selected", file=sys.stderr)
                 return 2
@@ -3362,7 +3421,8 @@ def main():
 
         selected = []
         if "integration" in suites:
-            selected = REGISTRY.select(args.tests, args.tag, args.requires)
+            selected = REGISTRY.select(
+                args.tests, args.tag, args.requires, args.exclude_tag)
         elif args.tests:
             print("Test names can only select integration tests",
                   file=sys.stderr)

--- a/test/autotest_test.py
+++ b/test/autotest_test.py
@@ -2059,7 +2059,8 @@ class DmtcpTestHarnessUnitTest(unittest.TestCase):
                                ["autotest.py", "--retain-success-artifacts",
                                 "retain-success"]), \
              mock.patch.object(REGISTRY, "select",
-                               lambda names, tags, requirements: [spec]), \
+                               lambda names, tags, requirements,
+                               exclude_tags=None: [spec]), \
              mock.patch.object(autotest_module, "DmtcpHarness",
                                FakeHarness), \
              mock.patch.object(autotest_module, "run_with_optional_retry",
@@ -2116,7 +2117,8 @@ class DmtcpTestHarnessUnitTest(unittest.TestCase):
 
         with mock.patch.object(sys, "argv", ["autotest.py"]), \
              mock.patch.object(REGISTRY, "select",
-                               lambda names, tags, requirements:
+                               lambda names, tags, requirements,
+                               exclude_tags=None:
                                selected_specs), \
              mock.patch.object(autotest_module, "DmtcpHarness",
                                FakeHarness), \
@@ -2183,7 +2185,8 @@ class DmtcpTestHarnessUnitTest(unittest.TestCase):
         with mock.patch.object(sys, "argv",
                                ["autotest.py", "--color", "always"]), \
              mock.patch.object(REGISTRY, "select",
-                               lambda names, tags, requirements: [spec]), \
+                               lambda names, tags, requirements,
+                               exclude_tags=None: [spec]), \
              mock.patch.object(autotest_module, "DmtcpHarness",
                                FakeHarness), \
              mock.patch.object(autotest_module, "run_with_optional_retry",
@@ -2260,7 +2263,8 @@ class DmtcpTestHarnessUnitTest(unittest.TestCase):
                                ["autotest.py", "--suite", "all",
                                 "dmtcp1"]), \
              mock.patch.object(REGISTRY, "select",
-                               lambda names, tags, requirements:
+                               lambda names, tags, requirements,
+                               exclude_tags=None:
                                selected_specs), \
              mock.patch.object(autotest_module, "DmtcpHarness",
                                FakeHarness), \
@@ -2327,7 +2331,8 @@ class DmtcpTestHarnessUnitTest(unittest.TestCase):
                                ["autotest.py", "--slow", "--slow",
                                 "slow"]), \
              mock.patch.object(REGISTRY, "select",
-                               lambda names, tags, requirements: [spec]), \
+                               lambda names, tags, requirements,
+                               exclude_tags=None: [spec]), \
              mock.patch.object(autotest_module, "DmtcpHarness",
                                FakeHarness), \
              mock.patch.object(autotest_module, "run_with_optional_retry",
@@ -2408,7 +2413,8 @@ class DmtcpTestHarnessUnitTest(unittest.TestCase):
         with mock.patch.object(sys, "argv",
                                ["autotest.py", "--jobs", "4"]), \
              mock.patch.object(REGISTRY, "select",
-                               lambda names, tags, requirements:
+                               lambda names, tags, requirements,
+                               exclude_tags=None:
                                selected_specs), \
              mock.patch.object(autotest_module, "DmtcpHarness",
                                FakeHarness), \
@@ -2488,7 +2494,8 @@ class DmtcpTestHarnessUnitTest(unittest.TestCase):
         with mock.patch.object(sys, "argv",
                                ["autotest.py", "--jobs", "4"]), \
              mock.patch.object(REGISTRY, "select",
-                               lambda names, tags, requirements:
+                               lambda names, tags, requirements,
+                               exclude_tags=None:
                                selected_specs), \
              mock.patch.object(autotest_module, "DmtcpHarness",
                                FakeHarness), \
@@ -2552,7 +2559,8 @@ class DmtcpTestHarnessUnitTest(unittest.TestCase):
                                ["autotest.py", "--jobs", "4",
                                 "--color", "always"]), \
              mock.patch.object(REGISTRY, "select",
-                               lambda names, tags, requirements: [spec]), \
+                               lambda names, tags, requirements,
+                               exclude_tags=None: [spec]), \
              mock.patch.object(autotest_module, "DmtcpHarness",
                                FakeHarness), \
              mock.patch.object(autotest_module, "run_with_optional_retry",

--- a/test/tsan_target.c
+++ b/test/tsan_target.c
@@ -1,0 +1,39 @@
+// Long-running, race-free, checkpointable target compiled with -fsanitize=thread,
+// used to develop/verify DMTCP support for TSAN'd binaries.
+//   gcc -fsanitize=thread -g -O0 -pthread tsan_target.c -o tsan_target
+//   setarch -R ./tsan_target          # ASLR off: TSAN requires it
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdio.h>
+#include <unistd.h>
+
+static pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+static long counter;
+
+static void *worker(void *arg)
+{
+  long id = (long)arg;
+  for (int i = 0;; i++) {
+    pthread_mutex_lock(&m);
+    long snap = ++counter;  // snapshot under the lock; printing the shared
+    pthread_mutex_unlock(&m);  // variable unlocked would be a real race
+    if (i % 5 == 0) {
+      printf("worker %ld: counter=%ld\n", id, snap);
+      fflush(stdout);
+      sleep(1);
+    }
+  }
+  return NULL;
+}
+
+int main(void)
+{
+  pthread_t t[2];
+  for (long i = 0; i < 2; i++) {
+    pthread_create(&t[i], NULL, worker, (void *)i);
+  }
+  for (int i = 0; i < 2; i++) {
+    pthread_join(t[i], NULL);
+  }
+  return 0;
+}

--- a/test/tsan_target_race.c
+++ b/test/tsan_target_race.c
@@ -1,0 +1,58 @@
+// Race-detection-fidelity target: verifies that TSAN's data-race detection
+// itself (not just process survival) still works correctly after a DMTCP
+// checkpoint/restart cycle.
+//   gcc -fsanitize=thread -g -O0 -pthread tsan_target_race.c -o tsan_target_race
+//   setarch -R ./tsan_target_race          # ASLR off: TSAN requires it
+//
+// Phase 1 (race-free, iterations 0..RACE_FREE_ITERS-1): both threads
+// increment 'counter' under a mutex, like tsan_target.c. Long enough (with
+// the 1s sleep below) to comfortably outlast the checkpoint that the test
+// harness takes immediately after launch.
+//
+// Phase 2 (racy, iterations >= RACE_FREE_ITERS): both threads increment
+// 'counter' with NO synchronization -- a deliberate, TSAN-detectable data
+// race. Since DMTCP restores the iteration counter exactly as it was at
+// checkpoint time, phase 2 is only ever reached after checkpoint+restart,
+// so a detected race here proves TSAN's detection state survived restart.
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#define RACE_FREE_ITERS 3
+
+static pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
+static long counter;
+
+static void *worker(void *arg)
+{
+  long id = (long)arg;
+  for (int i = 0;; i++) {
+    if (i < RACE_FREE_ITERS) {
+      pthread_mutex_lock(&m);
+      long snap = ++counter;
+      pthread_mutex_unlock(&m);
+      printf("worker %ld: race-free counter=%ld\n", id, snap);
+    } else {
+      // Deliberate, unguarded race: both threads read-modify-write
+      // 'counter' concurrently with no synchronization whatsoever.
+      counter++;
+      printf("worker %ld: racy counter=%ld\n", id, counter);
+    }
+    fflush(stdout);
+    sleep(1);
+  }
+  return NULL;
+}
+
+int main(void)
+{
+  pthread_t t[2];
+  for (long i = 0; i < 2; i++) {
+    pthread_create(&t[i], NULL, worker, (void *)i);
+  }
+  for (int i = 0; i < 2; i++) {
+    pthread_join(t[i], NULL);
+  }
+  return 0;
+}


### PR DESCRIPTION
*This has 3 commits from PR #1279, followed by the remaining commits.  The commits from PR #1279 should be reviewed and pushed in before reviewing this commit.*

`make check-tsan` to test it (works for gcc and clang)
This currently includes PR #1260 (PAGEMAP_SCAN) as the first 3 commits.  I'll rebase when PR #1260 is approved.  Please review PR #1260 before reviewing the current PR.  For this PR, the number of lines of code added is less than 400 (and much of it due to a new autotest target).  Most other changes to DMTCP are local.  For easy reviewing, just directly review "Files changed", but only after PR #1260 (the first 3 commits) is pushed in, after which, this PR should then be rebased against origin/main.

@karya0 , Note there were two or three places where Claude replaced libdmtcp calls to libc by a "syscall(SYS_exit_group)", I think another syscall, and a C++ guard replaced a function (an atomic??).  This was needed because TSAN does not notice syscalls and C++ guards, and we needed to make sure that a TSAN interceptor (wrapper) would not interfere with DMTCP.

**NOTE ON ALTERNATIVE DESIGNS:**
1. Another possibility would be to allow TSAN to initialize itself in its ctor function, and to delay the ctor initialization of DMTCP by having its wrapper pass-through, until TSAN is done initializing itself.  Then DMTCP would have to "adopt" and changes that TSAN made that we would need to later checkpoint.
2. Still another possibility would be to modify the user binary that was built with TSAN.  We would look for DT_NEED libtsan.so, and if we find it, then we would modify the binary so that a DT_NEED of libdmtcp.so (and its plugins??) comes first.
3. Finally, note that for clang, its default is to statically link tsan.  So, option 2 would not work there.  But for clang, there is a flag to force dynamic linking:  `-fsanitize=thread -shared-libsan`

## Summary

Enables DMTCP to checkpoint and restart programs built with ThreadSanitizer
(`-fsanitize=thread`) — full, repeated checkpoint/restart cycles, verified for
all three runtime forms:

- **gcc** — dynamic `libtsan.so`
- **clang `-shared-libsan`** — dynamic `libclang_rt.tsan*.so`
- **clang** (default) — statically-linked runtime in the executable

TSAN is itself an `LD_PRELOAD`-style interposer with a multi-terabyte, sparsely
resident shadow/meta address space, so it needs specific handling at launch,
checkpoint, and restart. `dmtcp_launch` auto-detects a TSAN target and sets
everything up — no manual `setarch -R` or `LD_PRELOAD` tweaking required.

## How it works

**Launch**
- **Load order** — TSAN must interpose *before* libdmtcp. `dmtcp_launch` detects
  the TSAN runtime (the `DT_NEEDED` soname, or a `__tsan_init` symbol for the
  static runtime) and prepends it, giving `app → TSAN → DMTCP → libc` so DMTCP's
  `_real_*` resolve past TSAN to libc.
- **ASLR off** — TSAN aborts under ASLR; `dmtcp_launch` sets
  `personality(ADDR_NO_RANDOMIZE)` for TSAN targets.
- **No re-entry into a half-initialized TSAN** — TSAN's constructor calls DMTCP
  wrappers before DMTCP is initialized, so those paths avoid TSAN-intercepted
  sync primitives / C++ function-local static guards (`determineCkptSignal`, the
  alloc-plugin malloc path).

**Checkpoint**
- **Sparse shadow** is saved by a pagemap residency scan (only resident pages are
  written), so the multi-TB shadow is never faulted in. (Included here as a
  general zero-page optimization, with unit tests and a `zeropages` test.)
- **Checkpoint I/O uses raw syscalls** (`Util::writeAll`/`readAll`) to bypass
  TSAN's `read`/`write` interceptors.

**Restart**
- **`MAP_NORESERVE`** when re-mapping anonymous regions, so TSAN's terabyte-scale
  reserved regions don't fail to commit (`ENOMEM`).
- **`called_from_lib:libdmtcp.so` suppression** (written by `dmtcp_launch`) so
  post-restart plugin handlers don't hang in a TSAN interceptor running on
  not-yet-re-established per-thread state.
- **Fresh TSAN fiber on restart** — the checkpoint thread records its own TSAN
  trace events while writing the image, so a saved image could capture that
  thread's trace torn mid-update; on the *next* restart it faulted on the
  dangling tail. On restart the checkpoint thread now switches to a fresh TSAN
  fiber before its first traced call, abandoning the possibly-torn trace. This
  fixes the second consecutive restart; normal `ckpt/resume` is untouched.

## Tests / CI

- New `tsan`, `tsan-clang`, `tsan-clang-static` specs (`test/tsan_target.c`), run
  at the default 2 checkpoint/restart cycles; each is built only when its
  compiler's TSAN runtime is present.
- TSAN reserves ~125 TiB of address space, so these specs can't run under
  `make check` (its `ulimit -v` cap kills TSAN before `main`, and an unprivileged
  process can't raise the hard limit). A dedicated **`make check-tsan`** target
  runs them without the cap; CI runs both `make check` (which auto-skips them)
  and `make check-tsan`.

## Summary of effort with Superpowers/Claude Code

*This is so that we can share experiences.  In total, this took 2 long days.  A first version was available after about 2-1/2 or 3 hours.  But various bugs were there.  Finally, Superpowers/Claude Code got completely stuck in the case of cktp/restart/ckpt/restart.  It wandered aimlessly with me pressing "Yes", until it was suggesting some very poor designs.  I then asked Gemini more about the TSAN API, and I discovered fibers -- a simple solution.  After restart, the TSAN trace of the ckpt thread was being corrupted.  We now switch to a new fiber (trace and other state of a TSAN-instrumented thread) and then destroyed the old, stale thread.  In total, it was two long days.  At the end, there was 349 lines of code and 181 lines of comments.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added improved ThreadSanitizer support for launching, checkpointing, and restarting instrumented applications.
  - Added handling for both dynamically and statically linked ThreadSanitizer runtimes.
  - Added automatic ThreadSanitizer suppressions and address-randomization handling where needed.
  - Added TSAN regression scenarios, including race detection across checkpoint and restart.

- **Testing**
  - Added dedicated `check-tsan` testing and Clang-based TSAN coverage.
  - Added `--exclude-tag` to omit selected test categories from test runs.
  - Improved checkpoint/resume test reliability and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->