### PR TITLE
Handle thread stack guard page in glibc >= 2.42

### DIFF
--- a/src/threadinfo.h
+++ b/src/threadinfo.h
@@ -88,6 +88,14 @@ struct Thread {
 
   uint32_t wrapperLockCount;
 
+  // Lightweight stack guard region installed by glibc >= 2.42 at the low end
+  // of the thread's stack via madvise(MADV_GUARD_INSTALL). Recorded when the
+  // thread is created so that the checkpoint thread can temporarily remove it
+  // while writing the checkpoint image and reinstall it afterward and on
+  // restart. guardSize == 0 means no guard region is tracked for this thread.
+  void *guardAddr;
+  size_t guardSize;
+
   Thread *next;
   Thread *prev;
 };

--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -2,6 +2,7 @@
 #include <pthread.h>
 #include <semaphore.h>
 #include <signal.h>
+#include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
@@ -269,6 +270,8 @@ ThreadList::prepareThread(Thread *th, void *(*fn)(void *), void *arg)
   th->exiting = 0;
   th->wrapperLockCount = 0;
   th->procname[0] = '\0';
+  th->guardAddr = NULL;
+  th->guardSize = 0;
 }
 
 /*****************************************************************************
@@ -309,6 +312,36 @@ ThreadList::initThread(Thread *th)
   ThreadList::addToActiveList(th);
 }
 
+// The lightweight stack guard regions that glibc >= 2.42 installs at the low end
+// of each thread's stack (recorded in the pthread_create wrapper) read as
+// occupied memory and fault when accessed. removeStackGuards() clears them so
+// the checkpoint memory scan can read every stack page; restoreStackGuards()
+// puts them back afterward, and on restart, keeping stack-overflow protection
+// during normal execution.
+//
+// The MADV_GUARD_* macros only exist on glibc >= 2.42, so they appear only
+// inside this guard; older glibc gets no-op stubs. Keep the condition in sync
+// with the one in the pthread_create wrapper, which records guardAddr/guardSize.
+#if defined(MADV_GUARD_INSTALL) && defined(MADV_GUARD_REMOVE)
+static void
+madviseStackGuards(int advice)
+{
+  for (Thread *thread = activeThreads; thread != NULL; thread = thread->next) {
+    if (thread->guardSize > 0) {
+      WARN_ERRNO(madvise(thread->guardAddr, thread->guardSize, advice) == 0,
+                 "failed to update lightweight stack guard region: "
+                 "tid={} addr={} size={} advice={}",
+                 thread->tid, thread->guardAddr, thread->guardSize, advice);
+    }
+  }
+}
+static void removeStackGuards()  { madviseStackGuards(MADV_GUARD_REMOVE); }
+static void restoreStackGuards() { madviseStackGuards(MADV_GUARD_INSTALL); }
+#else
+static void removeStackGuards()  {}
+static void restoreStackGuards() {}
+#endif // if defined(MADV_GUARD_INSTALL) && defined(MADV_GUARD_REMOVE)
+
 /*************************************************************************
  *
  *  Write checkpoint image
@@ -335,7 +368,13 @@ ThreadList::writeCkpt()
   // const ssize_t pagesize = Util::pageSize();
   // ASSERT_EQ(sizeof(header) % pagesize, 0ul);
 
+  // Remove the lightweight stack guard regions so writeCkptImage() can process
+  // every stack page without faulting; reinstall them afterward so this
+  // (checkpointing) process keeps its guard protection while it continues. The
+  // restarted process reinstalls them separately in postRestartWork().
+  removeStackGuards();
   CkptSerializer::writeCkptImage(header, ckptFilename);
+  restoreStackGuards();
 }
 
 /*************************************************************************
@@ -817,6 +856,11 @@ ThreadList::postRestartWork()
   SharedData::postRestart();
 
   restoreInProgress = true;
+
+  // The checkpoint image was written with the lightweight stack guard regions
+  // removed (see writeCkpt()). Reinstall them now that memory has been restored
+  // at its original addresses, before the threads are recreated on their stacks.
+  restoreStackGuards();
 
   Util::allowGdbDebug(DEBUG_POST_RESTART);
 

--- a/src/threadwrappers.cpp
+++ b/src/threadwrappers.cpp
@@ -19,6 +19,7 @@
  *  <http://www.gnu.org/licenses/>.                                         *
  ****************************************************************************/
 
+#include <sys/param.h> // for EXEC_PAGESIZE
 #include <sys/syscall.h>
 #include "../jalib/jalloc.h"
 #include "constants.h"
@@ -130,25 +131,43 @@ pthread_create(pthread_t *pth,
 
   if (retval == 0) {
     ProcessInfo::instance().clearPthreadJoinState(*pth);
-    // Since glibc 2.42, pthread_create adds a lightweight guard page
-    // at the beginning of the new thread's stack using madvise() and
-    // MADV_GUARD_INSTALL. DMTCP may reads from this guard page and
-    // cause a segfault. As a quick fix, we remove the guard page
-    // immediately.
+    // Since glibc 2.42, pthread_create installs a lightweight guard region at
+    // the low end of the new thread's stack via madvise(MADV_GUARD_INSTALL).
+    // The checkpoint memory scan would classify these guard pages as occupied
+    // and fault while reading them. Record the guard region here so the
+    // checkpoint thread can temporarily remove it while writing the checkpoint
+    // image and reinstall it afterward (see ThreadList::writeCkpt() and
+    // ThreadList::postRestartWork()).
     //
-    // FIXME: A better solution will be keep a record or added
-    // lightweight guard page. Remove them at checkpoint time and
-    // restore them at restart time.
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ >= 42
+    // glibc places the guard immediately below the lowest usable stack byte, so
+    // the region is [stack_addr - guardSize, stack_addr). guardSize is the
+    // configured guard (pthread_attr_getguardsize(), rounded up to the page
+    // size), floored at EXEC_PAGESIZE: glibc enforces that floor so the guard is
+    // at least one page under any supported kernel page size. On aarch64
+    // EXEC_PAGESIZE is 64 KB (vs. a 4 KB runtime page), so the guard is 64 KB
+    // there even though getguardsize() reports 4 KB. This reproduces glibc's own
+    // sizing exactly, giving the precise per-thread region independent of how
+    // the kernel lays out or merges stack VMAs.
+    //
+    // The MADV_GUARD_* macros (and the lightweight guard they compensate for)
+    // both appeared in glibc 2.42. Keep this condition in sync with the one in
+    // ThreadList::updateStackGuards(), which removes/reinstalls the region.
+#if defined(MADV_GUARD_INSTALL) && defined(MADV_GUARD_REMOVE)
     pthread_attr_t new_attr;
     void *stack_addr;
     size_t stack_size, guard_size;
     pthread_getattr_np(*pth, &new_attr);
     pthread_attr_getstack(&new_attr, &stack_addr, &stack_size);
     pthread_attr_getguardsize(&new_attr, &guard_size);
-    madvise((void*)((char*)stack_addr - guard_size), guard_size,
-            MADV_GUARD_REMOVE);
     pthread_attr_destroy(&new_attr);
+
+    size_t pageSize = sysconf(_SC_PAGESIZE);
+    guard_size = (guard_size + pageSize - 1) & ~(pageSize - 1);
+    if (guard_size < (size_t) EXEC_PAGESIZE) {
+      guard_size = EXEC_PAGESIZE;
+    }
+    newThread->guardAddr = (char *)stack_addr - guard_size;
+    newThread->guardSize = guard_size;
 #endif
   } else { // if we failed to create new pthread
     ThreadSync::wrapperExecutionLockUnlockForNewThread(newThread);


### PR DESCRIPTION
Previously, PR https://github.com/dmtcp/dmtcp/pull/1234 tried to solve this problem introduced in glibc 2.42. The old fix has two issues:
1. Completely removes the guard page for all thread stacks. Therefore, permanently disables stack-overflow protection for every thread.
2. The "guard_size" returned from the function `pthread_attr_getguardsize()` may not reflect the correct guard page size. On some 64-bit ARM machines, the actual guard page is 64K, but the function still returns 4k.

This PR fixed both problems.
1. This PR only remove the guard page at checkpoint and will restore the guard page after restart or resume.
2. This PR uses max of guard page size and EXEC_PAGESIZE to determine the actual guard page size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint and restart reliability by properly managing per-thread lightweight stack guard regions during checkpoint writes and restart.
  * Prevented memory scanning from faulting on protected guard pages while creating checkpoints.
  * Reinstalled stack guard protection before threads resume after restart.
* **New Features**
  * Added automatic tracking of lightweight per-thread stack guard metadata on supported glibc versions for safer, more accurate guard handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->