### PR TITLE
autotest.py, mtcp_restart.c: trivial reformatting and changing string

### DIFF
--- a/src/mtcp/mtcp_restart.c
+++ b/src/mtcp/mtcp_restart.c
@@ -685,7 +685,7 @@ restorememoryareas(RestoreInfo *rinfo)
       "  # In most recent Linuxes/glibc/gdb, you will also need to do:\n"
       "  (gdb) source DMTCP_ROOT/util/gdb-dmtcp-utils\n"
       "  (gdb) load-symbols # (better for recent GDB: try it)\n"
-      "  (gdb) load-symbols-library ADDR_OR_FILE"
+      "  (gdb) load-symbols-library-all ADDR_OR_FILE"
       "  # Better for newer GDB versions\n"
       "  (gdb) add-symbol-files-all # (better for GDB-8 and earlier)\n",
       mtcp_sys_getpid()

--- a/test/autotest.py
+++ b/test/autotest.py
@@ -3322,8 +3322,8 @@ def print_integration_list(selected: List[TestSpec]) -> int:
 def run_integration_tests(
         args, selected: List[TestSpec],
         show_suite_heading: bool,
-        name_width: int = RUN_TESTNAME_WIDTH) -> Tuple[
-            int, int, List[FailureRecord]]:
+        name_width: int = RUN_TESTNAME_WIDTH) -> Tuple[int, int,
+                                                       List[FailureRecord]]:
     passed = 0
     failures = []
     if show_suite_heading:
@@ -3369,11 +3369,9 @@ def main():
             return 2
     except KeyError as error:
         name = error.args[0]
-        disabled_test = next(
-            (test for test in REGISTRY._disabled_tests
-             if test.name == name),
-            None,
-        )
+        disabled_test = next( (test for test in REGISTRY._disabled_tests
+                                    if test.name == name),
+                              None,)
         if disabled_test:
             print(f"Disabled test: {name}", file=sys.stderr)
             print(f"  Reason: {disabled_test.list_notes[0]}",

--- a/util/gdb-dmtcp-utils.py
+++ b/util/gdb-dmtcp-utils.py
@@ -41,7 +41,7 @@ gdb.execute("set python print-stack full")
 # Then you can try either of:
 #     (gdb) add-symbol-files-all  # Better for older GDB versions
 #     (gdb) load-symbols  # Better for newer GDB versions
-#     (gdb) load-symbols-library ADDR_OR_FILE  # Better for newer GDB versions
+#     (gdb) load-symbols-library-all ADDR_OR_FILE # Better for newer GDB version
 #            [Deletes prev. symbols; add-symbols-files-all will no longer work]
 
 # This also adds GDB commands:


### PR DESCRIPTION
Trivial reformatting of autotest.py and fixed string in mtcp_restart.c.  (I forgot  these in a previous commit.)  Please approve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the GDB restart guidance to use the newer `load-symbols-library-all` command when loading symbols.
  * Refreshed the GDB usage example to match newer versions’ recommended command.
* **Style**
  * Reformatted internal test code (type annotation and error-handling lookup formatting) for readability without changing behavior or outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->