### PR TITLE
Fix StackHead, used for dwcas, cmpxchg16b, etc.

### DIFF
--- a/jalib/jalloc.cpp
+++ b/jalib/jalloc.cpp
@@ -326,7 +326,7 @@ class JFixedAllocStack
         char buf[N];
       };
     };
-    struct StackHead {
+    struct alignas(16) StackHead {
       uintptr_t counter;
       FreeItem* node;
     };


### PR DESCRIPTION
[ This is a trivial one-liner to review.  The commit comments (shown here) say it all. ]

 * jalloc.cpp uses __atomic_compare_exchange()
 * That compiles to inline Intel assembly (cmpxchg16b) (and similarly for aarch64/ARM64 and RISC-V, but sometimes needs -mcx16 or -march=native to force it.
 * For 16-byte data (StackHead), it must be 16-byte aligned for inline assembly; this guarantees that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory allocation stability in low-level operations, reducing the risk of rare alignment-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->