### PR TITLE
Name change: unlk_thread -> unlock_threads

### DIFF
--- a/src/threadlist.cpp
+++ b/src/threadlist.cpp
@@ -94,7 +94,7 @@ lock_threads(void)
 }
 
 static void
-unlk_threads(void)
+unlock_threads(void)
 {
   ASSERT_LOCK_SUCCESS(DmtcpMutexUnlock(&threadlistLock));
 }
@@ -545,7 +545,7 @@ ThreadList::suspendThreads()
       usleep(10);
     }
   } while (needrescan);
-  unlk_threads();
+  unlock_threads();
 
   for (int i = 0; i < numUserThreads; i++) {
     sem_wait(&semNotifyCkptThread);
@@ -1037,7 +1037,7 @@ ThreadList::addToActiveList(Thread *th)
   }
   activeThreads = curThread;
 
-  unlk_threads();
+  unlock_threads();
 }
 
 /*****************************************************************************


### PR DESCRIPTION
Trivial review.
The original name, unlk_threads, was chosen 10 years ago.  Let's normalize it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thread lock release handling during thread suspension and when adding threads to the active list.
  * Improved consistency and reliability of thread management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->