### PR TITLE
Fix inverted diagnostic conditions

### DIFF
--- a/src/dmtcp_assert.h
+++ b/src/dmtcp_assert.h
@@ -25,10 +25,11 @@ inline constexpr int kAssertFailureExitCode = 99;
 
 /*
  * Assertion helper guide:
- * - ASSERT(cond, "msg {}", arg) logs and exits; WARN(cond, ...) logs and
- *   continues.  NOTE(...) and TRACE(...) use the same formatter and are
- *   controlled by the runtime log level.  ASSERT_ERRNO/WARN_ERRNO add the
- *   errno value captured at the failing check.
+ * - ASSERT(cond, "msg {}", arg) logs and exits when cond is false;
+ *   WARN(cond, ...) logs and continues when cond is false.  NOTE(...) and
+ *   TRACE(...) use the same formatter and are controlled by the runtime log
+ *   level.  ASSERT_ERRNO/WARN_ERRNO add the errno value captured at the
+ *   failing check.
  * - Named helpers such as ASSERT_EQ(expected, actual),
  *   ASSERT_NOT_NULL(ptr), ASSERT_ZERO(expr), ASSERT_LOCK_SUCCESS(expr), and
  *   ASSERT_PTHREAD_SUCCESS(expr) evaluate their operands once and include the

--- a/src/kvdb.cpp
+++ b/src/kvdb.cpp
@@ -32,7 +32,7 @@ KVDBResponse request(KVDBRequest request,
     return KVDBResponse::INVALID_REQUEST;
   }
 
-  WARN(id.length() > sizeof(msg.kvdbId) - 1,
+  WARN(id.length() <= sizeof(msg.kvdbId) - 1,
           "KVDB id is too long and will be truncated: length={} limit={}",
           id.length(), sizeof(msg.kvdbId) - 1);
   size_t kvdbIdLength = id.length();

--- a/src/tls.cpp
+++ b/src/tls.cpp
@@ -387,7 +387,7 @@ get_at_sysinfo()
                   "expected argv[argc] to be null while scanning auxv");
 
   // stack[-1] should be argv[argc-1]
-  ASSERT((void **)stack[-1] >= stack && (void **)stack[-1] >= stack + 100000,
+  ASSERT((void **)stack[-1] >= stack && (void **)stack[-1] <= stack + 100000,
          "candidate argv[argc-1] failed consistency check: stack={} "
          "candidate={}",
          stack, stack[-1]);


### PR DESCRIPTION
## Summary
- Fix KVDB warning polarity so long IDs trigger the truncation warning instead of valid IDs
- Fix the TLS auxv stack sanity check to use the intended upper bound, matching mtcp_check_vdso.c
- Clarify ASSERT/WARN documentation: raw macros log when the condition is false

## Audit
- Ran parallel read-only audits over core, plugins, and assert/logger helpers for WARN/ASSERT polarity issues
- Plugin and helper audits found no additional runtime polarity bugs

## Validation
- python3 util/dmtcp-style.py src/kvdb.cpp src/tls.cpp src/dmtcp_assert.h
- git diff --check
- make -j8
- make -C test
- make -C test unit/dmtcp_unit_tests
- ./test/autotest.py -v dmtcp1
- ./test/autotest.py --suite unit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified assertion helper documentation to detail behavior differences among assertion types and error value handling.

* **Bug Fixes**
  * Fixed inverted condition in ID validation warning logic.
  * Corrected bounds checking validation in system information processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->