### PR TITLE
Disable ckpt when using kvdb

### DIFF
--- a/src/kvdb.cpp
+++ b/src/kvdb.cpp
@@ -8,6 +8,7 @@
 #include "jconvert.h"
 #include "kvdb.h"
 #include "threadinfo.h"
+#include "wrapperlock.h"
 
 namespace dmtcp
 {
@@ -45,6 +46,7 @@ KVDBResponse request(KVDBRequest request,
   msg.valLen = val.length() + 1;
   msg.extraBytes = msg.keyLen + msg.valLen;
 
+  WrapperLock wrapperLock;
   return CoordinatorAPI::kvdbRequest(msg, key, val, oldVal);
 }
 


### PR DESCRIPTION
kvdbRequest creates a temporary socket to communicate with the coordinator,which is not tracked by DMTCP. Therefore, it's unsafe to checkpoint when user's application, including DMTCP plugins, is requesting the KVDB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved key-value database request handling during checkpoint operations, reducing the risk of interference and improving request reliability.
  * Preserved existing request validation and processing behavior, ensuring no changes to how valid requests are prepared or handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->