### PR TITLE
Avoid recreating pre-existing pipe fds on restart

### DIFF
--- a/plugin/cuda/cuda-ckpt.cpp
+++ b/plugin/cuda/cuda-ckpt.cpp
@@ -112,14 +112,25 @@ int recreate_pipes(pipe_info_t *pipe_fd_array, int num_fds) {
   pipe_map_t pipe_map[MAX_PIPE_FDS] = {0};
   int map_count = 0;
 
-  // Reserve sites for the original pipes; new pipes will land elsewhere.
+  // Placeholder fd used to reserve the original pipe fd sites.
   int fd_unique = open("/dev/zero", O_RDONLY);
+
+  // inspect_pipes() records every pipe fd present at checkpoint, including
+  // pipes owned by other subsystems (e.g. MPI/Hydra PMI pipes and DMTCP's own
+  // pipes) that DMTCP re-creates on restart.  Those fds are already occupied
+  // here; the CUDA driver's own pipes are the ones DMTCP does not restore, so
+  // their fd numbers are still free.  Keep only those free, CUDA-owned pipes
+  // and reserve their fd sites; new pipes will land elsewhere.
+  int kept = 0;
   for (int i = 0; i < num_fds; i++) {
     int fd = pipe_fd_array[i].fd;
-    // Assert no pre-existing fd at site of old fds
-    JASSERT(fd == fd_unique || fcntl(fd, F_GETFD) == -1);
-    dup2(fd_unique, fd); // Occupy fd; Close it later.
+    if (fd != fd_unique && fcntl(fd, F_GETFD) != -1) {
+      continue; // occupied by another subsystem's restored pipe; not ours
+    }
+    pipe_fd_array[kept++] = pipe_fd_array[i];
+    dup2(fd_unique, fd); // Occupy fd; close it later.
   }
+  num_fds = kept;
 
   // Create a new pipe_map with the original pipes
   for (int i = 0; i < num_fds; i++) {

--- a/plugin/cuda/cuda-ckpt.cpp
+++ b/plugin/cuda/cuda-ckpt.cpp
@@ -56,6 +56,10 @@ int cuda_initialized = 0;
 pipe_info_t pipe_list[MAX_PIPE_FDS] = {0};
 int num_fds_found;
 
+// FIXME: In DMTCP 5.0, we will stop promoting pipes to socket. Then pipes
+// created by CUDA will be handled properly, and we don't need to save
+// and restore pipes in this plugin.
+//
 // The main inspection function
 int inspect_pipes(pipe_info_t *pipe_fd_array, int max_pipe_fds) {
   // ... (content of inspect_pipes function from previous response) ...

--- a/plugin/cuda/test/Makefile
+++ b/plugin/cuda/test/Makefile
@@ -1,0 +1,20 @@
+CC=gcc
+CXX=g++
+
+FILES=counter
+
+default: counter
+
+counter: counter.cu
+	nvcc -g -O0 -o $@ $^ -cudart=shared
+
+tidy:
+	rm -f *~ .*.swp dmtcp_restart_script*.sh ckpt_*.dmtcp
+
+clean: tidy
+	rm -f $(FILES)
+
+distclean: clean
+	rm -f dmtcp_restart_script*.sh ckpt_*.dmtcp
+
+.PHONY: default tidy clean distclean


### PR DESCRIPTION
Libraries like Hydra create pipes that are not saved or recreated by DMTCP. When recreating pipes for CUDA at restart, avoid recreating these pre-existing pipes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA checkpoint/restore behavior so saved file descriptor slots are restored more safely when other components already use some of them.
  * Reduced the chance of restart failures caused by file descriptor conflicts.

* **Tests**
  * Added build support for a CUDA test target to help validate checkpoint/restore behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->