### PR TITLE
mtcp_restart: fix stale stack-unmap snapshot; use MAP_NORESERVE; print addr conflicts on restart

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -204,7 +204,11 @@ tests-32: build
 #  and modifies most of the zero-mapped pages -- using 16 MB)
 # JDK Runtime Environment (Java/IcedTea6 1.12.4 (OpenJDK, Java 1.6.0_27)
 #   now needs at least 32 MB  (June, 2013)
-LIMIT=ulimit -v 33554432
+# -S (soft limit only): leaves the hard limit untouched, so autotest.py can
+# still raise the soft limit back up for a test that needs it (see
+# TestSpec.needs_max_address_space, e.g. the mmap-noreserve test, which
+# mmaps a region far larger than 32MB).
+LIMIT=ulimit -S -v 33554432
 
 check: tests
 	@cd test && $(MAKE) --no-print-directory check-prereqs

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -1,6 +1,6 @@
 /*****************************************************************************
  * Copyright (C) 2014 Kapil Arya <kapil@ccs.neu.edu>                         *
- * Copyright (C) 2014 Gene Cooperman <gene@ccs.neu.edu>                      *
+ * Copyright (C) 2014,2026 Gene Cooperman <gene@ccs.neu.edu>                 *
  *                                                                           *
  * DMTCP is free software: you can redistribute it and/or                    *
  * modify it under the terms of the GNU Lesser General Public License as     *

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -77,6 +77,18 @@ static void mmapfile(RestoreInfo *rinfo, int fd, void *buf, size_t size,
  */
 #define STACKSIZE 4 * 1024 * 1024
 
+// A restored anonymous region gets MAP_NORESERVE only if its size is at
+// least this many bytes (see read_one_memory_area()).  TSAN's and Java's
+// shadow/meta mappings run into the multiple-terabytes range; ordinary
+// anonymous regions (heap, stack, etc.) are far below this threshold.  The
+// threshold is much smaller on 32-bit targets, whose entire user address
+// space is only a few GiB.
+#if defined(__i386__) || defined(__arm__)
+# define MAP_NORESERVE_SIZE_THRESHOLD (10ULL * 1024 * 1024)  // 10 MiB
+#else
+# define MAP_NORESERVE_SIZE_THRESHOLD (1ULL * 1024 * 1024 * 1024)  // 1 GiB
+#endif
+
 static RestoreInfo rinfo;
 
 /* Internal routines */
@@ -925,7 +937,16 @@ read_one_memory_area(RestoreInfo *rinfo, int fd, VA endOfStack)
     if ((area.properties & DMTCP_ZERO_PAGE_CHILD_HEADER) == 0) {
       // MMAP only if it's not a child header.
       imagefd = -1;
-      if (area.name[0] == '/') { /* If not null string, not [stack] or [vdso] */
+      // Skip reopening the backing file for a region already converted to
+      // MAP_ANONYMOUS above (originally MAP_SHARED): area.name may still be
+      // a real, still-existing path (only area.flags was rewritten), and
+      // reopening it here would leave imagefd >= 0 for a region we've
+      // already decided is anonymous. area.name itself must stay intact:
+      // the mmapFileSize-based partial-read decision below also keys off
+      // area.name[0] == '/', and clearing it would desync the checkpoint
+      // file stream for regions with a small mmapFileSize.
+      if (area.name[0] == '/' && !(area.flags & MAP_ANONYMOUS)) {
+        /* If not null string, not [stack] or [vdso] */
         imagefd = mtcp_sys_open(area.name, O_RDONLY, 0);
         if (imagefd >= 0) {
           /* If the current file size is smaller than the original, we map the region
@@ -967,10 +988,35 @@ read_one_memory_area(RestoreInfo *rinfo, int fd, VA endOfStack)
       * are valid.  Can we unmap vdso and vsyscall in Linux?  Used to use
       * mtcp_safemmap here to check for address conflicts.
       */
+      int mmapFlags = area.flags;
+      if (area.flags & MAP_ANONYMOUS) {
+        /* Programs/tools like Java and ThreadSanitizer reserve enormous
+         * sparse regions (their shadow/meta mappings can span multiple
+         * terabytes) with MAP_ANONYMOUS|MAP_NORESERVE.  Such a
+         * zero-initialized region is sometimes called anonymous pages (or
+         * non-resident, or unallocated).  The _only_ reason to add
+         * MAP_NORESERVE is to overcome any limits on memory overcommit
+         * (e.g., Committed_AS) by the kernel.  But they will still be
+         * anonymous (non-resident) pages in both cases.  (See
+         * /proc/meminfo, with CommitLimit and Committed_AS fields.)
+         * Only add MAP_NORESERVE if the region is large enough to
+         * plausibly threaten the overcommit limit on its own (e.g., TSAN's
+         * or Java's multi-terabyte shadow/meta mappings); ordinary
+         * anonymous regions keep the kernel's normal overcommit accounting.
+         * FIXME: We could have read /proc/self/smaps to test if the nr
+         * (noreserve) attribute is listed under VmFlags.  If so, we would
+         * set an additional area.flags for it, and use MAP_NORESERVE here
+         * only if nr was seen.
+         */
+        if ((uint64_t) area.size >= MAP_NORESERVE_SIZE_THRESHOLD) {
+          mmapFlags |= MAP_NORESERVE;
+        }
+        MTCP_ASSERT(imagefd == -1);  // anonymous memory region
+      }
       mmappedat =
         mmap_fixed_noreplace(rinfo, area.addr, area.size,
                             area.prot | PROT_WRITE,
-                            area.flags, imagefd, area.offset);
+                            mmapFlags, imagefd, area.offset);
 
       MTCP_ASSERT(mmappedat == area.addr);
 

--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -99,6 +99,8 @@ static void restore_vdso_vvar(RestoreInfo *rinfo);
 static void compute_regions_to_munmap(RestoreInfo *rinfo);
 static void refreshRegionsToMunmap(RestoreInfo *rinfo);
 static void validateRestoreBufferLocation(RestoreInfo *rinfo);
+static void reserveUnusedRestoreBufSpace(RestoreInfo *rinfo,
+                                         uint64_t origStart, uint64_t origEnd);
 
 // const char service_interp[] __attribute__((section(".interp"))) =
 // "/lib64/ld-linux-x86-64.so.2";
@@ -262,6 +264,9 @@ mtcp_restart_process_args(int argc, char *argv[], char **environ, void (*restore
     mtcp_sys_exit(0);
   }
 
+  uint64_t restoreBufOrigStart = rinfo.ckptHdr.restoreBuf.startAddr;
+  uint64_t restoreBufOrigEnd = rinfo.ckptHdr.restoreBuf.endAddr;
+
   validateRestoreBufferLocation(&rinfo);
 
   compute_regions_to_munmap(&rinfo);
@@ -269,6 +274,15 @@ mtcp_restart_process_args(int argc, char *argv[], char **environ, void (*restore
   /* For __arm__ and __aarch64__ will need to invalidate cache after this.
    */
   remapExistingAreasToReservedArea(&rinfo, restore_func);
+
+  // validateRestoreBufferLocation() above narrowed rinfo.ckptHdr.restoreBuf
+  // down to whichever third of the original reservation mtcp_restart could
+  // safely relocate into, silently freeing the other two thirds back to the
+  // kernel. Reclaim that freed space now (as PROT_NONE, matching its
+  // pre-restart state) so nothing else (e.g., a TSAN interceptor) can claim
+  // it before the restored process's own ProcessInfo::restart() rebuilds
+  // the full reservation.
+  reserveUnusedRestoreBufSpace(&rinfo, restoreBufOrigStart, restoreBufOrigEnd);
 
   // Copy over old stack to new location;
   mtcp_memcpy(rinfo.new_stack_addr, rinfo.old_stack_addr, rinfo.old_stack_size);
@@ -389,6 +403,75 @@ validateRestoreBufferLocation(RestoreInfo *rinfo)
   rinfo->ckptHdr.restoreBuf = restoreBuf;
 
   mtcp_sys_close(mapsfd);
+}
+
+// mtcp_restart's own footprint within a 90MB restoreBuf third (relocated
+// text/data/bss/stack, at most vdso/vvar) is a handful of mappings; this
+// bounds the fixed buffer reserveUnusedRestoreBufSpace() reads them into.
+#define MAX_RESTOREBUF_AREAS 32
+
+// Re-scan /proc/self/maps over the original, un-narrowed restoreBuf range and
+// re-mmap (PROT_NONE) every gap that isn't already occupied by mtcp_restart's
+// own (now-relocated) regions, vdso/vvar, or its stack. Called after
+// remapExistingAreasToReservedArea() so the chosen third's real mappings are
+// already in place and are naturally skipped, rather than re-reserved.
+NO_OPTIMIZE
+static void
+reserveUnusedRestoreBufSpace(RestoreInfo *rinfo,
+                             uint64_t origStart, uint64_t origEnd)
+{
+  int mtcp_sys_errno;
+  int mapsfd = mtcp_sys_open2("/proc/self/maps", O_RDONLY);
+  MTCP_ASSERT (mapsfd >= 0);
+
+  // Buffer every overlapping area before creating any gap-fill mappings
+  // below: mutating our own VMA layout via mmap_fixed_noreplace() while
+  // /proc/self/maps is still being read line-by-line is fragile, since the
+  // kernel can merge/split adjacent VMAs between reads of that virtual
+  // file. A single read pass with no concurrent mutation avoids that.
+  // mtcp_restart will always have a small number of areas here, guaranteed
+  // to be less than MAX_RESTOREBUF_AREAS.
+  Area areas[MAX_RESTOREBUF_AREAS];
+  int numAreas = 0;
+  Area area;
+  while (mtcp_readmapsline(rinfo, mapsfd, &area)) {
+    uint64_t areaStart = (uint64_t) area.addr;
+    uint64_t areaEnd = (uint64_t) area.endAddr;
+    if (areaEnd <= origStart || areaStart >= origEnd) {
+      continue;
+    }
+    MTCP_ASSERT(numAreas < MAX_RESTOREBUF_AREAS);
+    areas[numAreas++] = area;
+  }
+  mtcp_sys_close(mapsfd);
+
+  uint64_t cursor = origStart;
+  for (int i = 0; i < numAreas; i++) {
+    if (cursor >= origEnd) {
+      break;
+    }
+
+    uint64_t areaStart = (uint64_t) areas[i].addr;
+    uint64_t areaEnd = (uint64_t) areas[i].endAddr;
+    if (areaEnd <= cursor) {
+      continue;
+    }
+    if (areaStart > cursor) {
+      void *addr = mmap_fixed_noreplace(rinfo, (VA) cursor, areaStart - cursor,
+                                        PROT_NONE,
+                                        MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+      MTCP_ASSERT(addr != MAP_FAILED);
+    }
+    if (areaEnd > cursor) {
+      cursor = areaEnd;
+    }
+  }
+  if (cursor < origEnd) {
+    void *addr = mmap_fixed_noreplace(rinfo, (VA) cursor, origEnd - cursor,
+                                      PROT_NONE,
+                                      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    MTCP_ASSERT(addr != MAP_FAILED);
+  }
 }
 
 NO_OPTIMIZE

--- a/src/mtcp/mtcp_util.c
+++ b/src/mtcp/mtcp_util.c
@@ -866,6 +866,30 @@ int mtcp_parse_dprintf_env(char **environ)
          (mtcp_strcmp(logLevel, "trace") == 0 ||
           mtcp_strcmp(logLevel, "3") == 0);
 }
+// Scan /proc/self/maps and print every region overlapping [addr, addr+len),
+// to diagnose an unexpected address collision (e.g. EEXIST from
+// mmap_fixed_noreplace() below).  Best-effort: only called on an already-
+// failing path, so a failure here just skips the extra diagnostics.
+static void
+printOverlappingAreas(RestoreInfo *rinfo, void *addr, size_t len)
+{
+  int mtcp_sys_errno;
+  VA rangeStart = (VA) addr;
+  VA rangeEnd = (VA) addr + len;
+  int mapsfd = mtcp_sys_open("/proc/self/maps", O_RDONLY, 0);
+  if (mapsfd == -1) {
+    return;
+  }
+  Area area;
+  while (mtcp_readmapsline(rinfo, mapsfd, &area)) {
+    if (area.endAddr > rangeStart && area.addr < rangeEnd) {
+      MTCP_PRINTF("  colliding with existing region: %p-%p prot: %p"
+                  " flags: %p name: %s\n",
+                  area.addr, area.endAddr, area.prot, area.flags, area.name);
+    }
+  }
+  mtcp_sys_close(mapsfd);
+}
 
 // This emulates MAP_FIXED_NOREPLACE, which became available only in Linux 4.17
 // FIXME:  This assume that addr is a multiple of PAGESIZE.  We should
@@ -892,12 +916,16 @@ void* mmap_fixed_noreplace(RestoreInfo *rinfo, void *addr, size_t len,
   } else if (addr2 != MAP_FAILED) {
     // undo the mmap
     MTCP_PRINTF("error mapping %p bytes at %p; mapped at %p instead\n", len, addr, addr2);
+    printOverlappingAreas(rinfo, addr, len);
     mtcp_sys_munmap(addr2, len);
     mtcp_sys_errno = EEXIST;
     return MAP_FAILED;
   } else {
     // the mmap really did fail
     MTCP_PRINTF("error %d mapping %p bytes at %p, flags: %p, prot :%p\n", mtcp_sys_errno, len, addr, flags, prot);
+    if (mtcp_sys_errno == EEXIST) {
+      printOverlappingAreas(rinfo, addr, len);
+    }
     return MAP_FAILED;
   }
 }

--- a/test/autotest-parity.md
+++ b/test/autotest-parity.md
@@ -96,6 +96,7 @@ or executable-path checks enable them.
 | `hellompich-n1`, `hellompich-n2`, `openmpi` | Configure-flag-gated and built-artifact-gated | MPI smoke tests require configure-discovered launchers and the built MPI test binary; `openmpi` keeps the old `[5, 6]` peer-count allowance. |
 | `java1` | Configure-flag-gated and required-file-gated | Requires both `HAS_JAVA`/`HAS_JAVAC` and the built `test/java1.class` artifact. |
 | `shared-memory3` | Ported, slow | This old-disabled test now passes two checkpoint/restart cycles on the current host. It keeps the old harness's `S=10*DEFAULT_S` checkpoint settle delay. |
+| `mmap-noreserve` | Ported with `cycles=2`, address-space-gated | Regression guard for restoring a huge `MAP_NORESERVE` anonymous region (`src/mtcp/mtcp_restart.c`, `MAP_NORESERVE_SIZE_THRESHOLD`), modeled on how ThreadSanitizer reserves its shadow/meta mappings. The registry's `needs_max_address_space` check skips it when `RLIMIT_AS` is finite and too low to hold the test's reservation. |
 
 Logging-specific limits:
 

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -14,6 +14,8 @@ import json
 import os
 import pathlib
 import pty
+import resource
+import select
 import shlex
 import shutil
 import signal
@@ -1761,6 +1763,49 @@ class TestRegistry:
         return list(dict.fromkeys(reasons))
 
     @classmethod
+    def _address_space_reason(cls) -> Optional[str]:
+        # Trial-run instead of duplicating mmap-noreserve.c's REGION_BYTES:
+        # it prints READY on success, or fails fast via perror("mmap").
+        binary = ROOT / "test" / "mmap-noreserve"
+        if not binary.exists():
+            return None  # _command_executable_reasons() will report this
+        try:
+            original = resource.getrlimit(resource.RLIMIT_AS)
+            resource.setrlimit(resource.RLIMIT_AS, (original[1], original[1]))
+        except (ValueError, OSError):
+            return None  # can't tell; let the test attempt to run
+        # Runs at import time with no outer timeout, so bound the wait: it
+        # stays alive after printing READY, so select() one line rather than
+        # waiting for exit, and always kill/reap it before restoring RLIMIT_AS.
+        proc = None
+        timed_out = False
+        try:
+            proc = subprocess.Popen([str(binary)], stdout=subprocess.PIPE,
+                                    stderr=subprocess.STDOUT, text=True)
+            readable, _, _ = select.select([proc.stdout], [], [], 10)
+            timed_out = not readable
+            line = proc.stdout.readline() if readable else ""
+            ready = line.strip() == "READY"
+        except OSError:
+            return None
+        finally:
+            if proc is not None:
+                proc.kill()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
+            try:
+                resource.setrlimit(resource.RLIMIT_AS, original)
+            except (ValueError, OSError):
+                pass
+        if timed_out:
+            return None  # probe inconclusive; let the test attempt to run
+        if ready:
+            return None
+        return "virt. mem. hard limit too small"
+
+    @classmethod
     def _categorize_tests(cls, tests: Iterable[TestSpec]) -> List[TestSpec]:
         return [
             replace(
@@ -1880,6 +1925,10 @@ class TestRegistry:
             TestSpec("stat", 1, ["./test/stat"]),
             TestSpec("mmap1", 1, ["./test/mmap1"]),
             TestSpec("mremap", 1, ["./test/mremap"]),
+            # Regression guard for restoring a huge MAP_NORESERVE anonymous
+            # region (src/mtcp/mtcp_restart.c, MAP_NORESERVE_SIZE_THRESHOLD),
+            # modeled on how ThreadSanitizer reserves its shadow/meta mappings.
+            TestSpec("mmap-noreserve", 1, ["./test/mmap-noreserve"]),
             TestSpec("gettimeofday", 1, ["./test/gettimeofday"]),
             TestSpec("sigchild", 1, ["./test/sigchild"]),
             TestSpec("rlimit-restore", 1, ["./test/rlimit-restore"]),

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -92,13 +92,10 @@ class DmtcpCommandJson:
                 "dmtcp_command JSON field type has been replaced by command")
         actual_command = payload.get("command")
         if actual_command != expected_command:
-            raise ValueError(
-                f"expected JSON command '{expected_command}', "
-                f"got {actual_command!r}"
-            )
+            raise ValueError(f"expected JSON command '{expected_command}', "
+                             f"got {actual_command!r}")
         if "phase" in payload:
-            raise ValueError(
-                "dmtcp_command JSON field phase is redundant")
+            raise ValueError("dmtcp_command JSON field phase is redundant")
         if "ok" in payload:
             raise ValueError("dmtcp_command JSON field ok is obsolete")
         command_status = payload.get("command_status")
@@ -108,14 +105,13 @@ class DmtcpCommandJson:
         if "coordinator_host" in payload:
             coordinator_host = payload.get("coordinator_host")
             if type(coordinator_host) is not str:
-                raise ValueError(
-                    "dmtcp_command JSON field coordinator_host must be a string")
+                raise ValueError("dmtcp_command JSON field coordinator_host "
+                                 "must be a string")
         if "coordinator_port" in payload:
             coordinator_port = payload.get("coordinator_port")
             if type(coordinator_port) is not int:
-                raise ValueError(
-                    "dmtcp_command JSON field coordinator_port must be an "
-                "integer")
+                raise ValueError("dmtcp_command JSON field coordinator_port "
+                                 "must be an integer")
 
     @classmethod
     def is_success(cls, payload: Dict[str, object]) -> bool:
@@ -540,8 +536,9 @@ class TestContext:
         for proc in self.processes:
             self._terminate_process_group(proc, f"worker {proc.pid}")
         if self.coordinator_proc is not None and self.coordinator_proc.poll() is None:
-            self._terminate_process_group(self.coordinator_proc,
-                                          f"coordinator {self.coordinator_proc.pid}")
+            self._terminate_process_group(
+                self.coordinator_proc,
+                f"coordinator {self.coordinator_proc.pid}")
         for path in self._created_private_env_paths:
             shutil.rmtree(path, ignore_errors=True)
 
@@ -645,9 +642,11 @@ class TestContext:
                     except ValueError:
                         pass
             if self.coordinator_proc is not None and self.coordinator_proc.poll() is not None:
-                raise HarnessFailure("coordinator", "coordinator exited before writing port")
+                raise HarnessFailure(
+                    "coordinator", "coordinator exited before writing port")
             time.sleep(0.05)
-        raise HarnessFailure("coordinator", "coordinator did not write port file")
+        raise HarnessFailure(
+            "coordinator", "coordinator did not write port file")
 
     def _launch_processes(self):
         for index, command in enumerate(self.spec.commands):
@@ -1004,7 +1003,8 @@ class TestContext:
             pass
 
     def _record_cleanup(self, message: str):
-        with (self.work.path / "cleanup.log").open("a", encoding="utf-8") as out:
+        with (self.work.path / "cleanup.log").open(
+                "a", encoding="utf-8") as out:
             out.write(message)
             out.write("\n")
 
@@ -2513,7 +2513,8 @@ class TestRegistry:
     def _has_all(values, required) -> bool:
         return all(value in values for value in required)
 
-    def select(self, names=None, tags=None, requirements=None) -> List[TestSpec]:
+    def select(self, names=None, tags=None,
+               requirements=None) -> List[TestSpec]:
         if names:
             tests = [self.get_test(name) for name in names]
         else:
@@ -3321,7 +3322,8 @@ def print_integration_list(selected: List[TestSpec]) -> int:
 def run_integration_tests(
         args, selected: List[TestSpec],
         show_suite_heading: bool,
-        name_width: int = RUN_TESTNAME_WIDTH) -> Tuple[int, int, List[FailureRecord]]:
+        name_width: int = RUN_TESTNAME_WIDTH) -> Tuple[
+            int, int, List[FailureRecord]]:
     passed = 0
     failures = []
     if show_suite_heading:

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -3366,7 +3366,18 @@ def main():
                   file=sys.stderr)
             return 2
     except KeyError as error:
-        print(f"Unknown test: {error.args[0]}", file=sys.stderr)
+        name = error.args[0]
+        disabled_test = next(
+            (test for test in REGISTRY._disabled_tests
+             if test.name == name),
+            None,
+        )
+        if disabled_test:
+            print(f"Disabled test: {name}", file=sys.stderr)
+            print(f"  Reason: {disabled_test.list_notes[0]}",
+                  file=sys.stderr)
+        else:
+            print(f"Unknown test: {name}", file=sys.stderr)
         return 2
 
     if "integration" in suites and not selected:

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -237,6 +237,12 @@ class TestSpec:
     run_serial: bool = False
     post_restart_validator: Optional[Callable[["TestContext"], None]] = None
     post_run_validator: Optional[Callable[["TestContext"], None]] = None
+    # 'make check' runs this suite under a small `ulimit -S -v` (see LIMIT in
+    # Makefile.in) to keep mtcp_restart from flying out of control. A test
+    # that deliberately mmaps a huge MAP_NORESERVE region (see
+    # test/mmap-noreserve.c) needs the process's own address-space limit
+    # raised first; see DmtcpHarness.run()'s use of this flag.
+    needs_max_address_space: bool = False
 
     def peer_counts(self) -> List[int]:
         if isinstance(self.peers, int):
@@ -368,6 +374,40 @@ class DmtcpHarness:
 
     def run(self, spec: TestSpec) -> TestResult:
         spec = self._scaled_spec(spec)
+        raised_as_limit = None
+        if spec.needs_max_address_space:
+            raised_as_limit = self._raise_address_space_limit(spec.name)
+        try:
+            return self._run_locked(spec)
+        finally:
+            if raised_as_limit is not None:
+                self._restore_address_space_limit(raised_as_limit)
+
+    # Raise RLIMIT_AS's soft limit to the hard limit, scoped to tests with
+    # needs_max_address_space (see LIMIT in Makefile.in: `ulimit -S -v`
+    # leaves the hard limit alone so it can be restored here).
+    @staticmethod
+    def _raise_address_space_limit(test_name: str) -> Optional[Tuple[int, int]]:
+        try:
+            soft, hard = resource.getrlimit(resource.RLIMIT_AS)
+            resource.setrlimit(resource.RLIMIT_AS, (hard, hard))
+            return (soft, hard)
+        except (ValueError, OSError) as error:
+            print(f"DMTCP: autotest: {test_name}: could not raise RLIMIT_AS "
+                  f"(address space) soft limit to the hard limit: {error}",
+                  file=sys.stderr)
+            return None
+
+    @staticmethod
+    def _restore_address_space_limit(original: Tuple[int, int]):
+        soft, hard = original
+        try:
+            resource.setrlimit(resource.RLIMIT_AS, (soft, hard))
+        except (ValueError, OSError) as error:
+            print(f"DMTCP: autotest: could not restore RLIMIT_AS (address "
+                  f"space) soft limit: {error}", file=sys.stderr)
+
+    def _run_locked(self, spec: TestSpec) -> TestResult:
         work = TestWorkDir(self.root, spec.name)
         context = TestContext(self, spec, work)
         result = None
@@ -1754,6 +1794,10 @@ class TestRegistry:
         )
         if reasons:
             return list(dict.fromkeys(reasons))
+        if test.needs_max_address_space:
+            reason = cls._address_space_reason()
+            if reason:
+                reasons.append(reason)
         for command in test.commands:
             reasons.extend(cls._command_executable_reasons(command))
         for path in test.required_files:
@@ -1928,7 +1972,8 @@ class TestRegistry:
             # Regression guard for restoring a huge MAP_NORESERVE anonymous
             # region (src/mtcp/mtcp_restart.c, MAP_NORESERVE_SIZE_THRESHOLD),
             # modeled on how ThreadSanitizer reserves its shadow/meta mappings.
-            TestSpec("mmap-noreserve", 1, ["./test/mmap-noreserve"]),
+            TestSpec("mmap-noreserve", 1, ["./test/mmap-noreserve"],
+                     needs_max_address_space=True),
             TestSpec("gettimeofday", 1, ["./test/gettimeofday"]),
             TestSpec("sigchild", 1, ["./test/sigchild"]),
             TestSpec("rlimit-restore", 1, ["./test/rlimit-restore"]),

--- a/test/mmap-noreserve.c
+++ b/test/mmap-noreserve.c
@@ -1,0 +1,99 @@
+/* Regression test for restoring a huge MAP_NORESERVE anonymous region
+ * (src/mtcp/mtcp_restart.c, MAP_NORESERVE_SIZE_THRESHOLD).
+ *
+ * Mirrors how ThreadSanitizer reserves its shadow/meta mappings: a single
+ * huge MAP_ANONYMOUS|MAP_NORESERVE region with only a handful of pages ever
+ * touched.  Without MAP_NORESERVE on restore, re-mapping a region this size
+ * fails with ENOMEM (see the "MAP_NORESERVE for anonymous regions" commit).
+ *
+ * The region is far smaller on 32-bit targets (__i386__/__arm__), whose
+ * entire user address space is only a few GiB, but it stays comfortably
+ * above MAP_NORESERVE_SIZE_THRESHOLD so the fix under test is still
+ * exercised.
+ */
+// _GNU_SOURCE for MAP_NORESERVE
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+#if defined(__i386__) || defined(__arm__)
+# define REGION_BYTES ((size_t)50 * 1024 * 1024)               /* 50 MiB */
+#else
+# define REGION_BYTES ((size_t)2 * 1024 * 1024 * 1024 * 1024) /* 2 TiB */
+#endif
+
+#define NUM_TOUCHED_PAGES 5
+
+static unsigned char *region;
+static size_t page_size;
+static size_t touched_offsets[NUM_TOUCHED_PAGES];
+
+static size_t alignDown(size_t x, size_t align)
+{
+  return x - (x % align);
+}
+
+static unsigned char patByte(int idx)
+{
+  return (unsigned char)(idx * 37 + 11);
+}
+
+static void fillTouchedPages(void)
+{
+  for (int i = 0; i < NUM_TOUCHED_PAGES; i++) {
+    region[touched_offsets[i]] = patByte(i);
+  }
+}
+
+static int verifyTouchedPages(void)
+{
+  for (int i = 0; i < NUM_TOUCHED_PAGES; i++) {
+    if (region[touched_offsets[i]] != patByte(i)) {
+      printf("FAIL: touched page %d: got %u want %u\n",
+             i, region[touched_offsets[i]], patByte(i));
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main(void)
+{
+  page_size = sysconf(_SC_PAGESIZE);
+
+  region = mmap(NULL, REGION_BYTES, PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+  if (region == MAP_FAILED) {
+    perror("mmap");
+    return 2;
+  }
+
+  touched_offsets[0] = 0;
+  touched_offsets[1] = alignDown(REGION_BYTES / 4, page_size);
+  touched_offsets[2] = alignDown(REGION_BYTES / 2, page_size);
+  touched_offsets[3] = alignDown(3 * (REGION_BYTES / 4), page_size);
+  touched_offsets[4] = REGION_BYTES - page_size;
+
+  fillTouchedPages();
+
+  if (!verifyTouchedPages()) {
+    printf("FAIL: pre-checkpoint verify\n");
+    fflush(stdout);
+    return 1;
+  }
+  printf("READY\n");
+  fflush(stdout);
+
+  for (int iter = 0;; iter++) {
+    if (!verifyTouchedPages()) {
+      fflush(stdout);
+      return 1;
+    }
+    printf("OK iter %d\n", iter);
+    fflush(stdout);
+    sleep(1);
+  }
+  return 0;
+}


### PR DESCRIPTION
**Commits #2, #5 and #6 have not yet been reviewed since the original review.  (I'm still waiting on a review of PR #1278.  I want to push that in before this, so that all the commits are in the same order as the timeline of a checkpoint-restart.)**

*This is another tightening of DMTCP, discovered while trying to support TSAN targets.  In one commit, the bug was not exposed in the plain DMTCP, but with ASLR disabled, a MAP_GROWSDOWN page fault was triggered.  This was a bug waiting to happen.  In a second commit, we add MAP_NORESERVE now to restore huge memory regions.  SPECULATION ON THE ONE COMMIT: it potentially might also affect guard pages for multiple thread stacks.  Guard pages are now used in recent gcc/glibc versions.  I'm also attaching a file BUG-sigmask-test.c that triggered the new code for TSAN when ASLR was disabled:
[BUG-sigmask-test.c](https://github.com/user-attachments/files/29784027/BUG-sigmask-test.c)*

6 commits:

1. mtcp_restart: print colliding region details
   mmap_fixed_noreplace() only reported "error 17 mapping ..." on EEXIST,
   with no indication of what already occupied the address. Adds
   printOverlappingAreas(): scans /proc/self/maps and prints every
   overlapping region (address, perms, flags, name) on EEXIST or the
   pre-4.17 emulation path, so collisions are diagnosable from stderr
   alone, without attaching gdb.

2. mtcp_restart: keep restoreBuf reservation intact
    Previously, validateRestoreBufferLocation() narrowed the checkpoint's
   90MB restoreBuf reservation down to whichever third mtcp_restart can
   safely relocate itself into, silently munmap'ing the other two thirds
  back to the kernel for the remainder of mtcp_restart's execution.  But a
  TSAN interceptor or other target software that interposes on things like
  pthread_create would then mmap (e.g. via __tsan_create_fiber()) its own
  data structure (e.g., a live ThreadState) into the recently freed space.
  Fix: reclaim the two unused thirds as PROT_NONE immediately after
  mtcp_restart relocates into its chosen slot, so the entire original
  reservation stays genuinely held.

3. mtcp_restart: MAP_NORESERVE for anonymous regions
   Restoring a -fsanitize=thread target failed with ENOMEM: TSAN's
   multi-terabyte shadow/meta regions are mapped with MAP_NORESERVE, but
   /proc/self/maps doesn't expose that flag, so it was lost across
   checkpoint/restart. Adds MAP_NORESERVE back for anonymous regions at
   or above a size threshold (1 GiB, or 10 MiB on 32-bit targets, whose
   address space is much smaller), leaving ordinary anonymous regions
   under normal overcommit accounting. Also fixes a bug this surfaced: a
   checkpointed MAP_SHARED region converted to MAP_ANONYMOUS could still
   have a live imagefd, tripping a new assert.

4. test: add mmap-noreserve regression test
   Adds a checkpoint/restart test that maps a huge MAP_ANONYMOUS|
   MAP_NORESERVE region (2 TiB, or 50 MiB on 32-bit) modeled on TSAN's
   shadow mappings, verifying a handful of touched pages survive restart
   byte-exact.

5. test: raise or skip ulimit for mmap-noreserve
    'make check' was setting `ulimit -v 33554432` and so this test of sparse
    memory always failed.  Now doing `ulimit -S -v`, and autotest.py
    raises the soft limit to the hard limit on this test, to run it.

 6. autotest: say 'Disabled test' not 'Unknown test'
     When doing `autotest.py openmpi`, etc., It would report
     `Unknown test: openmpi`.  It now checks, and in this case, it reports:
     `Disabled test: openmpi`.

 7. Minor reformatting of autotest.py (respect 80-col limit)

Addressed CodeRabbit's one nitpick (DPRINTF on region widening in
refreshRegionsToMunmap) by folding it into commit 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit
* **Bug Fixes**
  * Improved checkpoint restart memory restoration to prevent freed address gaps and enhance reliability for large anonymous `MAP_NORESERVE` mappings.
  * Refined restoration behavior for anonymous regions and backing-file reopening conditions.
* **Diagnostics**
  * Added clearer diagnostics when `mmap` address conflicts (`EEXIST`) occur.
* **Tests**
  * Added an `mmap-noreserve` regression test and gated it via virtual-memory limit checks.
  * Updated autotest harness behavior and parity documentation for the new test.
* **Chores**
  * Adjusted `check*` ulimit handling to set a soft `RLIMIT_AS`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->