### PR TITLE
if old (stale) dmtcp_coordinator will now offer:  "kill <PID>"

### DIFF
--- a/src/coordinatorapi.cpp
+++ b/src/coordinatorapi.cpp
@@ -28,6 +28,9 @@
 #include <netdb.h>
 #include <poll.h>
 #include <semaphore.h>  // for sem_post(&sem_launch)
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -564,6 +567,36 @@ bool waitForBarrier(const string& barrier,
   return true;
 }
 
+void findOldCoordAndPromptToKill(int port) {
+  if (port == 0) {
+    return;
+  }
+  char portStr[10];
+  int rc = snprintf(portStr, sizeof(portStr), "%d", port);
+  ASSERT_ERRNO(rc > 0 && rc < (long)sizeof(portStr), "Bad port: {}", port);
+
+  FILE *stream = popen("ps -eo pid,cmd", "r");
+  if (stream == NULL) {
+    return;
+  }
+  char line[1000];
+  while (fgets(line, sizeof(line), stream) != NULL) {
+    // Catch formats like "dmtcp_coordinator -p 7779" or "... --port 7779"
+    char prevPortDigit;
+    if (strstr(line, "dmtcp_coord") != NULL &&
+        strstr(line, portStr) != NULL &&
+        (prevPortDigit = *(strstr(line, portStr) - 1)) &&
+        (prevPortDigit < '0' || prevPortDigit > '9')) {
+      long int pid = strtol(line, NULL, 10);
+      if (pid > 0) {
+        printf("FOUND OLD PID (\"ps -eo pid,cmd\"): %s", line);
+        printf("  *** TO KILL:     kill -9 %ld\n\n", pid);
+      }
+    }
+  }
+  pclose(stream);
+}
+
 void
 startNewCoordinator(CoordinatorMode mode)
 {
@@ -581,12 +614,17 @@ startNewCoordinator(CoordinatorMode mode)
   errno = 0;
   jalib::JServerSocket coordinatorListenerSocket(jalib::JSockAddr::ANY,
                                                  port, 128);
-  ASSERT_ERRNO(coordinatorListenerSocket.isValid(),
-               "Failed to create socket to connect to coordinator port; this "
-               "may be an old coordinator, a missing --join-coordinator, or a "
-               "port still being released by the OS: host={} port={} "
-               "listener_port={}",
-               host, port, coordinatorListenerSocket.port());
+  if (!coordinatorListenerSocket.isValid()) {
+    int orig_errno = errno;
+    NOTE("Failed to create socket to connect to coordinator port.\n"
+         "This may be an old coordinator, a missing --join-coordinator, or a\n"
+         "port still being released by the OS.\n"
+         "Requested coordinator: host={} port={} listener_port={}\n",
+         host, port, coordinatorListenerSocket.port());
+    findOldCoordAndPromptToKill(port);
+    errno = orig_errno;
+    ASSERT_ERRNO(false, "coordinatorListenerSocket.isValid: SEE COMMENT ABOVE");
+  }
   // Now dup the sockfd to
   coordinatorListenerSocket.changeFd(PROTECTED_COORD_FD);
   setCoordPort(coordinatorListenerSocket.port());

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -1745,11 +1745,12 @@ char *short_name(char short_buf[], char *name, unsigned int len, char *suffix) {
   if (6 + strlen(suffix) > len) {
     return NULL;
   }
-  memset(short_buf, '\0', len);
+  short_buf[0] = '\0';
   int cmd_len = min(strlen(base_name)+1, len);
-  memcpy(short_buf, base_name, cmd_len);
+  memmove(short_buf, base_name, cmd_len);
   int short_buf_len = min(strlen(base_name), len - suffix_len - 1);
-  strncpy(short_buf + short_buf_len, suffix, suffix_len);
+  strncpy(short_buf + short_buf_len, suffix, suffix_len + 1);
+  memset(short_buf+strlen(short_buf), '\0', len - strlen(short_buf));
   return short_buf;
 }
 

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -1745,10 +1745,12 @@ char *short_name(char short_buf[], char *name, unsigned int len, char *suffix) {
   if (6 + strlen(suffix) > len) {
     return NULL;
   }
+  // Compute base_name_len now, in case short_buf and base_name overlap
+  size_t base_name_len = strlen(base_name);
   short_buf[0] = '\0';
   int cmd_len = min(strlen(base_name)+1, len);
   memmove(short_buf, base_name, cmd_len);
-  int short_buf_len = min(strlen(base_name), len - suffix_len - 1);
+  int short_buf_len = min(base_name_len, len - suffix_len - 1);
   strncpy(short_buf + short_buf_len, suffix, suffix_len + 1);
   memset(short_buf+strlen(short_buf), '\0', len - strlen(short_buf));
   return short_buf;


### PR DESCRIPTION
Commit 1:  Fix a bug from 2020 in rewriting dmtcp_coordinator cmdline

Commit 2:
 >    dmtcp_launch: Offer "kill PID" in "Failed connect"    
     * In coordinatorapi.cpp, it now presents a message:
```
       "Failed to create socket to connect to coordinator port. ..."
       when there is an old (stale) coordinator.  This commit tells the
       user:  "If you believe that is an old (stale) coordinator, kill with:\n"
              "  ********  kill -9 {}\n"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordinator startup failure diagnostics: when the listener can’t start, the error output now includes clearer host/port context and guidance to identify and stop any already-running coordinator using that port.
  * Fixed short-name generation to ensure safer truncation and proper null-termination, preventing malformed or partially displayed names in edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->