### PR TITLE
Removes about 200 compiler pedantic warnings, etc.

### DIFF
--- a/configure
+++ b/configure
@@ -36,6 +36,7 @@ esac
 fi
 
 
+
 # Reset variables that may have inherited troublesome values from
 # the environment.
 
@@ -823,10 +824,8 @@ enable_silent_rules
 enable_maintainer_mode
 enable_dependency_tracking
 enable_openmp
-enable_logging
 enable_debug
 enable_quiet
-enable_timing
 enable_realtime_ckpt_signal
 enable_unique_checkpoint_filenames
 enable_forked_checkpointing
@@ -10500,6 +10499,7 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
 printf "%s\n" "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
 
+
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if this is WSL (Windows Subystem for Linux)" >&5
 printf %s "checking if this is WSL (Windows Subystem for Linux)... " >&6; }
 if uname -r | grep -i Microsoft > /dev/null; then
@@ -11080,6 +11080,7 @@ printf "%s\n" "no" >&6; }
 fi
 
 
+
 #check for vim
 # Extract the first word of "vim", so it can be a program name with args.
 set dummy vim; ac_word=$2
@@ -11172,6 +11173,7 @@ else
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
 fi
+
 
 
 #check for strace
@@ -12464,42 +12466,6 @@ printf "%s\n" "$sysconf_pagesize" >&6; }
 
 printf "%s\n" "#define MTCP_PAGE_SIZE $sysconf_pagesize" >>confdefs.h
 
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for __WAIT_STATUS type" >&5
-printf %s "checking for __WAIT_STATUS type... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-
-    #include <sys/wait.h>
-    #include <sys/types.h>
-    #include <stdlib.h>
-    int main() {
-      __WAIT_STATUS status __attribute__((unused));
-      return 0;
-    }
-
-
-_ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  wait_status='yes'
-else case e in #(
-  e) wait_status='no' ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $wait_status" >&5
-printf "%s\n" "$wait_status" >&6; }
-
-if test "$wait_status" = "no"; then
-
-printf "%s\n" "#define __WAIT_STATUS int *" >>confdefs.h
-
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: *** glibc-2.24 removed __WAIT_STATUS; This check will go away in the future." >&5
-printf "%s\n" "$as_me: *** glibc-2.24 removed __WAIT_STATUS; This check will go away in the future." >&6;}
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -14013,3 +13979,5 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 printf "%s\n" "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
+
+

--- a/configure.ac
+++ b/configure.ac
@@ -932,42 +932,8 @@ fi
 AC_DEFINE_UNQUOTED([MTCP_PAGE_SIZE], $sysconf_pagesize,
                    [Page size (sysconf(_SC_PAGESIZE))])
 
-dnl TODO:  __WAIT_STATUS is defined in include/config.h to be 'int *'
-dnl        POSIX says 'int'.  Why do we need __WAIT_STATUS for DMTCP,
-dnl        and then do AC_DEFINE to define it??
-dnl        It was part of the glibc lxstat support, but it was deprecated,
-dnl        and then removed as of glibcgccAtomicBuiltins" = "no"; then
 AC_MSG_RESULT([$sysconf_pagesize])
 AC_DEFINE_UNQUOTED([MTCP_PAGE_SIZE], $sysconf_pagesize,
                    [Page size (sysconf(_SC_PAGESIZE))])
-
-dnl TODO:  __WAIT_STATUS is defined in include/config.h to be 'int *'
-dnl        POSIX says 'int'.  Why do we need __WAIT_STATUS for DMTCP,
-dnl        and then do AC_DEFINE to define it??
-dnl        It was part of the glibc lxstat support, but it was deprecated,
-dnl        and then removed as of glibc-2.24 in 2016.
-dnl        DMTCP should also drop support for __WAIT_STATUS.
-dnl Check whether __WAIT_STATUS is available.
-AC_MSG_CHECKING(for __WAIT_STATUS type)
-AC_LINK_IFELSE(
-[
-  AC_LANG_SOURCE([[
-    #include <sys/wait.h>
-    #include <sys/types.h>
-    #include <stdlib.h>
-    int main() {
-      __WAIT_STATUS status __attribute__((unused));
-      return 0;
-    }
-  ]])
-], [wait_status='yes'], [wait_status='no'])
-AC_MSG_RESULT([$wait_status])
-
-if test "$wait_status" = "no"; then
-  AC_DEFINE([__WAIT_STATUS],[int *],
-            [can use __WAIT_STATUS as wait status type])
-fi
-dnl __WAIT_STATUS entered at commit 7d1344 (2009) and bdcac4 (2016)
-AC_MSG_NOTICE([*** glibc-2.24 removed __WAIT_STATUS; This check will go away in the future.])
 
 AC_OUTPUT

--- a/contrib/tun/tun.c
+++ b/contrib/tun/tun.c
@@ -325,7 +325,7 @@ open64(const char *pathname, int flags, ...)
      */
     g_tun_fd = result;
     DPRINTF("[%s:%d]: PARAMS: pathname: %s, flags:%d; Result: %d\n",
-            __FUNCTION__, __LINE__, pathname, flags, g_tun_fd);
+            __func__, __LINE__, pathname, flags, g_tun_fd);
   }
   return result;
 }
@@ -355,7 +355,7 @@ open(const char *pathname, int flags, ...)
      */
     g_tun_fd = result;
     DPRINTF("[%s:%d]: PARAMS: pathname: %s, flags:%d; Result: %d\n",
-            __FUNCTION__, __LINE__, pathname, flags, g_tun_fd);
+            __func__, __LINE__, pathname, flags, g_tun_fd);
   }
   return result;
 }
@@ -388,7 +388,7 @@ ioctl(int fd, unsigned long int request, ...)
 
     /* Capture arguments of ioctl() */
     DPRINTF("[%s:%d]: PARAMS: fd: %d, request:%s, arg:%p; Result: %d\n",
-            __FUNCTION__, __LINE__, fd, request_name, arg, result);
+            __func__, __LINE__, fd, request_name, arg, result);
     inc_last_req_idx();
     g_request_table[g_last_req_idx].request = request;
     g_request_table[g_last_req_idx].arg = get_arg(request, arg);

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -109,7 +109,6 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
-/* Verbose trace output and log files in $DMTCP_TMPDIR */
 /* Page size (sysconf(_SC_PAGESIZE)) */
 #undef MTCP_PAGE_SIZE
 
@@ -150,6 +149,3 @@
 
 /* This is WSL (Windows Subsystem for Linux. */
 #undef WSL
-
-/* can use __WAIT_STATUS as wait status type */
-#undef __WAIT_STATUS

--- a/src/dmtcp_launch.cpp
+++ b/src/dmtcp_launch.cpp
@@ -48,7 +48,6 @@ using namespace dmtcp;
 
 static void processArgs(int *orig_argc, const char ***orig_argv);
 static int testMatlab(const char *filename);
-static int testJava(const char **argv);
 static bool testSetuid(const char *filename);
 static void testStaticallyLinked(const char *filename);
 static bool testScreen(const char **argv, const char ***newArgv);
@@ -529,6 +528,10 @@ main(int argc, const char **argv)
       stderr);
   }
 
+  // FIXME: ***DELETE THE FOLLOWING COMMENT***
+  //        ***SEE: Detect unallocated pages via pagemap residency at checkpoint
+  //        ***     That PR #1260 handles unallocated (i.e., zero-mapped
+  //        ***     pages.  Delete this comment when putshed in.
   // Remove this when zero-mapped pages are supported.  For segments with
   // no file backing:  Start with 4096 (page) offset and keep doubling offset
   // until finding region of memory segment with many zeroes.
@@ -543,7 +546,6 @@ main(int argc, const char **argv)
   // - Gene
 
   testMatlab(argv[0]);
-  testJava(argv);  // Warn that -Xmx flag needed to limit virtual memory size
 
   // If libdmtcp.so is in standard search path and _also_ has setgid access,
   // then LD_PRELOAD will work.
@@ -699,45 +701,6 @@ testMatlab(const char *filename)
 # endif // if __GNUC__ == 4 && __GNUC_MINOR__ > 1
 #endif // ifdef __GNUC__
   return 0;
-}
-
-// FIXME:  Remove this when DMTCP supports zero-mapped pages
-static int
-testJava(const char **argv)
-{
-  static const char *theJavaWarning =
-    "\n**** WARNING:  Sun/Oracle Java claims a large amount of memory\n"
-    "****  for its heap on startup.  As of DMTCP version 1.2.4, DMTCP _does_\n"
-    "****  handle zero-mapped virtual memory, but it may take up to a\n"
-    "****  minute.  This will be fixed to be much faster in a future\n"
-    "****  version of DMTCP.  In the meantime, if your Java supports it,\n"
-    "****  use the -Xmx flag for a smaller heap:  e.g.  java -Xmx64M javaApp\n"
-    "****  (Invoke dmtcp_launch with --quiet to avoid this msg.)\n\n";
-
-  if (getenv(ENV_VAR_QUIET) != NULL &&
-      !Util::strEquals(getenv(ENV_VAR_QUIET), "0")) {
-    return 0;
-  }
-  if (Util::strEquals(argv[0], "java")) {
-    while (*(++argv) != NULL) {
-      if (std::string_view(*argv).starts_with("-Xmx")) {
-        return 0; // The user called java with -Xmx.  No need for warning.
-      }
-    }
-  }
-
-  // If physical memory is large enough, warn them that -Xmx is faster.
-  const long pageCount = sysconf(_SC_PHYS_PAGES);
-  const long pageSize = sysconf(_SC_PAGESIZE);
-  if (pageCount > 0 && pageSize > 0) {
-    const unsigned long long memTotalBytes =
-      static_cast<unsigned long long>(pageCount) *
-      static_cast<unsigned long long>(pageSize);
-    if (memTotalBytes > 4ULL * 1024 * 1024 * 1024) {
-      fputs(theJavaWarning, stderr);
-    }
-  }
-  return -1;
 }
 
 static bool

--- a/src/miscwrappers.cpp
+++ b/src/miscwrappers.cpp
@@ -323,7 +323,7 @@ syscall(long sys_num, ...)
 #endif
   case SYS_wait4:
   {
-    SYSCALL_GET_ARGS_4(pid_t, pid, __WAIT_STATUS, status, int, options,
+    SYSCALL_GET_ARGS_4(pid_t, pid, int *, status, int, options,
                        struct rusage *, rusage);
     ret = wait4(pid, status, options, rusage);
     break;

--- a/src/mtcp/mtcp_util.h
+++ b/src/mtcp/mtcp_util.h
@@ -21,12 +21,12 @@
 
 #include "procmapsarea.h"
 
-#define MTCP_PRINTF(args ...)                                               \
+#define MTCP_PRINTF(fmt, ...)                                               \
   do {                                                                      \
     mtcp_printf("[%d] %s:%d %s:\n  ",                                       \
-                mtcp_sys_getpid(), __FILE__, __LINE__, __FUNCTION__);       \
+                mtcp_sys_getpid(), __FILE__, __LINE__, __func__);           \
     (void)mtcp_sys_errno; /* prevent compiler warning if we don't use it */ \
-    mtcp_printf(args);                                                      \
+    mtcp_printf(fmt, ##__VA_ARGS__);                                                      \
   } while (0)
 
 #define MTCP_ASSERT(condition)                          \
@@ -38,7 +38,7 @@
 #ifdef LOGGING
 # define DPRINTF MTCP_PRINTF
 #else // ifdef LOGGING
-# define DPRINTF(args ...) // debug printing
+# define DPRINTF(fmt, ...) // debug printing
 #endif // ifdef LOGGING
 
 #if 0

--- a/src/mtcp/stdlibfnc.c
+++ b/src/mtcp/stdlibfnc.c
@@ -82,7 +82,7 @@ _Unwind_Resume(void)
 {
   int mtcp_sys_errno;
 
-  MTCP_PRINTF("MTCP Internal Error: %s Not Implemented.\n", __FUNCTION__);
+  MTCP_PRINTF("MTCP Internal Error: %s Not Implemented.\n", __func__);
   mtcp_abort();
 }
 
@@ -91,7 +91,7 @@ __gcc_personality_v0(void)
 {
   int mtcp_sys_errno;
 
-  MTCP_PRINTF("MTCP Internal Error: %s Not Implemented.\n", __FUNCTION__);
+  MTCP_PRINTF("MTCP Internal Error: %s Not Implemented.\n", __func__);
   mtcp_abort();
 }
 
@@ -100,7 +100,7 @@ __intel_security_cookie(void)
 {
   int mtcp_sys_errno;
 
-  MTCP_PRINTF("MTCP Internal Error: %s Not Implemented.\n", __FUNCTION__);
+  MTCP_PRINTF("MTCP Internal Error: %s Not Implemented.\n", __func__);
   mtcp_abort();
 }
 
@@ -109,6 +109,6 @@ __intel_security_check_cookie(void)
 {
   int mtcp_sys_errno;
 
-  MTCP_PRINTF("MTCP Internal Error: %s Not Implemented.\n", __FUNCTION__);
+  MTCP_PRINTF("MTCP Internal Error: %s Not Implemented.\n", __func__);
   mtcp_abort();
 }

--- a/src/nosyscallsreal.c
+++ b/src/nosyscallsreal.c
@@ -331,7 +331,7 @@ _real_kill(pid_t pid, int sig)
 }
 
 pid_t
-_real_wait(__WAIT_STATUS stat_loc)
+_real_wait(int *stat_loc)
 {
   REAL_FUNC_PASSTHROUGH_PID_T(wait) (stat_loc);
 }
@@ -349,13 +349,13 @@ _real_waitid(idtype_t idtype, id_t id, siginfo_t *infop, int options)
 }
 
 pid_t
-_real_wait3(__WAIT_STATUS status, int options, struct rusage *rusage)
+_real_wait3(int *status, int options, struct rusage *rusage)
 {
   REAL_FUNC_PASSTHROUGH_PID_T(wait3) (status, options, rusage);
 }
 
 pid_t
-_real_wait4(pid_t pid, __WAIT_STATUS status, int options, struct rusage *rusage)
+_real_wait4(pid_t pid, int *status, int options, struct rusage *rusage)
 {
   REAL_FUNC_PASSTHROUGH_PID_T(wait4) (pid, status, options, rusage);
 }

--- a/src/plugin/pid/pidwrappers.cpp
+++ b/src/plugin/pid/pidwrappers.cpp
@@ -406,9 +406,9 @@ realWaitidId(idtype_t idtype, id_t id)
 }
 
 extern "C" pid_t
-wait(__WAIT_STATUS stat_loc)
+wait(int *stat_loc)
 {
-  return waitpid(-1, (int *)stat_loc, 0);
+  return waitpid(-1, stat_loc, 0);
 }
 
 extern "C" pid_t
@@ -418,13 +418,13 @@ waitpid(pid_t pid, int *stat_loc, int options)
 }
 
 extern "C" pid_t
-wait3(__WAIT_STATUS status, int options, struct rusage *rusage)
+wait3(int *status, int options, struct rusage *rusage)
 {
   return wait4(-1, status, options, rusage);
 }
 
 extern "C" pid_t
-wait4(pid_t pid, __WAIT_STATUS status, int options, struct rusage *rusage)
+wait4(pid_t pid, int *status, int options, struct rusage *rusage)
 {
   int stat;
   int saved_errno = errno;
@@ -433,7 +433,7 @@ wait4(pid_t pid, __WAIT_STATUS status, int options, struct rusage *rusage)
   const struct timespec maxts = { 1, 0 };
 
   if (status == NULL) {
-    status = (__WAIT_STATUS)&stat;
+    status = &stat;
   }
 
   if (!dmtcp_pid_is_enabled()) {
@@ -449,7 +449,7 @@ wait4(pid_t pid, __WAIT_STATUS status, int options, struct rusage *rusage)
       if (realResult == -1) {
         saved_errno = errno;
       }
-      retval = virtualizeWait4Result(realResult, (int *)status);
+      retval = virtualizeWait4Result(realResult, status);
     }
 
     if ((options & WNOHANG) || retval != 0) {

--- a/src/plugin/pid/pidwrappers.h
+++ b/src/plugin/pid/pidwrappers.h
@@ -231,13 +231,13 @@ pid_t _real_setsid(void);
 
 int _real_kill(pid_t pid, int sig);
 
-pid_t _real_wait(__WAIT_STATUS stat_loc);
+pid_t _real_wait(int *stat_loc);
 pid_t _real_waitpid(pid_t pid, int *stat_loc, int options);
 int _real_waitid(idtype_t idtype, id_t id, siginfo_t *infop, int options);
 
-pid_t _real_wait3(__WAIT_STATUS status, int options, struct rusage *rusage);
+pid_t _real_wait3(int *status, int options, struct rusage *rusage);
 pid_t _real_wait4(pid_t pid,
-                  __WAIT_STATUS status,
+                  int *status,
                   int options,
                   struct rusage *rusage);
 LIB_PRIVATE extern int send_sigwinch;

--- a/src/syscallsreal.c
+++ b/src/syscallsreal.c
@@ -263,7 +263,7 @@ dmtcp_prepare_wrappers(void)
     if (dmtcp_real_func_addr[ENUM(name)] == NULL) {                           \
       dmtcp_prepare_wrappers();                                               \
     }                                                                         \
-    fn = dmtcp_real_func_addr[ENUM(name)];                                    \
+    fn = (typeof(&name))(uintptr_t)dmtcp_real_func_addr[ENUM(name)];          \
     if (fn == NULL) {                                                         \
       fprintf(stderr, "*** DMTCP: Error: lookup failed for %s.\n"             \
                       "           The symbol wasn't found in current library" \
@@ -648,14 +648,14 @@ LIB_PRIVATE
 void
 _real_openlog(const char *ident, int option, int facility)
 {
-  REAL_FUNC_PASSTHROUGH(openlog) (ident, option, facility);
+  REAL_FUNC_PASSTHROUGH_NORETURN(openlog) (ident, option, facility);
 }
 
 LIB_PRIVATE
 void
 _real_closelog(void)
 {
-  REAL_FUNC_PASSTHROUGH(closelog) ();
+  REAL_FUNC_PASSTHROUGH_NORETURN(closelog) ();
 }
 
 // set the handler
@@ -826,7 +826,7 @@ _real_waitid(idtype_t idtype, id_t id, siginfo_t *infop, int options)
 
 LIB_PRIVATE
 pid_t
-_real_wait4(pid_t pid, __WAIT_STATUS status, int options, struct rusage *rusage)
+_real_wait4(pid_t pid, int *status, int options, struct rusage *rusage)
 {
   REAL_FUNC_PASSTHROUGH(wait4) (pid, status, options, rusage);
 }

--- a/src/syscallwrappers.h
+++ b/src/syscallwrappers.h
@@ -491,7 +491,7 @@ int _real_unlink(const char *pathname);
 
 int _real_waitid(idtype_t idtype, id_t id, siginfo_t *infop, int options);
 pid_t _real_wait4(pid_t pid,
-                  __WAIT_STATUS status,
+                  int *status,
                   int options,
                   struct rusage *rusage);
 

--- a/test/syscall-tester.c
+++ b/test/syscall-tester.c
@@ -327,8 +327,9 @@ const int ENDLIST = -1;
 #define FAILURE   -1
 #define UNDEFINED -2
 
-#define print_error(format, args...) \
-  printf("\033[0;31m%s():%d " format "\033[0m", __FUNCTION__, __LINE__, ##args);
+#define print_error(format, ...) \
+  printf("\033[0;31m%s():%d " format "\033[0m", \
+         __func__, __LINE__, ##__VA_ARGS__);
 
 /* a really generic way of spitting out analysis that isn't the important one
    in the test, used in the block test code.  Also, it is marked as
@@ -365,7 +366,7 @@ char passage[] = "This is tedious and lonely code. There is no salvation "
                  "in writing this code.";
 
 /* Print a spacer at the debug level */
-#define testbreak() printf("\n--- Line %d: %s() --- \n", __LINE__, __FUNCTION__);
+#define testbreak() printf("\n--- Line %d: %s() --- \n", __LINE__, __func__);
 
 /* a simple utility routine */
 void *


### PR DESCRIPTION
 * 922 warnings -> 699 warnings (during `g++ --pedantic`)
 * Removed all references to __WAIT_STATUS (obsolete)
 * Removed testJava()from dmtcp_launch.cpp (This was buggy, anyway.  And the new PR #1260 (handle unallocated pages, such as for Java) makes the special case of Java unnecessary.)

[ Each fix is local (usually just one line).  This should be easy to review.  The number of lines of code to review is small.  It's only when compiling with -pedantic that some warnings are repeated many times. ]

[ There are more warnings that could be removed later.  These were the low-hanging "easy" ones. ]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility by removing compile-time dependence on `__WAIT_STATUS` and standardizing `wait`/`wait3`/`wait4` status handling to use `int*` across wrappers.
  * Corrected startup warning behavior to use the Matlab-specific check instead of the Java one.
* **Style**
  * Updated debug/error output to use `__func__` and modernized variadic macro signatures for consistent logging.
* **Chores**
  * Refreshed generated configuration templates and improved page-size reporting during configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->