### PR TITLE
Skip autotest on Python < 3.7

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -17,11 +17,16 @@ import tempfile
 import threading
 import time
 import traceback
-from dataclasses import dataclass, field, replace
 from random import sample
 from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import autotest_config
+
+if sys.version_info < (3, 7):
+    print("Skipping autotest; Python 3.7+ is required.", flush=True)
+    sys.exit(0)
+
+from dataclasses import dataclass, field, replace
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -37,6 +42,16 @@ ARTIFACT_LOG_HINT = (
     "result.log commands.log processes.log worker-*.out restart-*.out"
 )
 COORDINATOR_PROTOCOL_CATEGORY = "Coordinator protocol tests"
+
+
+def shell_join(args: Iterable[object]) -> str:
+    return " ".join(shlex.quote(str(arg)) for arg in args)
+
+
+def remove_prefix(text: str, prefix: str) -> str:
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text
 
 
 class DmtcpCommandJson:
@@ -651,7 +666,7 @@ class TestContext:
                     pass
                 os.execvpe(argv[0], argv, self.env)
             except BaseException as error:
-                message = f"exec failed for {shlex.join(argv)}: {error}\n"
+                message = f"exec failed for {shell_join(argv)}: {error}\n"
                 try:
                     os.write(2, message.encode("utf-8", "replace"))
                 finally:
@@ -865,7 +880,7 @@ class TestContext:
     def _record_command(self, phase: str, argv: List[str]):
         with (self.work.path / "commands.log").open("a",
                                                     encoding="utf-8") as out:
-            out.write(f"$ {shlex.join([str(arg) for arg in argv])}\n")
+            out.write(f"$ {shell_join(argv)}\n")
             out.write(f"phase={phase}\n")
 
     def _record_checkpoint_images(self, phase: str,
@@ -2105,7 +2120,7 @@ def format_active_failed_run_status(result: TestResult) -> str:
 def run_display_name(spec: Union[TestSpec, CommandTestSpec]) -> str:
     name = spec.name
     if spec.category == COORDINATOR_PROTOCOL_CATEGORY:
-        return name.removeprefix("coordinator-")
+        return remove_prefix(name, "coordinator-")
     return name
 
 
@@ -2341,7 +2356,7 @@ def command_failure_detail_lines(
         spec: CommandTestSpec, result: TestResult,
         max_output_lines: int = COMMAND_OUTPUT_TAIL_LINES) -> List[str]:
     lines = [
-        f"command: {shlex.join(spec.command)}",
+        f"command: {shell_join(spec.command)}",
         f"cwd: {spec.cwd}",
     ]
     output = result.details.rstrip()
@@ -2405,7 +2420,7 @@ def format_failure_record_lines(
         lines.append(f"    artifacts: {failure.artifact_dir}")
         lines.append(f"    logs: {ARTIFACT_LOG_HINT}")
     if failure.command is not None:
-        lines.append(f"    command: {shlex.join(failure.command)}")
+        lines.append(f"    command: {shell_join(failure.command)}")
     if failure.cwd is not None:
         lines.append(f"    cwd: {failure.cwd}")
     return lines

--- a/test/autotest_test.py
+++ b/test/autotest_test.py
@@ -1628,6 +1628,47 @@ class DmtcpTestHarnessUnitTest(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertIn("No tests selected", result.stderr)
 
+    def test_autotest_skips_before_python37(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_path = pathlib.Path(tempdir)
+            (temp_path / "sitecustomize.py").write_text(
+                "import collections\n"
+                "import sys\n"
+                "VersionInfo = collections.namedtuple(\n"
+                "    'version_info', 'major minor micro releaselevel serial')\n"
+                "sys.version_info = VersionInfo(3, 6, 8, 'final', 0)\n"
+            )
+            (temp_path / "dataclasses.py").write_text(
+                "raise ModuleNotFoundError('No module named dataclasses')\n"
+            )
+            env = os.environ.copy()
+            env["PYTHONPATH"] = os.pathsep.join(
+                [str(temp_path), env.get("PYTHONPATH", "")]
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "test" / "autotest.py"),
+                    "--list",
+                    "dmtcp1",
+                ],
+                cwd=str(ROOT),
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+                timeout=10,
+            )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(
+            result.stdout,
+            "Skipping autotest; Python 3.7+ is required.\n",
+        )
+        self.assertEqual(result.stderr, "")
+
     def test_autotest_list_rejects_unknown_test(self):
         result = subprocess.run(
             [


### PR DESCRIPTION
## Summary
- Skip autotest on Python < 3.7 with a clear message instead of carrying a Python 3.6 compatibility shim.
- Keep Python 3.7-compatible replacements for newer helpers used by harness diagnostics.
- Add a regression test for the Python < 3.7 skip path.

## Test Plan
- `/tmp/Python-3.6.15/python test/autotest.py --list dmtcp1`
- `python3 test/autotest.py --list dmtcp1`
- `python3 -m unittest autotest_test.DmtcpTestHarnessUnitTest.test_autotest_skips_before_python37 autotest_test.DmtcpTestHarnessUnitTest.test_command_failure_details_are_capped_and_actionable autotest_test.DmtcpTestHarnessUnitTest.test_autotest_suite_all_runs_command_suites_then_integration`
- `python3 -m py_compile test/autotest.py test/autotest_test.py`
- `/tmp/Python-3.6.15/python -m py_compile test/autotest.py test/autotest_test.py`
- `git diff --check`

## Notes
- Full `python3 test/autotest_test.py` still has pre-existing local config-sensitive failures: missing `autotest_config.HAS_SYS_MQ_OPEN`, and `waitid-syscall` is not registered in this configured tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Autotest now exits early with a clear message when run on Python versions earlier than 3.7.
  * Command and execution failure messages are now easier to read, with improved shell-style formatting in logs and summaries.
  * Display names for coordinator-related runs now render consistently without the extra prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->