### PR TITLE
close_range() is not defined prior to glibc-2.34

### DIFF
--- a/src/wrappers.cpp
+++ b/src/wrappers.cpp
@@ -393,6 +393,7 @@ close(int fd)
   return ret;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0) && __GLIBC_PREREQ(2, 34)
 extern "C" int
 close_range(unsigned int first, unsigned int last, int flags)
 {
@@ -426,6 +427,7 @@ close_range(unsigned int first, unsigned int last, int flags)
 
   return ret;
 }
+#endif
 
 extern "C" int
 fclose(FILE *fp)


### PR DESCRIPTION
[ This is a trivial one-liner to review.  The comments here say it all. ]

Some platforms like Rocky Linux 8 (on glibc-2.28) don't yet have glibc-2.34.
This conditionally defines close_range for `src/wrappers.cpp`.  We missed that one in conditionally defining elsewhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform compatibility by only enabling a specific system call wrapper on supported Linux and library versions.
  * Prevents build or runtime issues on environments that do not meet the minimum version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->