### PR TITLE
Fix compiler warnings surfaced by --enable-debug (-Wall)

### DIFF
--- a/src/dmtcp_dlsym.cpp
+++ b/src/dmtcp_dlsym.cpp
@@ -177,7 +177,7 @@ static Elf32_Word
 hash_next(Elf32_Word index, Elf32_Word *hash_table, int use_gnu_hash)
 {
   if (use_gnu_hash) {
-    ASSERT_GT(index, STN_UNDEF);
+    ASSERT_GT(index, (Elf32_Word)STN_UNDEF);
     uint32_t nbuckets = ((uint32_t *)hash_table)[0];
     uint32_t symndx = ((uint32_t *)hash_table)[1];
     uint32_t maskwords = ((uint32_t *)hash_table)[2];

--- a/src/dmtcpworker.cpp
+++ b/src/dmtcpworker.cpp
@@ -210,6 +210,8 @@ dmtcp_initialize()
 // be called before dmtcp_initialize_entry_point.
 // Note that 1-100 are reserved for implementation, but we are okay since this
 // function is only enabled for debugging.
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wprio-ctor-dtor"
 extern "C" void __attribute__((constructor(100)))
 dmtcp_initialize_entry_point_test()
 {
@@ -217,6 +219,7 @@ dmtcp_initialize_entry_point_test()
   pthread_t thread = pthread_self();
   pthread_getaffinity_np(thread, sizeof(cpu_set_t), &cpuset);
 }
+# pragma GCC diagnostic pop
 #endif
 
 // Initialize remaining components.

--- a/src/plugin/file/fileconnection.h
+++ b/src/plugin/file/fileconnection.h
@@ -91,8 +91,8 @@ class FileConnection : public Connection
                    int type = FILE_REGULAR)
       : Connection(type)
       , _path(path)
-      , _mode(mode)
-      , _fileAlreadyExists(false) {}
+      , _fileAlreadyExists(false)
+      , _mode(mode) {}
 
     virtual void doLocking() override;
     virtual void drain() override;

--- a/src/plugin/socket/kernelbufferdrainer.cpp
+++ b/src/plugin/socket/kernelbufferdrainer.cpp
@@ -290,7 +290,7 @@ KernelBufferDrainer::beginDrainOf(int fd, const ConnectionIdentifier &id, int ba
                                    sizeof theMagicDrainCookie));
 
   // now setup a reader:
-  if (_isSeqpacket[fd] = (baseType == SOCK_SEQPACKET)) {
+  if ((_isSeqpacket[fd] = (baseType == SOCK_SEQPACKET))) {
     addDataSocket(new JSeqpacketReader(fd));
   } else {
     addDataSocket(new jalib::JChunkReader(fd, 512));

--- a/src/plugin/timer/timerwrappers.cpp
+++ b/src/plugin/timer/timerwrappers.cpp
@@ -184,9 +184,14 @@ pthread_getcpuclockid(pthread_t thread, clockid_t *clock_id)
   // We need to acquire an exclusive lock here because the corresponding Pid
   // plugin wrapper requires an exclusive lock.
   WrapperLockExcl wrapperLock;
+  // glibc declares clock_id as __nonnull, but we defensively guard against
+  // callers that violate that contract anyway.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull-compare"
   if (clock_id == NULL) {
     return _real_pthread_getcpuclockid(thread, clock_id);
   }
+#pragma GCC diagnostic pop
   clockid_t realId;
   int ret = _real_pthread_getcpuclockid(thread, &realId);
   if (ret == 0) {

--- a/src/threadsync.cpp
+++ b/src/threadsync.cpp
@@ -278,7 +278,7 @@ ThreadSync::wrapperExecutionLockUnlock()
 
   Thread *thread = dmtcp_get_current_thread();
 
-  ASSERT_NE(0,
+  ASSERT_NE(0u,
             thread->wrapperLockCount,
             "wrapper execution lock unlock without matching lock: tid={}",
             thread->tid);

--- a/src/threadwrappers.cpp
+++ b/src/threadwrappers.cpp
@@ -54,7 +54,7 @@ static void
 processChildThread(Thread *thread)
 {
   dmtcp_init_virtual_tid();
-  ASSERT_NE(0,
+  ASSERT_NE(0u,
             thread->wrapperLockCount,
             "child thread entered without inherited wrapper lock: tid={}",
             thread->tid);
@@ -113,7 +113,7 @@ pthread_create(pthread_t *pth,
 
   Thread *newThread = ThreadList::getNewThread(start_routine, arg);
   ThreadSync::wrapperExecutionLockLockForNewThread(newThread);
-  ASSERT_NE(0,
+  ASSERT_NE(0u,
             newThread->wrapperLockCount,
             "new thread wrapper lock was not pre-acquired: tid={}",
             newThread->tid);

--- a/test/file3.c
+++ b/test/file3.c
@@ -25,7 +25,6 @@ main()
   int dmtcpEnabled = dmtcp_is_enabled();
   uint32_t generation = 0;
   int renamedAfterCkpt = 0;
-  int sawRecreatedFile = 0;
 
   char *dir = getenv("DMTCP_TMPDIR");
 
@@ -87,7 +86,6 @@ main()
     if (renamedAfterCkpt) {
       rc = stat(filename, &statbuf);
       if (rc == 0) {
-        sawRecreatedFile = 1;
         if ((statbuf.st_mode & 07000) != 0 ||
             (statbuf.st_mode & 0777) != EXPECTED_MODE) {
           abort();

--- a/test/syscall-tester.c
+++ b/test/syscall-tester.c
@@ -3781,7 +3781,6 @@ int BasicCloseRange(void)
   char tf3[NAMEBUF] = { 0 };
   int tmpfd1, tmpfd2, tmpfd3;
   int fd1, fd2, fd3;
-  int fd_before_protected, fd_after_protected;
   int passed;
   int block = SUCCESS;
   int flags;


### PR DESCRIPTION
Plain `./configure && make` already builds warning-free, but --enable-debug
(-Wall) turns up several warnings across src/ and test/. This fixes all of
them:

- Sign-compare mismatches (int vs unsigned) in assertion macros and an ELF
  constant
- Constructor initialization order not matching member declaration order
- Intentional assignment-in-condition flagged as likely ==/= typo
- Two cases of legitimate defensive code tripping stricter compiler
  assumptions (reserved constructor priority, nonnull-annotated parameter),
  suppressed locally via pragma since the behavior is intentional
- Dead/unused variables in two test files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type-safe checks and assertion handling in several internal code paths.
  * Added a safer null-pointer guard in a clock-related wrapper while keeping behavior unchanged.
  * Reduced compiler warnings in debug builds and other warning-prone areas.
* **Tests**
  * Cleaned up test code by removing unused variables and simplifying state handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->