### PR TITLE
Make sure 'ps' shows a nice cmdline (for dmtcp_coordinator, restarted targets)

### DIFF
--- a/include/dmtcp.h
+++ b/include/dmtcp.h
@@ -306,7 +306,14 @@ typedef struct {
   char procname[1024];
   char procSelfExe[1024];
 
-  char padding[1792];
+  // mm_struct's arg_start/arg_end and env_start/env_end at exec() time.
+  // mtcp_restart() never execve()s the target back in, so these go
+  // stale after restart, breaking /proc/PID/cmdline and .../environ.
+  // Read in ProcessInfo::getState(), restored in ::restart().
+  MemRegion argBounds;
+  MemRegion envBounds;
+
+  char padding[1760];
 } DmtcpCkptHeader;
 
 static_assert(sizeof(DmtcpCkptHeader) == 4096, "DmtcpCkptHeader must be 4096 bytes");

--- a/src/dmtcp_coordinator.cpp
+++ b/src/dmtcp_coordinator.cpp
@@ -1797,9 +1797,11 @@ main(int argc, char **argv)
   initializeJalib();
 
   flags.progName = argv[0];
-
-  set_short_cmdline(argv[0], jalib::XToString(flags.thePort).c_str());
-  set_long_cmdline(argv[0], jalib::XToString(flags.thePort).c_str());
+  // shift below advances argv itself, and flags.thePort isn't authoritative
+  // until listenSock->port() returns further down (covers both an explicit
+  // -p/--coord-port and an OS-assigned --port 0) -- save argv[0] here for
+  // the cmdline rewrite there instead of doing it with the default port now.
+  char *origArgv0 = argv[0];
 
   /* NOTE: The convention is that user-specified explicit runtime arguments
    *       get a higher priority than env. vars. The logFilename variable will
@@ -1930,6 +1932,13 @@ main(int argc, char **argv)
     Util::writeCoordPortToFile(flags.thePort, flags.thePortFile.c_str());
   }
   TRACE("Listening on port: port={}", flags.thePort);
+
+  // Now that flags.thePort is authoritative, rewrite argv[0]/comm to show
+  // the coordinator's real, final port instead of the compiled-in default
+  // (the previous call site, before argument parsing, always showed that
+  // default here regardless of -p/--coord-port or an OS-assigned --port 0).
+  set_short_cmdline(origArgv0, jalib::XToString(flags.thePort).c_str());
+  set_long_cmdline(origArgv0, jalib::XToString(flags.thePort).c_str());
 
   if (!flags.quiet) {
     fprintf(stderr, "dmtcp_coordinator starting..."

--- a/src/dmtcprestartinternal.cpp
+++ b/src/dmtcprestartinternal.cpp
@@ -22,10 +22,13 @@
 #include <elf.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <linux/capability.h>
 #include <stdio.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <sys/xattr.h>
+#include <unistd.h>
 #include "config.h"
 #ifdef HAS_PR_SET_PTRACER
 #include <sys/prctl.h>
@@ -417,11 +420,99 @@ char *get_pause_param()
   return pause_param;
 }
 
+// Checks the "security.capability" xattr (see: man 7 capabilities) rather
+// than linking against libcap, since we only need this one bit.
+static bool
+mtcpRestartHasCapSysResource(const string &path)
+{
+  unsigned char buf[XATTR_CAPS_SZ_3];
+  ssize_t len = getxattr(path.c_str(), "security.capability",
+                          buf, sizeof(buf));
+  if (len < (ssize_t) sizeof(struct vfs_cap_data)) {
+    return false;
+  }
+  struct vfs_cap_data capdata;
+  memcpy(&capdata, buf, sizeof(capdata));
+  // "+ep" needs both the per-capability permitted bit and the file-wide
+  // effective flag (VFS_CAP_FLAGS_EFFECTIVE); without the latter, permitted
+  // capabilities aren't auto-raised to effective at exec.
+  return (capdata.magic_etc & VFS_CAP_FLAGS_EFFECTIVE) &&
+         (capdata.data[CAP_TO_INDEX(CAP_SYS_RESOURCE)].permitted &
+          CAP_TO_MASK(CAP_SYS_RESOURCE)) != 0;
+}
+
+// Writes/refreshes the reminder marker so its mtime reflects "warned about
+// the current mtcp_restart binary."
+static void
+writeSetcapReminderFile(const string &dmtcpDir, const string &reminderFile,
+                         const string &msg)
+{
+  mkdir(dmtcpDir.c_str(), S_IRWXU);
+  FILE *f = fopen(reminderFile.c_str(), "w");
+  if (f != NULL) {
+    fputs(msg.c_str(), f);
+    fclose(f);
+  }
+}
+
+// Reminds the user to grant mtcp_restart CAP_SYS_RESOURCE (see the
+// restoreArgvEnvBoundsBestEffort comment in processinfo.cpp), without
+// repeating the reminder on every restart. Tracked via a timestamp file,
+// ~/.dmtcp/setcap_mtcp_restart.txt: newer than mtcp_restart means already
+// warned about this binary; missing means never warned; and if the
+// capability turns out to already be set, the file is removed as stale.
+static void
+remindToSetcapMtcpRestart(const string &mtcpRestartPath, int quietCount)
+{
+  // Skip when privileged: $HOME (or a symlink under it) could be attacker-
+  // controlled, and this is only a cosmetic ps/pgrep reminder.
+  if (getuid() == 0 || geteuid() == 0) {
+    return;
+  }
+  const char *home = getenv("HOME");
+  if (home == NULL) {
+    return;
+  }
+  string dmtcpDir = string(home) + "/.dmtcp";
+  string reminderFile = dmtcpDir + "/setcap_mtcp_restart.txt";
+
+  if (mtcpRestartHasCapSysResource(mtcpRestartPath)) {
+    unlink(reminderFile.c_str());
+    return;
+  }
+
+  string msg = "Restarted process cmdline not shown in 'ps'.  To fix, do:\n"
+               "  sudo setcap cap_sys_resource+ep " + mtcpRestartPath + "\n";
+
+  struct stat binSt, reminderSt;
+  if (stat(mtcpRestartPath.c_str(), &binSt) == -1) {
+    return;
+  }
+
+  if (stat(reminderFile.c_str(), &reminderSt) == 0) {
+    if (binSt.st_mtime > reminderSt.st_mtime && quietCount == 0) {
+      fputs(msg.c_str(), stderr);
+      writeSetcapReminderFile(dmtcpDir, reminderFile, msg);
+    }
+    return;
+  }
+
+  if (quietCount == 0) {
+    fputs(msg.c_str(), stderr);
+    writeSetcapReminderFile(dmtcpDir, reminderFile, msg);
+  }
+}
+
 vector<char *>
 getMtcpArgs(MemRegion restoreBuf)
 {
   vector<char *> mtcpArgs;
   mtcp_restart = Util::getPath(mtcp_restart.c_str());
+  // SharedData must already be initialized (see RestoreTarget::initialize(),
+  // called before this) for Util::getPath() above to have resolved anything
+  // beyond the bare binary name.
+  int quietCount = *getenv(ENV_VAR_QUIET) - '0';
+  remindToSetcapMtcpRestart(mtcp_restart, quietCount);
   pause_param = get_pause_param();
   stderrFd = jalib::XToString(PROTECTED_STDERR_FD);
 

--- a/src/processinfo.cpp
+++ b/src/processinfo.cpp
@@ -22,6 +22,8 @@
 #include "processinfo.h"
 #include <fcntl.h>
 #include <fenv.h>
+#include <string.h>
+#include <sys/prctl.h>
 #include <sys/resource.h>
 #include <sys/syscall.h>
 #include <sys/time.h>
@@ -35,6 +37,24 @@
 #include "uniquepid.h"
 #include "util.h"
 #include "dmtcp_assert.h"
+
+// <sys/prctl.h> may lack these; define locally rather than pull in
+// <linux/prctl.h>, which can conflict with <sys/prctl.h>.
+#ifndef PR_SET_MM
+# define PR_SET_MM 35
+#endif
+#ifndef PR_SET_MM_ARG_START
+# define PR_SET_MM_ARG_START 8
+#endif
+#ifndef PR_SET_MM_ARG_END
+# define PR_SET_MM_ARG_END 9
+#endif
+#ifndef PR_SET_MM_ENV_START
+# define PR_SET_MM_ENV_START 10
+#endif
+#ifndef PR_SET_MM_ENV_END
+# define PR_SET_MM_ENV_END 11
+#endif
 
 namespace dmtcp
 {
@@ -153,6 +173,8 @@ ProcessInfo::ProcessInfo()
 
   strcpy(ckptSignature, DMTCP_CKPT_SIGNATURE);
   memset(padding, 0, sizeof(padding));
+  argBounds = {0, 0};
+  envBounds = {0, 0};
 
   upid = UniquePid::ThisProcess();
   uppid = UniquePid::ParentProcess();
@@ -522,12 +544,53 @@ ProcessInfo::restoreHeap()
   }
 }
 
+// Best-effort re-point of the kernel's mm_struct arg_start/arg_end/
+// env_start/env_end (see the DmtcpCkptHeader comment). Active if:
+//   sudo setcap cap_sys_resource+ep PATH_TO/bin/mtcp_restart
+// Otherwise silently ignore any errors.
+static void
+restoreArgvEnvBoundsBestEffort(MemRegion argBounds, MemRegion envBounds)
+{
+  if (argBounds.startAddr == 0 || envBounds.startAddr == 0) {
+    // Old checkpoint image, or a kernel without these /proc/self/stat fields.
+    return;
+  }
+  if (argBounds.startAddr > argBounds.endAddr ||
+      envBounds.startAddr > envBounds.endAddr) {
+    // Corrupted or partially-captured bounds; don't feed prctl() nonsense.
+    return;
+  }
+
+  // *_END before *_START for each pair: the kernel checks a new *_START
+  // against the CURRENT *_END, so setting our much-higher real *_START
+  // first would fail with EINVAL against mtcp_restart's stale low *_END.
+  // MemRegion's fields are already uint64_t; static_cast is only so a
+  // reader doesn't have to go check that.
+  struct { int opt; uint64_t addr; } ops[] = {
+    { PR_SET_MM_ARG_END,   static_cast<uint64_t>(argBounds.endAddr)   },
+    { PR_SET_MM_ARG_START, static_cast<uint64_t>(argBounds.startAddr) },
+    { PR_SET_MM_ENV_END,   static_cast<uint64_t>(envBounds.endAddr)   },
+    { PR_SET_MM_ENV_START, static_cast<uint64_t>(envBounds.startAddr) },
+  };
+  for (size_t i = 0; i < sizeof(ops) / sizeof(ops[0]); i++) {
+    // prctl()'s variadic args are register-sized (unsigned long); on a
+    // 32-bit build that's narrower than our uint64_t addr, and passing the
+    // wider type here would misalign the trailing args.
+    if (prctl(PR_SET_MM, ops[i].opt,
+              static_cast<unsigned long>(ops[i].addr), 0UL, 0UL) == -1) {
+      return;
+    }
+  }
+}
+
 void
 ProcessInfo::restart()
 {
   updateRestoreBufAddr();
 
   restoreHeap();
+
+  restoreArgvEnvBoundsBestEffort(argBounds, envBounds);
 
   // Update the ckptDir
   string ckptDir = jalib::Filesystem::GetDeviceName(PROTECTED_CKPT_DIR_FD);
@@ -662,6 +725,58 @@ ProcessInfo::setCkptDir(const char *dir)
 
 }
 
+// Reads arg_start/arg_end/env_start/env_end (fields 48-51, man 5 proc)
+// from /proc/self/stat, unaffected by setenv()/--modify-env unlike
+// glibc's argv/environ. comm may contain ')', so split on the last one.
+static void
+readArgEnvBoundsFromProcSelfStat(MemRegion *argBounds, MemRegion *envBounds)
+{
+  *argBounds = {0, 0};
+  *envBounds = {0, 0};
+
+  char buf[4096];
+  int fd = _real_open("/proc/self/stat", O_RDONLY);
+  if (fd == -1) {
+    return;
+  }
+  ssize_t len = read(fd, buf, sizeof(buf) - 1);
+  _real_close(fd);
+  if (len <= 0) {
+    return;
+  }
+  buf[len] = '\0';
+
+  char *afterComm = strrchr(buf, ')');
+  if (afterComm == NULL) {
+    return;
+  }
+  afterComm++;
+
+  // Token 0 after comm is field 3 (state), so field N is token (N-3).
+  const int argStartTokenIdx = 48 - 3;
+  const int lastTokenIdxNeeded = 51 - 3;
+  char *saveptr = NULL;
+  char *tok = strtok_r(afterComm, " ", &saveptr);
+  int idx = 0;
+  unsigned long vals[4] = {0, 0, 0, 0};
+  while (tok != NULL && idx <= lastTokenIdxNeeded) {
+    if (idx >= argStartTokenIdx) {
+      vals[idx - argStartTokenIdx] = strtoul(tok, NULL, 10);
+    }
+    tok = strtok_r(NULL, " ", &saveptr);
+    idx++;
+  }
+  if (idx <= lastTokenIdxNeeded) {
+    // Older kernel without these fields; leave everything at 0.
+    return;
+  }
+
+  argBounds->startAddr = vals[0];
+  argBounds->endAddr = vals[1];
+  envBounds->startAddr = vals[2];
+  envBounds->endAddr = vals[3];
+}
+
 void
 ProcessInfo::getState()
 {
@@ -708,6 +823,8 @@ ProcessInfo::getState()
   _ckptCWD = buf;
 
   savedBrk = (uint64_t) sbrk(0);
+
+  readArgEnvBoundsFromProcSelfStat(&argBounds, &envBounds);
 
   TRACE("CHECK GROUP PID: gid={} fgid={} ppid={} pid={}",
         gid, fgid, ppid, pid);


### PR DESCRIPTION
First commit:  Minor fix for dmtcp_coordinator

Second commit:  restarted targets:  show a nice command line for 'ps uxw', etc.  In the past, on restart 'ps uxw' would show either a blank or a random string taken from the environment.  It was because mtcp_restart would have the kernel's /proc/PID/cmdline point to a certain address with the argv's, and after we restored memory, that pointer was pointing to garbage.  So, we use a capability, to ask the kernel to change the /proc/*/cmdline.  (Originally, CRIU was the one who proposed that for the kernel.)

**Third commit:** Warn if mtcp_restart lacks CAP_SYS_RESOURCE :
 * mtcp_restart's fix for /proc/PID/cmdline (previous commit) is a no-op unless it has CAP_SYS_RESOURCE, which is not the default. Silently doing nothing left users unaware there was anything to fix.
* dmtcp_restart now checks the target mtcp_restart binary's security.capability xattr directly (avoiding a new libcap build                 dependency); if the capability is missing and --quiet was not given, it prints the sudo setcap command to stderr. To avoid nagging on every restart, it remembers having warned via a timestamp file, ~/.dmtcp/setcap_mtcp_restart.txt: skip the reminder once that file is newer than the binary, but warn again if the binary was rebuilt since. If the capability is later granted, the file is removed.

**NOTE:** The second commit adds four more fields to ThreadInfo.  I assume that doesn't break any other formats (like plugin v4), or our restart header.  I also asked Claude to verify that we have both backward- and forward-compatibility between a checkpoint image file created under 'main' and restarted under this branch (or vice versa).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored processes now report accurate command-line arguments and environment variables after restart (via `/proc`).
  * Coordinator command-line/`comm` display now reflects the final resolved coordination port, including when an OS-assigned port is used.

* **Improvements**
  * Added a one-time (per binary) diagnostic reminder if restart permissions are missing, with `setcap cap_sys_resource+ep` guidance (rate-limited; suppressed when running as root or when `HOME` is unset).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->