### PR TITLE
Fixed harness test with Python 3.13+

### DIFF
--- a/test/autotest.py
+++ b/test/autotest.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+import sys
+
+if sys.version_info < (3, 7):
+    print("Skipping autotest; Python 3.7+ is required.", flush=True)
+    sys.exit(0)
+
 import argparse
 import concurrent.futures
 from collections import Counter
@@ -12,7 +18,6 @@ import shlex
 import shutil
 import signal
 import subprocess
-import sys
 import tempfile
 import threading
 import time
@@ -21,10 +26,6 @@ from random import sample
 from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import autotest_config
-
-if sys.version_info < (3, 7):
-    print("Skipping autotest; Python 3.7+ is required.", flush=True)
-    sys.exit(0)
 
 from dataclasses import dataclass, field, replace
 

--- a/test/autotest_test.py
+++ b/test/autotest_test.py
@@ -1628,7 +1628,7 @@ class DmtcpTestHarnessUnitTest(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertIn("No tests selected", result.stderr)
 
-    def test_autotest_skips_before_python37(self):
+    def test_if_autotest_skips_before_python37(self):
         with tempfile.TemporaryDirectory() as tempdir:
             temp_path = pathlib.Path(tempdir)
             (temp_path / "sitecustomize.py").write_text(


### PR DESCRIPTION
PR https://github.com/dmtcp/dmtcp/pull/1264 creates a bug with Python 3.13+.

On Python 3.13+, importing concurrent.futures transitively imports dataclasses (via _colorize -> traceback -> logging -> concurrent.futures._base). When simulating Python 3.6 via a fake sitecustomize.py (which overrides sys.version_info and provides a dummy dataclasses.py that raises ModuleNotFoundError), the script crashes at `import concurrent.futures` before the version check on line 25 is ever reached. Moving the version check (which only needs sys) to the very top ensures it runs before any module resolution can hit the fake dataclasses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved startup checks to fail faster with a clear message when Python 3.7 or newer isn’t being used.
  * Removed a redundant duplicate import and consolidated version validation for cleaner execution.
* **Tests**
  * Updated the relevant unit test name to better reflect its behavior around skipping when Python is below 3.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->