### PR TITLE
Fix motherofall race: main thread creates it, others wait for it

### DIFF
--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -117,8 +117,18 @@ dmtcp_get_current_thread()
     return curThread;
   }
 
-  ASSERT_NULL(motherofall);
-  ThreadList::init();
+  if (_real_gettid() == _real_getpid()) {
+    // We are the main thread of the process: create motherofall.
+    ASSERT_NULL(motherofall);
+    ThreadList::init();
+  } else {
+    // Another constructor may have created its own thread, racing to call
+    // ThreadList::init() first. We want the main thread of the process to
+    // win that race. So wait for it here instead.
+    while (__atomic_load_n(&motherofall, __ATOMIC_ACQUIRE) == nullptr) {
+    }
+    ThreadList::initThread(ThreadList::getNewThread(NULL, NULL));
+  }
 
   ASSERT_NOT_NULL(curThread);
   return curThread;
@@ -192,10 +202,12 @@ ThreadList::init()
   if (motherofall == nullptr) {
     // We need to use static storage for motherofall to avoid calling
     // JALLOC_MALLOC during initialization which could lead to infinite recursion.
-    motherofall = &motherofallStorage;
-    prepareThread(motherofall, NULL, NULL);
+    Thread *th = &motherofallStorage;
+    prepareThread(th, NULL, NULL);
     /* Set up caller as one of our threads so we can work on it */
-    initThread(motherofall);
+    initThread(th);
+    // Publish last (release), so a waiting thread sees it fully initialized.
+    __atomic_store_n(&motherofall, th, __ATOMIC_RELEASE);
   }
 
   /* Save this process's pid.  Then verify that the TLS has it where it should


### PR DESCRIPTION
*This hardens the code for the creation of motherofall.  For ThreadSanitizer (and others), their constructor can create a helper thread that lands as mother of all before the main thread (tid == pid) can land.  We need the main thread to be motherofall.*

dmtcp_get_current_thread()'s lazy first-call path assumed the very first DMTCP-intercepted call in the whole process always happens on the real main thread, and asserted motherofall was still null on that basis. That's false whenever some other thread (e.g. a runtime's early background thread, started before main() runs) makes a DMTCP-intercepted call first: it hits this same "first call" branch on its own (curThread is per-thread), while motherofall may already be set (or being set) by the real main thread.

Fix by checking thread identity directly (tid == pid) instead of inferring it from call order: the real main thread creates motherofall; any other thread waits (plain atomic spin -- no libc call, since this can run before that early background thread's own constructor has finished) until motherofall exists, then registers itself as an ordinary thread. motherofall is published with release semantics only after its Thread struct is fully initialized, so a waiting thread never observes a partially set-up motherofall.

----
*Here's a more in-depth explanation of how this bug can occur.*

I'll describe the issue here.  TSAN and DMTCP both have constructors, helper threads, and interpositions on pthread_create, malloc, and more.  TSAN is first in LD_PRELOAD order, due to compiling with DT_NEED.  So, TSAN can create its own thread first.  (If I remember, DMTCP is halfway through creating the DMTCP checkpoint thread.  But that triggers an interceptor of TSAN.  TSAN sees that someone is trying to create a new thread.  So, TSAN decides to create its own thread _first_ to inspect what's going on with the "user" thread (the DMTCP ckpt thread in this case).  But when TSAN tries to create its own helper thread, that also gets caught by ThreadList:init().  So, now it's a race to see who will reach ThreadList:init() first.  Whoever reaches it first is then labeled as motherofall by DTMCP.

If the TSAN helper thread is labeled as motherofall, then that's a disaster.  That's because the TSAN helper thread is intermittent.  It's created by an interposer when something interesting happens, and then it joins back to the parent when the TSAN thread is done with its work.

----

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread startup handling to make concurrent initialization more reliable.
  - Reduced a race condition that could cause non-main threads to see thread state before it was fully ready.
  - Main-thread and background-thread initialization now follow a safer, more consistent order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->