### PR TITLE
Adding warning message for load-symbols

### DIFF
--- a/util/gdb-dmtcp-utils.py
+++ b/util/gdb-dmtcp-utils.py
@@ -114,6 +114,10 @@ def file_base_address(file):
   text_fields = text_lines[0].split()
   return int(text_fields[-2], 16) - int(text_fields[-1], 16)
 def load_symbols(exec_file=None):
+  if exec_file and not os.path.exists(exec_file):
+    print("*** Error: File '" + exec_file + "' does not exist.")
+    return
+
   if not is_recent_gdb():
     print("Older GDB; use add-symbol-files-all (This GDB is version: " +
           gdb.VERSION + ")")


### PR DESCRIPTION
The load-symbols requires a filename. If a user provided an address, the error message from Python is confusing. Now, if the given argument is not a valid filename, the command will print a clear error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for explicitly provided executable paths.
  * Displays an error and avoids further processing when the executable is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->